### PR TITLE
Describe how to install repository keys on Ubuntu/Debian without deprecated apt-key (#425) [5.1]

### DIFF
--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -39,8 +39,8 @@ ifdef::snapshot[]
 .Debian
 [source,shell]
 ----
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian snapshot main" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian snapshot main" | sudo tee -a /etc/apt/sources.list
 sudo apt update && sudo apt install hazelcast
 ----
 
@@ -56,8 +56,8 @@ ifndef::snapshot[]
 .Debian
 [source,shell,subs="attributes+"]
 ----
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
 sudo apt update && sudo apt install hazelcast={full-version}
 ----
 

--- a/docs/modules/management/pages/cluster-utilities.adoc
+++ b/docs/modules/management/pages/cluster-utilities.adoc
@@ -31,8 +31,8 @@ Debian::
 +
 [source,bash]
 ----
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | sudo apt-key add -
-echo "deb https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
+wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
 sudo apt update && sudo apt install hazelcast
 ----
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/425