### PR TITLE
Fixes #447 Map name limitations with persistence enabled

### DIFF
--- a/docs/modules/storage/pages/configuring-persistence.adoc
+++ b/docs/modules/storage/pages/configuring-persistence.adoc
@@ -1024,6 +1024,14 @@ include::ROOT:example$/storage/SampleEncryptionAtRestConfiguration.java[tag=vaul
 
 Use the following options to configure persistence for xref:data-structures:map.adoc[map] and xref:jcache:overview.adoc[JCache] data structures.
 
+[NOTE]
+====
+To avoid exception errors, make sure that your map names do not:
+
+* Exceed 255 characters. 
+* Contain special characters (`*``:``"``'``|``<````,``>``?``/`).
+====
+
 [tabs] 
 ==== 
 XML:: 

--- a/docs/modules/storage/pages/configuring-persistence.adoc
+++ b/docs/modules/storage/pages/configuring-persistence.adoc
@@ -1026,10 +1026,10 @@ Use the following options to configure persistence for xref:data-structures:map.
 
 [NOTE]
 ====
-To avoid exception errors, make sure that your map names do not:
+You cannot persist a map if its name contains either of the following. Otherwise, Hazelcast throws an exception.
 
-* Exceed 255 characters. 
-* Contain special characters (`*``:``"``'``|``<````,``>``?``/`).
+* 255+ characters
+* Special characters (`*``:``"``'``|``<````,``>``?``/`)
 ====
 
 [tabs] 

--- a/docs/modules/storage/pages/persistence.adoc
+++ b/docs/modules/storage/pages/persistence.adoc
@@ -28,9 +28,9 @@ You can persist the contents of map or JCache data structures as well as any str
 cluster crashes while repartitioning, currently it is
 not possible to restore persisted data.
 
-- **Map naming conventions**: To avoid exception errors, do not use map names that:
-** Exceed 255 characters.
-** Contain special characters (`*``:``"``'``|``<````,``>``?``/`).
+- **Map naming conventions**: You cannot persist a map if its name contains either of the following. Otherwise, Hazelcast throws an exception.
+** 255+ characters
+** Special characters (`*``:``"``'``|``<````,``>``?``/`)
 
 == Related Resources
 

--- a/docs/modules/storage/pages/persistence.adoc
+++ b/docs/modules/storage/pages/persistence.adoc
@@ -21,11 +21,16 @@ Clusters can use persisted data to recover from the following scenarios:
 
 You can persist the contents of map or JCache data structures as well as any streaming job snapshots.
 
+
 == Limitations
 
-When a whole
+- **Cluster crashes**: When a whole
 cluster crashes while repartitioning, currently it is
 not possible to restore persisted data.
+
+- **Map naming conventions**: To avoid exception errors, do not use map names that:
+** Exceed 255 characters.
+** Contain special characters (`*``:``"``'``|``<````,``>``?``/`).
 
 == Related Resources
 


### PR DESCRIPTION
Added short notes to the following pages. 

- Persistence.adoc - Limitations
- Configuring-persistence.adoc - Data Structure Options

There may be more/different places where it makes more sense to highlight this information.