### PR TITLE
Rename Azul JDKs according to the new branding

### DIFF
--- a/docs/modules/deploy/pages/supported-jvms.adoc
+++ b/docs/modules/deploy/pages/supported-jvms.adoc
@@ -20,10 +20,10 @@ TIP: If you install Hazelcast with Docker or a package manager, it comes with a 
 |Amazon Corretto
 |8, 11 and 17
 
-|Azul Zing
+|Azul Prime (formerly Zing)
 |8
 
-|Azul Zulu
+|Azul Core (formerly Zulu)
 | 8, 11, and 17
 
 |IBM SDK, Java Technology Edition


### PR DESCRIPTION
The branding of the Azul JDKs changed. I kept the "formerly ..." because a lot of the Java community refers to them with the original name.