### PR TITLE
Update naming of Red Hat build of OpenJDK

### DIFF
--- a/docs/modules/deploy/pages/supported-jvms.adoc
+++ b/docs/modules/deploy/pages/supported-jvms.adoc
@@ -29,7 +29,7 @@ Hazelcast {full-version} has been tested against the following JDKs.
 |Oracle
 |8, 11, and later
 
-|Red Hat OpenJDK
+|Red Hat build of OpenJDK
 |8 and 11
 
 |===


### PR DESCRIPTION
We received a note from the Red Hat's OpenJDK development team if we could change the naming to be more "precise". The official name is "Red Hat build of OpenJDK".