### PR TITLE
Fixes #451 Removes references to odd number of members in cluster

### DIFF
--- a/docs/modules/ROOT/pages/capacity-planning.adoc
+++ b/docs/modules/ROOT/pages/capacity-planning.adoc
@@ -66,8 +66,7 @@ hosted jobs and increases resilience.
 
 To make fault tolerance possible, your cluster must have at least three
 members. Generally, you need `n+1` cluster members to tolerate `n`
-simultaneous member failures, and the number of members must be odd for split-brain
-detection to work.
+simultaneous member failures.
 
 If you use the Jet stream processing engine, it can use hundreds of CPU cores 
 efficiently by exploiting data and

--- a/docs/modules/fault-tolerance/pages/fault-tolerance.adoc
+++ b/docs/modules/fault-tolerance/pages/fault-tolerance.adoc
@@ -60,7 +60,7 @@ Sinks can cooperate in different ways:
   keys after a restart. Also if you process the journal for a map, the
   journal will contain the update event multiple times.
 
-== Distributed Snapshot
+== Distributed Snapshot
 
 The technique Hazelcast uses to achieve fault tolerance is called a
 “distributed snapshot”, described in a link:http://lamport.azurewebsites.net/pubs/chandy.pdf[paper by Chandy and Lamport]. At regular
@@ -81,7 +81,7 @@ receive the barrier item from each of them at separate times, but it
 must start taking a snapshot at a single point in time. There are two
 approaches it can take, as explained below.
 
-=== Exactly-Once
+=== Exactly-Once
 
 With exactly-once configured, as soon as the processor gets a barrier
 item in any input stream (from any upstream processor), it must stop
@@ -101,7 +101,7 @@ image:exactly-once-2.png[Exactly-once processing: received both barrier items]
 +
 image:exactly-once-3.png[Exactly-once processing: forwarding the barrier]
 
-=== At-Least-Once
+=== At-Least-Once
 
 With at-least-once configured, the processor can keep consuming all the
 streams until it gets all the barriers, at which point it stops to take
@@ -168,7 +168,7 @@ split-brain protection like this:
 jobConfig.setSplitBrainProtection(true);
 ```
 
-NOTE: Make sure that you disable the split-brain condition when introducing new members to the cluster. Otherwise, both sub-clusters may grow to more than half of the previous size, circumventing split-brain protection.
+NOTE: Make sure that you resolve the split-brain condition before introducing new members to the cluster. Otherwise, both sub-clusters may grow to more than half of the previous size, circumventing split-brain protection.
 
 === Disk Snapshot Storage
 

--- a/docs/modules/fault-tolerance/pages/fault-tolerance.adoc
+++ b/docs/modules/fault-tolerance/pages/fault-tolerance.adoc
@@ -168,14 +168,7 @@ split-brain protection like this:
 jobConfig.setSplitBrainProtection(true);
 ```
 
-If there’s an even number of members in your cluster, this may mean the
-job will not be able to restart at all if the cluster splits into two
-equally-sized parts. We recommend having an odd number of members.
-
-Note also that you should ensure there is no split-brain condition at
-the moment you are introducing new members to the cluster. If that
-happens, both sub-clusters may grow to more than half of the previous
-size, circumventing the split-brain protection.
+NOTE: Make sure that you disable the split-brain condition when introducing new members to the cluster. Otherwise, both sub-clusters may grow to more than half of the previous size, circumventing split-brain protection.
 
 === Disk Snapshot Storage
 


### PR DESCRIPTION
Updates to text

- fault-tolerance.adoc - Removed reference to odd number of cluster members in Split-Brain Protection and slight rewording of Note admonition text.

- capacity-planning.adoc - Removed references to odd number of cluster members.

