### PR TITLE
code fixes to make CDC code samples runnable in 5.0

### DIFF
--- a/docs/modules/pipelines/pages/cdc-join.adoc
+++ b/docs/modules/pipelines/pages/cdc-join.adoc
@@ -418,7 +418,23 @@ import java.util.concurrent.TimeUnit;
 
 public class Ordering {
 
-  
+    static StreamStage<ChangeRecord> fix(StreamStage<ChangeRecord> input) {
+        return input
+                .groupingKey(ChangeRecord::key)
+                .mapStateful(
+                        TimeUnit.SECONDS.toMillis(10),
+                        () -> new LongAccumulator(0),
+                        (lastSequence, key, record) -> {
+                            long sequence = record.sequenceValue();
+                            if (lastSequence.get() < sequence) {
+                                lastSequence.set(sequence);
+                                return record;
+                            }
+                            return null;
+                        },
+                        (TriFunction<LongAccumulator, RecordPart, Long, ChangeRecord>) (sequence, recordPart, aLong) -> null);
+    }
+
 }
 ```
 
@@ -430,7 +446,7 @@ your IDE and prints the current content of the cache.
 ```java
 package org.example;
 
-import com.hazelcast.core.Hazelcast;
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.HazelcastInstance;
 
 public class CacheRead {

--- a/docs/modules/pipelines/pages/cdc-postgres.adoc
+++ b/docs/modules/pipelines/pages/cdc-postgres.adoc
@@ -200,8 +200,8 @@ Maven::
 
    <dependencies>
        <dependency>
-           <groupId>com.hazelcast.jet</groupId>
-           <artifactId>hazelcast-jet</artifactId>
+           <groupId>com.hazelcast</groupId>
+           <artifactId>hazelcast</artifactId>
            <version>{full-version}</version>
        </dependency>
        <dependency>
@@ -364,7 +364,7 @@ IDE and will print the current content of the cache.
 ```java
 package org.example;
 
-import com.hazelcast.core.Hazelcast;
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.HazelcastInstance;
 
 public class CacheRead {

--- a/docs/modules/pipelines/pages/cdc.adoc
+++ b/docs/modules/pipelines/pages/cdc.adoc
@@ -226,8 +226,8 @@ Maven::
 
    <dependencies>
        <dependency>
-           <groupId>com.hazelcast.jet</groupId>
-           <artifactId>hazelcast-jet</artifactId>
+           <groupId>com.hazelcast</groupId>
+           <artifactId>hazelcast</artifactId>
            <version>{full-version}</version>
        </dependency>
        <dependency>
@@ -391,7 +391,7 @@ IDE and will print the current content of the cache.
 ```java
 package org.example;
 
-import com.hazelcast.core.Hazelcast;
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.HazelcastInstance;
 
 public class CacheRead {


### PR DESCRIPTION
Several of the code samples in the CDC pages do not compile or run.