### PR TITLE
Remove limitation around the schema validation for Compact

### DIFF
--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -281,11 +281,6 @@ written by a new writer, they will be able to read all fields.
 
 == CompactSerializationConfig
 
-NOTE: Since the Compact serialization is in BETA, and the configuration API might change
-in the future, we didn't define it in our XSDs. If you want to configure Compact
-serialization with XML or YAML configurations, you have to disable schema validation, by
-setting the `hazelcast.config.schema.validation.enabled` system property to `false`.
-
 During the BETA period, Compact serialization has to be enabled explicitly as shown below.
 
 **Programmatic Configuration:**


### PR DESCRIPTION
We have decided to add XSD and JSON schema definition for the compact
format to the Hazelcast, even if it is still in BETA.

Due to that, disabling the schema validation is not required anymore.

So, this PR removes that warning.