### PR TITLE
Note added for multimap event support

### DIFF
--- a/docs/modules/events/pages/object-events.adoc
+++ b/docs/modules/events/pages/object-events.adoc
@@ -208,6 +208,8 @@ Its default value is `false`.
 You can listen to entry-based events in the MultiMap using `EntryListener`.
 The following is an example entry listener implementation for MultiMap.
 
+NOTE:  MultiMap Events support only `entryAdded`, `entryUpdated` and `mapCleared` events.
+
 [source,java]
 ----
 include::ROOT:example$/distributedevents/ExampleEntryListener.java[tag=mm]

--- a/docs/modules/events/pages/object-events.adoc
+++ b/docs/modules/events/pages/object-events.adoc
@@ -208,7 +208,7 @@ Its default value is `false`.
 You can listen to entry-based events in the MultiMap using `EntryListener`.
 The following is an example entry listener implementation for MultiMap.
 
-NOTE:  MultiMap Events support only `entryAdded`, `entryUpdated` and `mapCleared` events.
+NOTE: The entry listener for MultiMap supports only `entryAdded`, `entryUpdated` and `mapCleared` events.
 
 [source,java]
 ----


### PR DESCRIPTION
The generic event listener class `EntryListener ` supports many events but `MulltiMap` does not support all of them. To clarify that, related note is added.