### PR TITLE
Fixes #475 Linux install correction

### DIFF
--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -37,7 +37,7 @@ Linux::
 . Check that you have the GNU Wget package installed. You'll use Wget to download the GPG keys for the Hazelcast package.
 +
 ```bash
-wget -v
+wget -V
 ```
 +
 If you do not see a version number, download and install link:https://www.gnu.org/software/wget/[Wget^].
@@ -64,6 +64,7 @@ sudo yum install hazelcast
 ----
 +
 endif::[]
++
 ifndef::snapshot[]
 
 .Debian


### PR DESCRIPTION
Updated formatting on tab for 5.1.x {full version} as indentation and heading style incorrect.
Capitalized wget -**V** as incorrect command