### PR TITLE
Actually enable persistence in a code sample

### DIFF
--- a/docs/modules/ROOT/examples/cp/CPSubsystemPersistence.java
+++ b/docs/modules/ROOT/examples/cp/CPSubsystemPersistence.java
@@ -14,7 +14,7 @@ public class CPSubsystemPersistence {
         TcpIpConfig tcpIpConfig = join.getTcpIpConfig();
         tcpIpConfig.setEnabled(true);
         tcpIpConfig.addMember("127.0.0.1");
-       // config.getCPSubsystemConfig().setCPMemberCount(3).setPersistenceEnabled(true);
+        config.getCPSubsystemConfig().setCPMemberCount(3).setPersistenceEnabled(true);
 
         HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
         HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);


### PR DESCRIPTION
This snippet is used in https://docs.hazelcast.com/hazelcast/5.0-beta-1/cp-subsystem/persistence.html#using-cp-subsystem-persistence-with-ap-persistence

but for some reason the line enabling CP Persistence is commented out. It looks like a left-over to me. 