### PR TITLE
Update hazelcast.discovery.public.ip.enabled

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -2214,9 +2214,9 @@ See xref:extending-hazelcast:discovery-spi.adoc[Discovery SPI] for more informat
 |Enables the discovery joiner to use public IPs from `DiscoveredNode`.
 See xref:extending-hazelcast:discovery-spi.adoc[Discovery SPI] for more information.
 When set to `true`, the client assumes that it needs to use public IP addresses reported by the members.
-When set to `false`, the client always uses private addresses reported by the members. If it is null,
-it tries to infer how the cluster is structured and act accordingly. This inference is not %100 reliable and may
-result in false-negatives.
+When set to `false`, the client always uses private addresses reported by the members. If it is `null`,
+the client will try to infer how the discovery mechanism should be based on the reachability of the members.
+This inference is not %100 reliable and may result in false-negatives.
 
 |`hazelcast.client.event.queue.capacity`
 |1000000


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-nodejs-client/pull/1001 after pr reviews, we changed the explanation a little bit