### PR TITLE
Reword comparison matrix

### DIFF
--- a/docs/modules/clients/pages/hazelcast-clients.adoc
+++ b/docs/modules/clients/pages/hazelcast-clients.adoc
@@ -19,7 +19,9 @@ For documentation and code samples for each client, see the following:
 Not all features are available in all clients.
 
 To find out which features are available in each client,
-see the https://hazelcast.com/clients/[feature comparison matrix^].
+see the https://hazelcast.com/clients/[clients page^].
+
+After selecting the language you need, you can find the table showing supported features on the selected language.
 
 == Maximum Number of Client Connections Per Member
 

--- a/docs/modules/clients/pages/hazelcast-clients.adoc
+++ b/docs/modules/clients/pages/hazelcast-clients.adoc
@@ -19,7 +19,7 @@ For documentation and code samples for each client, see the following:
 Not all features are available in all clients.
 
 To find out which features are available in each client,
-see the https://hazelcast.com/clients/[clients page^].
+see the link:https://hazelcast.com/clients/[clients page].
 
 After selecting the language you need, you can find the table showing supported features on the selected language.
 


### PR DESCRIPTION
After the matrix is removed, and content is moved to per language basis, this content seems to be out-of-date.
Updated accordingly.