### PR TITLE
Bug fix in programatic configuration

### DIFF
--- a/docs/modules/cluster-performance/pages/best-practices.adoc
+++ b/docs/modules/cluster-performance/pages/best-practices.adoc
@@ -1095,7 +1095,7 @@ hazelcast:
 Config config = new Config();
 MapConfig mapConfig = config.getMapConfig("name-of-the-map");
 PartitioningStrategyConfig psConfig = mapConfig.getPartitioningStrategyConfig();
-psConfig.setPartitioningStrategyClass( "StringAndPartitionAwarePartitioningStrategy" );
+psConfig.setPartitioningStrategyClass( "com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy" );
 
 // OR
 psConfig.setPartitioningStrategy(YourCustomPartitioningStrategy);


### PR DESCRIPTION
Fix for programatic configuration for setPartitioningStrategyClass

Before: 
```
psConfig.setPartitioningStrategyClass( "StringAndPartitionAwarePartitioningStrategy" );
```

After:

```
psConfig.setPartitioningStrategyClass( "com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy" );
```