### PR TITLE
Added Missing Lifecycle State

### DIFF
--- a/docs/modules/events/pages/cluster-events.adoc
+++ b/docs/modules/events/pages/cluster-events.adoc
@@ -401,6 +401,7 @@ The Lifecycle Listener notifies for the following events:
 * `MERGED`: A member's merge operation has completed.
 * `CLIENT_CONNECTED`: A Hazelcast Client connected to the cluster.
 * `CLIENT_DISCONNECTED`: A Hazelcast Client disconnected from the cluster.
+* `CLIENT_CHANGED_CLUSTER`: The client connected to a new cluster.
 
 The following is an example Lifecycle Listener class.
 


### PR DESCRIPTION
Added `CLINET_CHANGED_CLUSTER` state to docs. 
For ref: https://github.com/hazelcast/hazelcast/blob/4bd78004dd5c5289475b63fab6a868b237adb94f/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java#L92