### PR TITLE
Separate commands from output

### DIFF
--- a/docs/modules/deploy/pages/deploying-with-operator.adoc
+++ b/docs/modules/deploy/pages/deploying-with-operator.adoc
@@ -26,13 +26,14 @@ At this point, your Hazelcast Enteprise Operator should be up and running. You c
 [source,shell]
 ----
 kubectl logs deployment.apps/hazelcast-enterprise-controller-manager
+----
 
+```
 2021-07-14T09:03:40.713Z        INFO    setup   Watching namespace: default
 2021-07-14T09:03:41.524Z        INFO    controller-runtime.metrics      metrics server is starting to listen    {"addr": ":8080"}
 2021-07-14T09:03:41.524Z        INFO    setup   starting manager
 2021-07-14T09:03:41.525Z        INFO    controller-runtime.manager      starting metrics server {"path": "/metrics"}
-...
-----
+```
 
 == Customize Namespace (optional)
 
@@ -86,14 +87,15 @@ After a moment, you can verify that Hazelcast cluster is up and running by check
 [source,shell]
 ----
 kubectl logs pod/hazelcast-sample-0
-...
+----
+
+```
 Members {size:3, ver:3} [
         Member [10.36.8.3]:5701 - ccf31703-de3b-4094-9faf-7b5d0dc145b2 this
         Member [10.36.7.2]:5701 - e75bd6e2-de4b-4360-8113-040773d858b7
         Member [10.36.6.2]:5701 - c3d105d2-0bca-4a66-8519-1cacffc05c98
 ]
-...
-----
+```
 
 == Connect to Hazelcast from Outside Kubernetes
 
@@ -110,12 +112,15 @@ After applying the configuration change in Kubernetes, each Hazelcast member wil
 [source,shell]
 ----
 kubectl get service
+----
+
+```
 NAME                 TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)          AGE
 hazelcast-sample     LoadBalancer   10.219.246.19    35.230.92.217   5701:30560/TCP   2m11s
 hazelcast-sample-0   NodePort       10.219.254.192   <none>          5701:31890/TCP   2m11s
 hazelcast-sample-1   NodePort       10.219.247.43    <none>          5701:32310/TCP   2m11s
 hazelcast-sample-2   NodePort       10.219.243.16    <none>          5701:32585/TCP   2m11s
-----
+```
 
 To connect to the cluster, you can add the external IP address of the LoadBalancer service to your Hazelcast client configuration.
 
@@ -156,15 +161,15 @@ After a moment, you can verify that Management Center is up and running by check
 [source,shell]
 ----
 kubectl logs managementcenter-sample-0
+----
 
-...
+```
 2021-08-26 15:21:04,842 [ INFO] [MC-Client-dev.lifecycle-1] [c.h.w.s.MCClientManager]: MC Client connected to cluster dev.
 2021-08-26 15:21:05,241 [ INFO] [MC-Client-dev.event-1] [c.h.w.s.MCClientManager]: Started communication with member: Member [10.36.8.3]:5701 - ccf31703-de3b-4094-9faf-7b5d0dc145b2
 2021-08-26 15:21:05,245 [ INFO] [MC-Client-dev.event-1] [c.h.w.s.MCClientManager]: Started communication with member: Member [10.36.7.2]:5701 - e75bd6e2-de4b-4360-8113-040773d858b7
 2021-08-26 15:21:05,251 [ INFO] [MC-Client-dev.event-1] [c.h.w.s.MCClientManager]: Started communication with member: Member [10.36.6.2]:5701 - c3d105d2-0bca-4a66-8519-1cacffc05c98
 2021-08-26 15:21:07,234 [ INFO] [main] [c.h.w.Launcher]: Hazelcast Management Center successfully started at http://localhost:8080/
-...
-----
+```
 
 To access the Management Center dashboard, open the browser at address `http://$MANCENTER_IP:8080`.
 


### PR DESCRIPTION
When users copy/paste code, they only want the commands, not the outputs.