### PR TITLE
Remove superfluous backslash

### DIFF
--- a/docs/modules/cp-subsystem/pages/management.adoc
+++ b/docs/modules/cp-subsystem/pages/management.adoc
@@ -126,9 +126,9 @@ include::ROOT:example$/cp/CpSubsystemAPI.java[tag=cpgroup]
 .REST API
 [source,sh]
 ----
-> curl http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/groups/$\{CPGROUP_NAME}
+> curl http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/groups/${CPGROUP_NAME}
 OR
-> sh cp-subsystem.sh -o get-group --group $\{CPGROUP_NAME} --address 127.0.0.1 --port 5701
+> sh cp-subsystem.sh -o get-group --group ${CPGROUP_NAME} --address 127.0.0.1 --port 5701
 +
 Sample Response:
 {
@@ -220,9 +220,9 @@ include::ROOT:example$/cp/CpSubsystemAPI.java[tag=destroygroup]
 .REST API
 [source,sh]
 ----
-> curl -X POST --data "${GROUPNAME}&$\{PASSWORD}" http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/groups/$\{CPGROUP_NAME}/remove
+> curl -X POST --data "${GROUPNAME}&${PASSWORD}" http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/groups/${CPGROUP_NAME}/remove
 OR
-> sh cp-subsystem.sh -o force-destroy-group --group $\{CPGROUP_NAME} --address 127.0.0.1 --port 5701 --groupname ${GROUPNAME} --password $\{PASSWORD}
+> sh cp-subsystem.sh -o force-destroy-group --group ${CPGROUP_NAME} --address 127.0.0.1 --port 5701 --groupname ${GROUPNAME} --password ${PASSWORD}
 ----
 +
 * **Remove a CP Member:**
@@ -247,9 +247,9 @@ include::ROOT:example$/cp/CpSubsystemAPI.java[tag=removemember]
 .REST API
 [source,sh]
 ----
-> curl -X POST --data "${GROUPNAME}&$\{PASSWORD}" http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/members/$\{CPMEMBER_UUID}/remove
+> curl -X POST --data "${GROUPNAME}&${PASSWORD}" http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/members/${CPMEMBER_UUID}/remove
 OR
-> sh cp-subsystem.sh -o remove-member --member $\{CPMEMBER_UUID} --address 127.0.0.1 --port 5701 --groupname ${GROUPNAME} --password $\{PASSWORD}
+> sh cp-subsystem.sh -o remove-member --member ${CPMEMBER_UUID} --address 127.0.0.1 --port 5701 --groupname ${GROUPNAME} --password ${PASSWORD}
 ----
 +
 * **Promote Local Member to a CP Member**
@@ -270,9 +270,9 @@ include::ROOT:example$/cp/CpSubsystemAPI.java[tag=promotemember]
 .REST API
 [source,sh]
 ----
-> curl -X POST --data "${GROUPNAME}&$\{PASSWORD}" http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/members
+> curl -X POST --data "${GROUPNAME}&${PASSWORD}" http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/members
 OR
-> sh cp-subsystem.sh -o promote-member --address 127.0.0.1 --port 5701 --groupname ${GROUPNAME} --password $\{PASSWORD}
+> sh cp-subsystem.sh -o promote-member --address 127.0.0.1 --port 5701 --groupname ${GROUPNAME} --password ${PASSWORD}
 ----
 +
 * **Wipe and Reset CP Subsystem**
@@ -324,9 +324,9 @@ include::ROOT:example$/cp/CpSubsystemAPI.java[tag=reset]
 .REST API
 [source,sh]
 ----
-> curl -X POST --data "${GROUPNAME}&$\{PASSWORD}" http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/reset
+> curl -X POST --data "${GROUPNAME}&${PASSWORD}" http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/reset
 OR
-> sh cp-subsystem.sh -o reset --address 127.0.0.1 --port 5701 --groupname ${GROUPNAME} --password $\{PASSWORD}
+> sh cp-subsystem.sh -o reset --address 127.0.0.1 --port 5701 --groupname ${GROUPNAME} --password ${PASSWORD}
 ----
 
 == Session Management API
@@ -346,9 +346,9 @@ include::ROOT:example$/cp/CpSubsystemAPI.java[tag=sessions]
 .REST API
 [source,sh]
 ----
-> curl http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/groups/$\{CPGROUP_NAME}/sessions
+> curl http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/groups/${CPGROUP_NAME}/sessions
 OR
-> sh cp-subsystem.sh -o get-sessions --group $\{CPGROUP_NAME} --address 127.0.0.1 --port 5701
+> sh cp-subsystem.sh -o get-sessions --group ${CPGROUP_NAME} --address 127.0.0.1 --port 5701
 +
 Sample Response:
 [{
@@ -388,7 +388,7 @@ include::ROOT:example$/cp/CpSubsystemAPI.java[tag=closesession]
 .REST API
 [source,sh]
 ----
-> curl -X POST --data "${GROUPNAME}&$\{PASSWORD}" http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/groups/$\{CPGROUP_NAME}/sessions/$\{CP_SESSION_ID}/remove
+> curl -X POST --data "${GROUPNAME}&${PASSWORD}" http://127.0.0.1:5701/hazelcast/rest/cp-subsystem/groups/${CPGROUP_NAME}/sessions/${CP_SESSION_ID}/remove
 OR
-> sh cp-subsystem.sh -o force-close-session --group $\{CPGROUP_NAME} --session-id $\{CP_SESSION_ID} --address 127.0.0.1 --port 5701 --groupname ${GROUPNAME} --password $\{PASSWORD}
+> sh cp-subsystem.sh -o force-close-session --group ${CPGROUP_NAME} --session-id ${CP_SESSION_ID} --address 127.0.0.1 --port 5701 --groupname ${GROUPNAME} --password ${PASSWORD}
 ----

--- a/docs/modules/deploy/pages/using-enterprise-edition.adoc
+++ b/docs/modules/deploy/pages/using-enterprise-edition.adoc
@@ -213,7 +213,7 @@ Its output is similar to the following:
 request through the REST API (if enabled; see the xref:clients:rest.adoc#using-the-rest-endpoint-groups[REST Endpoint Groups section]) on the `/license` as shown below:
 
 ```
-curl --data "${CLUSTERNAME}&$\{PASSWORD}&${LICENSE}" http://localhost:5001/hazelcast/rest/license
+curl --data "${CLUSTERNAME}&${PASSWORD}&${LICENSE}" http://localhost:5001/hazelcast/rest/license
 ```
 
 NOTE: The request parameters must be properly URL-encoded as described in the xref:clients:rest.adoc[REST Client section].

--- a/docs/modules/maintain-cluster/pages/shutdown.adoc
+++ b/docs/modules/maintain-cluster/pages/shutdown.adoc
@@ -75,7 +75,7 @@ To shutdown the cluster, use the following command:
 
 [source,shell]
 ----
-curl --data "${CLUSTERNAME}&$\{PASSWORD}"  http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/clusterShutdown
+curl --data "${CLUSTERNAME}&${PASSWORD}"  http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/clusterShutdown
 ----
 
 == Safely Shutting Down for Lossless Restart

--- a/docs/modules/management/pages/cluster-utilities.adoc
+++ b/docs/modules/management/pages/cluster-utilities.adoc
@@ -300,7 +300,7 @@ To get the state of the cluster, use the following command:
 +
 [source,shell]
 ----
-curl --data "${CLUSTERNAME}&$\{PASSWORD}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/state
+curl --data "${CLUSTERNAME}&${PASSWORD}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/state
 ----
 +
 * _Changing the cluster state:_
@@ -309,7 +309,7 @@ To change the state of the cluster to `frozen`, use the following command:
 +
 [source,shell]
 ----
-curl --data "${CLUSTERNAME}&$\{PASSWORD}&${STATE}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/changeState
+curl --data "${CLUSTERNAME}&${PASSWORD}&${STATE}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/changeState
 ----
 +
 * _Shutting down the cluster:_
@@ -318,7 +318,7 @@ To shutdown the cluster, use the following command:
 +
 [source,shell]
 ----
-curl --data "${CLUSTERNAME}&$\{PASSWORD}"  http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/clusterShutdown
+curl --data "${CLUSTERNAME}&${PASSWORD}"  http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/clusterShutdown
 ----
 +
 * _Querying the current cluster version:_
@@ -338,7 +338,7 @@ To partial start the cluster when Persistence is enabled, use the following comm
 +
 [source,shell]
 ----
-curl --data "${CLUSTERNAME}&$\{PASSWORD}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/partialStart/
+curl --data "${CLUSTERNAME}&${PASSWORD}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/partialStart/
 ----
 +
 * _Force starting the cluster:_
@@ -347,7 +347,7 @@ To force start the cluster when Persistence is enabled, use the following comman
 +
 [source,shell]
 ----
-curl --data "${CLUSTERNAME}&$\{PASSWORD}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/forceStart/
+curl --data "${CLUSTERNAME}&${PASSWORD}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/forceStart/
 ----
 +
 NOTE: You can also perform the above operations (partialStart and forceStart) using
@@ -361,7 +361,7 @@ To initiate the Hot Backup, use the following `curl` command:
 +
 [source,shell]
 ----
-curl --data "${CLUSTERNAME}&$\{PASSWORD}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/hotBackup
+curl --data "${CLUSTERNAME}&${PASSWORD}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/hotBackup
 ----
 +
 * _Changing the cluster version:_
@@ -371,7 +371,7 @@ a new minor version, use the following `curl` command:
 +
 [source,shell]
 ----
-curl --data "${CLUSTERNAME}&$\{PASSWORD}&${CLUSTER_VERSION}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/version
+curl --data "${CLUSTERNAME}&${PASSWORD}&${CLUSTER_VERSION}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/version
 ----
 +
 For example, assuming the default cluster name and password, issue the following command to any member


### PR DESCRIPTION
Backslash is used to escape the dollar sign, but only
when it's outside of the code section. Otherwise the
backslash is rendered in a final page.

Example #1: This line should NOT have the backslash,
because it's inside the [source] section: https://github.com/hazelcast/hz-docs/blame/c34c3869468b2937c6a5c21f736dc5e818af9f36/docs/modules/cp-subsystem/pages/management.adoc#L129

Example #2: This should should have the backslash,
because it's outside of the [source] section thus
the dollar sign has to be escaped: https://github.com/hazelcast/hz-docs/blame/dfc12d120f2944f978d718a981a103aae8a9274f/docs/modules/clients/pages/rest.adoc#L506