### PR TITLE
Describe how to install repository keys on Ubuntu/Debian without deprecated apt-key

### DIFF
--- a/docs/modules/deploy/pages/installing-upgrading.adoc
+++ b/docs/modules/deploy/pages/installing-upgrading.adoc
@@ -36,8 +36,8 @@ ifdef::snapshot[]
 .Debian
 [source,shell]
 ----
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian snapshot main" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian snapshot main" | sudo tee -a /etc/apt/sources.list
 sudo apt update && sudo apt install hazelcast
 ----
 
@@ -53,8 +53,8 @@ ifndef::snapshot[]
 .Debian
 [source,shell,subs="attributes+"]
 ----
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
 sudo apt update && sudo apt install hazelcast={full-version}
 ----
 

--- a/docs/modules/management/pages/cluster-utilities.adoc
+++ b/docs/modules/management/pages/cluster-utilities.adoc
@@ -31,8 +31,8 @@ Debian::
 +
 [source,bash]
 ----
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
 sudo apt update && sudo apt install hazelcast
 ----
 


### PR DESCRIPTION
Ubuntu 22.04 complains about `apt-key` being deprecated as an insecure method of adding signing keys.

This PR changes the description of installation to the currently preferred method of adding keys of 3rd party repositories. 

I've tested the method against all LTS Ubuntus starting from 16.04.

More information: https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html

Related PR: https://github.com/hazelcast/hazelcast-packaging/pull/143