### PR TITLE
Update performance-tuning.adoc

### DIFF
--- a/docs/modules/cluster-performance/pages/performance-tuning.adoc
+++ b/docs/modules/cluster-performance/pages/performance-tuning.adoc
@@ -114,7 +114,8 @@ especially if you run the JVM with large heap sizes. Tuning the garbage collecto
 for your use case is often a critical performance practice prior to deployment.
 Likewise, knowing what baseline GC behavior looks like and
 monitoring for behavior outside of normal tolerances will keep you aware of
-potential memory leaks and other pathological memory usage.
+potential memory leaks and other pathological memory usage. Hazelcast provides a basic
+GC recommendation in our xref:ROOT:production-checklist.adoc#jvm-recommendations[JVM Recommendations].
 
 === Minimize Heap Usage
 
@@ -124,16 +125,14 @@ hours of GC tuning and provides improved stability
 and predictability across your entire application.
 Even if your application uses very large amounts of data, you can still keep
 your heap small by using Hazelcast's High-Density Memory Store.
-Some common off-the-shelf GC tuning parameters for Hotspot and OpenJDK are as follows:
 
-```
--XX:+UseParallelOldGC
--XX:+UseParallelGC
--XX:+UseCompressedOops
-```
+=== Enable GC Logging
 
-To enable GC logging, use the following JVM arguments for Java 8:
+We xref:ROOT:production-checklist.adoc#jvm-recommendations[recommend] enabling
+GC logs to allow troubleshooting if performance problems occur. To enable GC
+logging, use the following JVM arguments:
 
+*Java 8*
 ```
 -verbose:gc
 -Xloggc:gc.log
@@ -147,7 +146,7 @@ To enable GC logging, use the following JVM arguments for Java 8:
 -XX:+PrintGCApplicationStoppedTime
 ```
 
-The above arguments only work for Java 8. For Java 9+, you can use the following arguments:
+*Java 9 (and above)*
 
 ```
 -Xlog:safepoint,gc+age=debug,gc*=debug:file=gc.log:uptime,level,tags:filesize=10m,filecount=10


### PR DESCRIPTION
Fixes #237 

Splits the "minimize heap usage" section into two and includes links to the Production Checklist where appropriate.