### PR TITLE
Update get-started-binary.adoc

### DIFF
--- a/docs/modules/getting-started/pages/get-started-binary.adoc
+++ b/docs/modules/getting-started/pages/get-started-binary.adoc
@@ -499,7 +499,7 @@ Mac::
 --
 [source,shell]
 ----
-management-center/bin/start
+management-center/bin/start.sh
 ----
 --
 Linux:: 
@@ -507,7 +507,7 @@ Linux::
 --
 [source,shell]
 ----
-management-center/bin/start
+management-center/bin/start.sh
 ----
 --
 Windows:: 


### PR DESCRIPTION
Linux and Mac script in the distro is called start.sh not start