### PR TITLE
Fix examples for HOST_AWARE partition group type

### DIFF
--- a/docs/modules/clusters/pages/partition-group-configuration.adoc
+++ b/docs/modules/clusters/pages/partition-group-configuration.adoc
@@ -53,12 +53,7 @@ XML::
 [source,xml]
 ----
 <hazelcast>
-    <partition-group enabled="true" group-type="HOST_AWARE">
-        <member-group>
-            <interface>10.10.0.*</interface>
-            <interface>10.10.3.*</interface>
-            <interface>10.10.5.*</interface>
-    </partition-group>
+    <partition-group enabled="true" group-type="HOST_AWARE"/>
 </hazelcast>
 ----
 --
@@ -71,10 +66,6 @@ hazelcast:
   partition-group:
     enabled: true
     group-type: HOST_AWARE
-    member-group:
-      - - 10.10.0.*
-        - 10.10.3.*
-        - 10.10.5.*
 ----
 
 Java::


### PR DESCRIPTION
The `member-groups` configuration is not taken into account for the `HOST_AWARE` group type.