### PR TITLE
Use Platform as product title

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: hazelcast
-title: Hazelcast
+title: Platform
 # Version in the URL
 version: '5.2-snapshot'
 # Version in the version selector (we display only the latest major.minor version)


### PR DESCRIPTION
The URLs are unchanged, but the labels here will display 'Platform', which is the correct product name
![image](https://user-images.githubusercontent.com/45230295/184888787-69ff135d-32d7-4952-bd49-0640ad666364.png)
