### PR TITLE
Describe spring integration with hazelcast-enterprise HZ-732

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /build/
 .DS_Store
 package-lock.json
+.idea/
+*.iml

--- a/docs/modules/integrated-clustering/pages/spring.adoc
+++ b/docs/modules/integrated-clustering/pages/spring.adoc
@@ -19,23 +19,9 @@ for Spring Configuration.
 
 _Classpath Configuration:_
 
-NOTE: To enable Spring integration, the `hazelcast-spring-{full-version}.jar`
-or the full `hazelcast.jar` must be on the classpath.
+NOTE: To enable Spring integration, the `hazelcast-spring-{full-version}.jar` must be on the classpath.
 
-If you use Maven, add the following lines to your `pom.xml`.
-
-If you use `hazelcast.jar`:
-
-[source,xml,subs="attributes+"]
-----
-<dependency>
-    <groupId>com.hazelcast</groupId>
-    <artifactId>hazelcast</artifactId>
-    <version>{full-version}</version>
-</dependency>
-----
-
-If you use `hazelcast-spring.jar`:
+If you use Maven, add the following lines to your `pom.xml`:
 
 [source,xml,subs="attributes+"]
 ----
@@ -43,6 +29,28 @@ If you use `hazelcast-spring.jar`:
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-spring</artifactId>
     <version>{full-version}</version>
+</dependency>
+----
+
+If you want to use `hazelcast-spring` with `hazelcast-enterprise` you need to exclude the transitive `hazelcast` dependency:
+
+[source,xml,subs="attributes+"]
+----
+<dependency>
+    <groupId>com.hazelcast</groupId>
+    <artifactId>hazelcast-enterprise</artifactId>
+    <version>{full-version}</version>
+</dependency>
+<dependency>
+    <groupId>com.hazelcast</groupId>
+    <artifactId>hazelcast-spring</artifactId>
+    <version>{full-version}</version>
+    <exclusions>
+        <exclusion>
+          <groupId>com.hazelcast</groupId>
+          <artifactId>hazelcast</artifactId>
+        </exclusion>
+    </exclusions>
 </dependency>
 ----
 


### PR DESCRIPTION
Currently, in order to use `hazelcast-spring` with `hazelcast-enterprise` one needs to exclude the `hazelcast` dependency.

I've added a description of how to set it up. Also, removed reference to `full hazelcast.jar` as we don't have it anymore

More context can be found here: https://hazelcast.atlassian.net/browse/HZ-732?focusedCommentId=58366