### PR TITLE
Update obsolete go client `Start a Local Cluster in Docker` example

### DIFF
--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -316,44 +316,44 @@ go get github.com/hazelcast/hazelcast-go-client
 package main
 
 import (
-	"context"
-	"fmt"
-	"log"
+  "context"
+  "fmt"
+  "log"
 
-	"github.com/hazelcast/hazelcast-go-client"
+  "github.com/hazelcast/hazelcast-go-client"
 )
 
 func main() {
-	ctx := context.TODO()
+  ctx := context.TODO()
 
-	cb := hazelcast.NewConfig()
-	cb.ClientName = "hello-world" <1>
+  cb := hazelcast.NewConfig()
+  cb.ClientName = "hello-world" <1>
 
-	hz, err := hazelcast.StartNewClientWithConfig(ctx, cb) <2>
-	if err != nil {
-		log.Fatal(err)
-	}
+  hz, err := hazelcast.StartNewClientWithConfig(ctx, cb) <2>
+  if err != nil {
+    log.Fatal(err)
+  }
 
-	mp, err := hz.GetMap(ctx, "my-distributed-map") <3>
-	if err != nil {
-		log.Fatal(err)
-	}
+  mp, err := hz.GetMap(ctx, "my-distributed-map") <3>
+  if err != nil {
+    log.Fatal(err)
+  }
 
-    <4>
-	_, err = mp.Put(ctx, "1", "John")
-	if err != nil {
-		log.Fatal(err)
-	}
+  <4>
+  _, err = mp.Put(ctx, "1", "John")
+  if err != nil {
+    log.Fatal(err)
+  }
 
-	_, err = mp.Put(ctx, "2", "Mary")
-	if err != nil {
-		log.Fatal(err)
-	}
+  _, err = mp.Put(ctx, "2", "Mary")
+  if err != nil {
+    log.Fatal(err)
+  }
 
-	_, err = mp.Put(ctx, "3", "Jane")
-	if err != nil {
-		log.Fatal(err)
-	}
+  _, err = mp.Put(ctx, "3", "Jane")
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 
 ----
@@ -574,41 +574,40 @@ Go::
 package main
 
 import (
-	"context"
-	"fmt"
-	"log"
+  "context"
+  "fmt"
+  "log"
 
-	"github.com/hazelcast/hazelcast-go-client"
+  "github.com/hazelcast/hazelcast-go-client"
 )
 
 func main() {
-	ctx := context.TODO()
+  ctx := context.TODO()
 
-	cb := hazelcast.NewConfig()
-	cb.ClientName = "hello-world"
+  cb := hazelcast.NewConfig()
+  cb.ClientName = "hello-world"
 
-	hz, err := hazelcast.StartNewClientWithConfig(ctx, cb)
-	if err != nil {
-		log.Fatal(err)
-	}
+  hz, err := hazelcast.StartNewClientWithConfig(ctx, cb)
+  if err != nil {
+    log.Fatal(err)
+  }
 
-	defer hz.Shutdown(ctx) <2>
+  defer hz.Shutdown(ctx) <2>
 
-	mp, err := hz.GetMap(ctx, "my-distributed-map") <1>
-	if err != nil {
-		log.Fatal(err)
-	}
+  mp, err := hz.GetMap(ctx, "my-distributed-map") <1>
+  if err != nil {
+    log.Fatal(err)
+  }
 
-	entries, err := mp.GetEntrySet(ctx) 
-	if err != nil {
-		log.Fatal(err)
-	}
+  entries, err := mp.GetEntrySet(ctx) 
+  if err != nil {
+    log.Fatal(err)
+  }
 
-	for _, entry := range entries {
-		fmt.Printf("key: %s, value: %s\n", entry.Key, entry.Value)
-	}
+  for _, entry := range entries {
+    fmt.Printf("key: %s, value: %s\n", entry.Key, entry.Value)
+  }
 }
-
 
 ----
 <1> Request all data in the map and print it to the console.

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -302,7 +302,7 @@ if __name__ == "__main__":
 Go::
 +
 --
-. Install the Python client library.
+. Install the Go client library.
 +
 [source,shell]
 ----
@@ -313,28 +313,69 @@ go get github.com/hazelcast/hazelcast-go-client
 +
 [source,go]
 ----
-import "github.com/hazelcast/hazelcast-go-client"
+package main
 
-func mapSampleRun() {
-  cb := hazelcast.NewConfigBuilder()
+import (
+	"context"
+	"fmt"
+	"log"
 
-  cb.Cluster().SetName("hello-world") <1>
+	"github.com/hazelcast/hazelcast-go-client"
+)
 
-  client, err := hazelcast.StartNewClientWithConfig(cb) <2>
+func main() {
+	ShutdownProperly := func(ctx context.Context, hz *hazelcast.Client, err error) {
+		errSd := hz.Shutdown(ctx)
+		switch {
+		case err != nil && errSd == nil:
+			log.Fatal(fmt.Errorf("%v", err))
+		case err != nil && errSd != nil:
+			log.Fatal(fmt.Errorf("%v; %v", err, errSd))
+		}
+	}
 
-	mp, _ := client.GetMap("my-distributed-map") <3>
+	cb := hazelcast.NewConfig()
+	cb.ClientName = "hello-world" <1>
+
+	ctx := context.TODO()
+
+	hz, err := hazelcast.StartNewClientWithConfig(ctx, cb) <2>
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	mp, err := hz.GetMap(ctx, "my-distributed-map") <3>
+	if err != nil {
+		ShutdownProperly(ctx, hz, err)
+	}
 
   <4>
-	mp.Put("1", "John")
-	mp.Put("2", "Mary")
-	mp.Put("3", "Jane")
+	_, err = mp.Put(ctx, "1", "John")
+	if err != nil {
+		ShutdownProperly(ctx, hz, err)
+	}
+	_, err = mp.Put(ctx, "2", "Mary")
+	if err != nil {
+		ShutdownProperly(ctx, hz, err)
+	}
+	_, err = mp.Put(ctx, "3", "Jane")
+	if err != nil {
+		ShutdownProperly(ctx, hz, err)
+	}
 
-} 
+  <5>
+	err = hz.Shutdown(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
 ----
 <1> The name of the cluster that you want to connect to.
 <2> Create a client instance, using your configuration.
 <3> Create a map called `my-distributed-map`.
 <4> Write some keys and values to the map.
+<5> Disconnect from the member.
 --
 ====
 
@@ -545,32 +586,59 @@ Go::
 
 [source,go]
 ----
-import "github.com/hazelcast/hazelcast-go-client"
+package main
 
-func mapSampleRun() {
-  cb := hazelcast.NewConfigBuilder()
+import (
+	"context"
+	"fmt"
+	"log"
 
-  cb.Cluster().SetName("hello-world")
+	"github.com/hazelcast/hazelcast-go-client"
+)
 
-  client, err := hazelcast.StartNewClientWithConfig(cb) 
+func main() {
+	ShutdownProperly := func(ctx context.Context, hz *hazelcast.Client, err error) {
+		errSd := hz.Shutdown(ctx)
+		switch {
+		case err != nil && errSd == nil:
+			log.Fatal(fmt.Errorf("%v", err))
+		case err != nil && errSd != nil:
+			log.Fatal(fmt.Errorf("%v; %v", err, errSd))
+		}
+	}
+
+	cb := hazelcast.NewConfig()
+	cb.ClientName = "hello-world"
+
+	ctx := context.TODO()
+
+	hz, err := hazelcast.StartNewClientWithConfig(ctx, cb)
+	if err != nil {
+		log.Fatalln(err)
+	}
 
   <1>
-  ctx := context.TODO()
-  myMap, err := client.GetMap(ctx, "my-distributed-map")
-  if err != nil {
-    // handle the error
-  }
-  entries, err := myMap.GetEntrySet(ctx)
-  if err != nil {
-    // handle the error
-  }
-  for key, value := range entries {
-    fmt.Println(key, value)
-  }
+	mp, err := hz.GetMap(ctx, "my-distributed-map")
+	if err != nil {
+		ShutdownProperly(ctx, hz, err)
+	}
 
-  hz.Shutdown() <2>
+	entries, err := mp.GetEntrySet(ctx)
+	if err != nil {
+		ShutdownProperly(ctx, hz, err)
+	}
 
-} 
+	for key, value := range entries {
+		fmt.Println(key, value)
+	}
+
+  <2>
+	err = hz.Shutdown(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
 ----
 <1> Request all data in the map and print it to the console.
 <2> Disconnect from the member.

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -317,56 +317,47 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/hazelcast/hazelcast-go-client"
 )
 
 func main() {
-	ShutdownProperly := func(ctx context.Context, hz *hazelcast.Client, err error) {
-		errSd := hz.Shutdown(ctx)
-		switch {
-		case err != nil && errSd == nil:
-			log.Fatal(fmt.Errorf("%v", err))
-		case err != nil && errSd != nil:
-			log.Fatal(fmt.Errorf("%v; %v", err, errSd))
-		}
-	}
+	ctx := context.TODO()
 
 	cb := hazelcast.NewConfig()
 	cb.ClientName = "hello-world" <1>
 
-	ctx := context.TODO()
-
 	hz, err := hazelcast.StartNewClientWithConfig(ctx, cb) <2>
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalf("Client could not connect to the cluster, %v", err)
 	}
+
+	defer func(ctx context.Context) { <5>
+		if err := hz.Shutdown(ctx); err != nil {
+			log.Fatalf("Could not shutdown gracefully, %v", err)
+		}
+	}(ctx)
 
 	mp, err := hz.GetMap(ctx, "my-distributed-map") <3>
 	if err != nil {
-		ShutdownProperly(ctx, hz, err)
+		log.Fatalf("Could not create a map, %v", err)
 	}
 
   <4>
 	_, err = mp.Put(ctx, "1", "John")
 	if err != nil {
-		ShutdownProperly(ctx, hz, err)
-	}
-	_, err = mp.Put(ctx, "2", "Mary")
-	if err != nil {
-		ShutdownProperly(ctx, hz, err)
-	}
-	_, err = mp.Put(ctx, "3", "Jane")
-	if err != nil {
-		ShutdownProperly(ctx, hz, err)
+		log.Fatalf("Might not be put to the map, %v", err)
 	}
 
-  <5>
-	err = hz.Shutdown(ctx)
+	_, err = mp.Put(ctx, "2", "Mary")
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalf("Might not be put to the map, %v", err)
+	}
+
+	_, err = mp.Put(ctx, "3", "Jane")
+	if err != nil {
+		log.Fatalf("Might not be put to the map, %v", err)
 	}
 }
 
@@ -375,7 +366,7 @@ func main() {
 <2> Create a client instance, using your configuration.
 <3> Create a map called `my-distributed-map`.
 <4> Write some keys and values to the map.
-<5> Disconnect from the member.
+<5> Disconnect from the cluster.
 --
 ====
 

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -334,52 +334,33 @@ func main() {
 		log.Fatal(err)
 	}
 
-    <5>
-	defer hz.Shutdown(ctx)
-
 	mp, err := hz.GetMap(ctx, "my-distributed-map") <3>
 	if err != nil {
 		log.Fatal(err)
 	}
 
-    <4>
+  <4>
 	_, err = mp.Put(ctx, "1", "John")
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    _, err = mp.Put(ctx, "2", "Mary")
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    _, err = mp.Put(ctx, "3", "Jane")
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    entries, err := mp.GetEntrySet(ctx)
-    if err != nil {
-        log.Fatal(err)
-    }
-
-	entries, err := mp.GetEntrySet(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	for _, entry := range entries {
-		fmt.Printf("key: %s, value: %s\n", entry.Key, entry.Value)
+	_, err = mp.Put(ctx, "2", "Mary")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = mp.Put(ctx, "3", "Jane")
+	if err != nil {
+		log.Fatal(err)
 	}
 }
-
 
 ----
 <1> The name of the cluster that you want to connect to.
 <2> Create a client instance, using your configuration.
 <3> Create a map called `my-distributed-map`.
 <4> Write some keys and values to the map.
-<5> Disconnect from the cluster.
 --
 ====
 
@@ -601,47 +582,35 @@ import (
 )
 
 func main() {
-	ShutdownProperly := func(ctx context.Context, hz *hazelcast.Client, err error) {
-		errSd := hz.Shutdown(ctx)
-		switch {
-		case err != nil && errSd == nil:
-			log.Fatal(fmt.Errorf("%v", err))
-		case err != nil && errSd != nil:
-			log.Fatal(fmt.Errorf("%v; %v", err, errSd))
-		}
-	}
+	ctx := context.TODO()
 
 	cb := hazelcast.NewConfig()
 	cb.ClientName = "hello-world"
 
-	ctx := context.TODO()
-
 	hz, err := hazelcast.StartNewClientWithConfig(ctx, cb)
 	if err != nil {
-		log.Fatalln(err)
-	}
-
-  <1>
-	mp, err := hz.GetMap(ctx, "my-distributed-map")
-	if err != nil {
-		ShutdownProperly(ctx, hz, err)
-	}
-
-	entries, err := mp.GetEntrySet(ctx)
-	if err != nil {
-		ShutdownProperly(ctx, hz, err)
-	}
-
-	for key, value := range entries {
-		fmt.Println(key, value)
+		log.Fatal(err)
 	}
 
   <2>
-	err = hz.Shutdown(ctx)
+	defer hz.Shutdown(ctx)
+
+  <1>
+	mp, err := hz.GetMap(ctx, "my-distributed-map") <1>
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatal(err)
+	}
+
+	entries, err := mp.GetEntrySet(ctx) 
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, entry := range entries {
+		fmt.Printf("key: %s, value: %s\n", entry.Key, entry.Value)
 	}
 }
+
 
 ----
 <1> Request all data in the map and print it to the console.

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -326,33 +326,33 @@ import (
 func main() {
   ctx := context.TODO()
 
-  cb := hazelcast.NewConfig()
-  cb.ClientName = "hello-world" <1>
+  cfg := hazelcast.Config{}
+	cfg.Cluster.Name = "hello-world" <1>
 
   hz, err := hazelcast.StartNewClientWithConfig(ctx, cb) <2>
   if err != nil {
-    log.Fatal(err)
+    panic(fmt.Errorf("starting the client with config: %w", err))
   }
 
   mp, err := hz.GetMap(ctx, "my-distributed-map") <3>
   if err != nil {
-    log.Fatal(err)
+    panic(fmt.Errorf("trying to get a map: %w", err))
   }
 
   <4>
-  _, err = mp.Put(ctx, "1", "John")
+  _, err = mp.Put(ctx, 1, "John")
   if err != nil {
-    log.Fatal(err)
+    panic(fmt.Errorf("trying to put to map: %w", err))
   }
 
-  _, err = mp.Put(ctx, "2", "Mary")
+  _, err = mp.Put(ctx, 2, "Mary")
   if err != nil {
-    log.Fatal(err)
+    panic(fmt.Errorf("trying to put to map: %w", err))
   }
 
-  _, err = mp.Put(ctx, "3", "Jane")
+  _, err = mp.Put(ctx, 3, "Jane")
   if err != nil {
-    log.Fatal(err)
+    panic(fmt.Errorf("trying to put to map: %w", err))
   }
 }
 
@@ -574,39 +574,38 @@ Go::
 package main
 
 import (
-  "context"
-  "fmt"
-  "log"
+	"context"
+	"fmt"
 
-  "github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client"
 )
 
 func main() {
-  ctx := context.TODO()
+	ctx := context.TODO()
 
-  cb := hazelcast.NewConfig()
-  cb.ClientName = "hello-world"
+	cfg := hazelcast.Config{}
+	cfg.Cluster.Name = "hello-world"
 
-  hz, err := hazelcast.StartNewClientWithConfig(ctx, cb)
-  if err != nil {
-    log.Fatal(err)
-  }
+	hz, err := hazelcast.StartNewClientWithConfig(ctx, cfg)
+	if err != nil {
+		panic(fmt.Errorf("starting the client with config: %w", err))
+	}
 
-  defer hz.Shutdown(ctx) <2>
+	defer hz.Shutdown(ctx) <2>
 
-  mp, err := hz.GetMap(ctx, "my-distributed-map") <1>
-  if err != nil {
-    log.Fatal(err)
-  }
+	mp, err := hz.GetMap(ctx, "my-distributed-map") <1>
+	if err != nil {
+		panic(fmt.Errorf("trying to get a map: %w", err))
+	}
 
-  entries, err := mp.GetEntrySet(ctx) 
-  if err != nil {
-    log.Fatal(err)
-  }
+	entries, err := mp.GetEntrySet(ctx)
+	if err != nil {
+		panic(fmt.Errorf("trying to get an entries of the map: %w", err))
+	}
 
-  for _, entry := range entries {
-    fmt.Printf("key: %s, value: %s\n", entry.Key, entry.Value)
-  }
+	for _, entry := range entries {
+		fmt.Printf("key: %v, value: %v\n", entry.Key, entry.Value)
+	}
 }
 
 ----

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -327,7 +327,7 @@ func main() {
   ctx := context.TODO()
 
   cfg := hazelcast.Config{}
-	cfg.Cluster.Name = "hello-world" <1>
+  cfg.Cluster.Name = "hello-world" <1>
 
   hz, err := hazelcast.StartNewClientWithConfig(ctx, cb) <2>
   if err != nil {
@@ -574,38 +574,38 @@ Go::
 package main
 
 import (
-	"context"
-	"fmt"
+  "context"
+  "fmt"
 
-	"github.com/hazelcast/hazelcast-go-client"
+  "github.com/hazelcast/hazelcast-go-client"
 )
 
 func main() {
-	ctx := context.TODO()
+  ctx := context.TODO()
 
-	cfg := hazelcast.Config{}
-	cfg.Cluster.Name = "hello-world"
+  cfg := hazelcast.Config{}
+  cfg.Cluster.Name = "hello-world"
 
-	hz, err := hazelcast.StartNewClientWithConfig(ctx, cfg)
-	if err != nil {
-		panic(fmt.Errorf("starting the client with config: %w", err))
-	}
+  hz, err := hazelcast.StartNewClientWithConfig(ctx, cfg)
+  if err != nil {
+    panic(fmt.Errorf("starting the client with config: %w", err))
+  }
 
-	defer hz.Shutdown(ctx) <2>
+  defer hz.Shutdown(ctx) <2>
 
-	mp, err := hz.GetMap(ctx, "my-distributed-map") <1>
-	if err != nil {
-		panic(fmt.Errorf("trying to get a map: %w", err))
-	}
+  mp, err := hz.GetMap(ctx, "my-distributed-map") <1>
+  if err != nil {
+    panic(fmt.Errorf("trying to get a map: %w", err))
+  }
 
-	entries, err := mp.GetEntrySet(ctx)
-	if err != nil {
-		panic(fmt.Errorf("trying to get an entries of the map: %w", err))
-	}
+  entries, err := mp.GetEntrySet(ctx)
+  if err != nil {
+    panic(fmt.Errorf("trying to get an entries of the map: %w", err))
+  }
 
-	for _, entry := range entries {
-		fmt.Printf("key: %v, value: %v\n", entry.Key, entry.Value)
-	}
+  for _, entry := range entries {
+    fmt.Printf("key: %v, value: %v\n", entry.Key, entry.Value)
+  }
 }
 
 ----

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -339,7 +339,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-  <4>
+    <4>
 	_, err = mp.Put(ctx, "1", "John")
 	if err != nil {
 		log.Fatal(err)
@@ -592,10 +592,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-  <2>
-	defer hz.Shutdown(ctx)
+	defer hz.Shutdown(ctx) <2>
 
-  <1>
 	mp, err := hz.GetMap(ctx, "my-distributed-map") <1>
 	if err != nil {
 		log.Fatal(err)

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -329,7 +329,7 @@ func main() {
   cfg := hazelcast.Config{}
   cfg.Cluster.Name = "hello-world" <1>
 
-  hz, err := hazelcast.StartNewClientWithConfig(ctx, cb) <2>
+  hz, err := hazelcast.StartNewClientWithConfig(ctx, cfg) <2>
   if err != nil {
     panic(fmt.Errorf("starting the client with config: %w", err))
   }

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -317,6 +317,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hazelcast/hazelcast-go-client"
@@ -330,36 +331,48 @@ func main() {
 
 	hz, err := hazelcast.StartNewClientWithConfig(ctx, cb) <2>
 	if err != nil {
-		log.Fatalf("Client could not connect to the cluster, %v", err)
+		log.Fatal(err)
 	}
 
-	defer func(ctx context.Context) { <5>
-		if err := hz.Shutdown(ctx); err != nil {
-			log.Fatalf("Could not shutdown gracefully, %v", err)
-		}
-	}(ctx)
+    <5>
+	defer hz.Shutdown(ctx)
 
 	mp, err := hz.GetMap(ctx, "my-distributed-map") <3>
 	if err != nil {
-		log.Fatalf("Could not create a map, %v", err)
+		log.Fatal(err)
 	}
 
-  <4>
+    <4>
 	_, err = mp.Put(ctx, "1", "John")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    _, err = mp.Put(ctx, "2", "Mary")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    _, err = mp.Put(ctx, "3", "Jane")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    entries, err := mp.GetEntrySet(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+	entries, err := mp.GetEntrySet(ctx)
 	if err != nil {
-		log.Fatalf("Might not be put to the map, %v", err)
+		log.Fatal(err)
 	}
 
-	_, err = mp.Put(ctx, "2", "Mary")
-	if err != nil {
-		log.Fatalf("Might not be put to the map, %v", err)
-	}
-
-	_, err = mp.Put(ctx, "3", "Jane")
-	if err != nil {
-		log.Fatalf("Might not be put to the map, %v", err)
+	for _, entry := range entries {
+		fmt.Printf("key: %s, value: %s\n", entry.Key, entry.Value)
 	}
 }
+
 
 ----
 <1> The name of the cluster that you want to connect to.


### PR DESCRIPTION
- Typo was fixed.
- Context and sample error handling mechanism were added.
- Obsolete implementation were creating a client for writing to members but did not close it. It even did not use the same client that it has already created it before in writing section and starts a new client in reading section again. Therefore I shutdown the client in both writing and reading sections of the guide. @yuce @utku-caglayan 