### PR TITLE
Wrap versions in quotes

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -4,8 +4,6 @@ title: Hazelcast
 version: '5.0'
 # Version in the version selector (we display only the latest major.minor version)
 display_version: '5.0'
-# Displays a banner to inform users that this is a prerelease version 
-prerelease: true
 asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
@@ -15,13 +13,13 @@ asciidoc:
     # Used for the Report an issue link
     page-ghissue: https://github.com/hazelcast/hz-docs/issues/new
     # All page-latest attributes are used as a variable in the docs for things like download links and search results
-    page-latest-cli: 5.2021.09-SNAPSHOT
-    page-latest-supported-mc: 5.0
-    page-latest-supported-java-client: 5.0
-    page-latest-supported-go-client: 1.0.0
-    page-latest-supported-cplusplus-client: 4.1.1
-    page-latest-supported-csharp-client: 4.0.2
-    page-latest-supported-python-client: 4.2
-    page-latest-supported-nodejs-client: 4.2.0
+    page-latest-cli: '5.2021.09-SNAPSHOT'
+    page-latest-supported-mc: '5.0'
+    page-latest-supported-java-client: '5.0'
+    page-latest-supported-go-client: '1.0.0'
+    page-latest-supported-cplusplus-client: '4.1.1'
+    page-latest-supported-csharp-client: '4.0.2'
+    page-latest-supported-python-client: '4.2'
+    page-latest-supported-nodejs-client: '4.2.0'
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
Otherwise 5.0 is rendered as 5, which breaks links