### PR TITLE
Update information about MC config

### DIFF
--- a/docs/modules/maintain-cluster/pages/monitoring.adoc
+++ b/docs/modules/maintain-cluster/pages/monitoring.adoc
@@ -1,5 +1,6 @@
 = Monitoring
 :description: Options available for monitoring the health and operations of Hazelcast clusters.
+:page-aliases: security:management-center.adoc
 
 [[monitoring-best-practices]]
 == Best Practices
@@ -75,16 +76,20 @@ data structures in detail, update map configurations and take thread dumps from 
 You can run scripts (JavaScript, Groovy, etc.) and commands on your members with its scripting and console modules.
 
 See the xref:{page-latest-supported-mc}@management-center::index.adoc[Management Center documentation]
-for its usage details.
+for more information and find details about its clustered JMX and clustered REST APIs
 
-=== Toggle Scripting Support
+Because Management Center is a client that connects to the cluster, you can control the following aspects of Management Center in the member configuration file:
 
-The support for script execution is disabled by default. The reason is security.
-Script engines allow to access the underlying system on the members (files and other resources).
-Scripts access the system, on which the member runs, with permissions of the running user.
+- <<managing-scripting-support,Scripting support>>
+- <<managing-console-support,Console support>>
+- <<limiting-source-addresses,Source IP addresses>>
 
-Scripting can be allowed or prevented by specifying the `scripting-enabled` attribute of
-the `management-center` element within the Hazelcast member configuration file, as shown below:
+=== Managing Scripting Support
+[[toggle-scripting-support]]
+
+Management Center allows you to execute scripts that can automate interactions with the cluster.
+
+By default, scripting is disabled for security. Scripting engines give code access to the underlying system on the members (files and other resources) and run with the same permissions as the current user. You can enable scripting in the member configuration file:
 
 [tabs] 
 ==== 
@@ -95,7 +100,7 @@ XML::
 ----
 <hazelcast>
     ...
-    <management-center scripting-enabled="false" />
+    <management-center scripting-enabled="true" />
     ...
 </hazelcast>
 ----
@@ -107,31 +112,26 @@ YAML::
 ----
 hazelcast:
   management-center:
-    scripting-enabled: false
+    scripting-enabled: true
 ----
 ====
 
 Note that the https://jcp.org/en/jsr/detail?id=223[JSR 223^] API is used in Hazelcast to support scripting.
 
-=== Toggle Console Support
+=== Managing Console Support
 
-The support for console commands execution is disabled by default. The reason is security.
-The console can access the underlying system on which Hazelcast runs and bypass the configured
-client permissions.
+Management Center allows you to execute commands from a built-in console in the user interface. This console is useful for testing and development purposes. You can enable the console in the member configuration file:
 
-Console commands execution can be allowed or prevented by specifying the `console-enabled` attribute of
-the `management-center` element within the Hazelcast member configuration file, as shown below:
-
-[tabs]
-====
-XML::
-+
---
+[tabs] 
+==== 
+XML:: 
++ 
+-- 
 [source,xml]
 ----
 <hazelcast>
     ...
-    <management-center console-enabled="false" />
+    <management-center console-enabled="true" />
     ...
 </hazelcast>
 ----
@@ -143,18 +143,15 @@ YAML::
 ----
 hazelcast:
   management-center:
-    console-enabled: false
+    console-enabled: true
 ----
 ====
 
+
 === Limiting Source Addresses
 
-It's possible to restrict the source IP addresses from which Management Center operations
-are allowed. By default all source connections are allowed.
-
-Defining these source addresses is possible through the `trusted-interfaces`
-configuration element. The wildcard (`*`) and ranges can be used.
-See the following example:
+By default, any instance of Management Center can connect to a cluster as long as it can be authenticated. To restrict access only to trusted instances of Management Center, you can define the trusted IP addresses in the `trusted-interfaces`
+configuration setting. This settings supports wildcards (`*`) and ranges (`-`).
 
 [tabs] 
 ==== 
@@ -185,13 +182,6 @@ hazelcast:
       - 192.168.1.*
 ----
 ====
-
-=== Clustered JMX and REST via Management Center
-
-[blue]*Hazelcast Enterprise*
-
-See the xref:{page-latest-supported-mc}@management-center::index.adoc[Management Center documentation]
-for information about Clustered JMX and Clustered REST (via Management Center) features.
 
 == Instance Tracking
 


### PR DESCRIPTION
Added information about managing console support for Management Center.

Removed duplicate information about MC config and redirected it.

Forwardport of #284 