### PR TITLE
[API-1530] Update Compact serialization documentation

### DIFF
--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -612,7 +612,7 @@ can be implemented on top of these, by using these types as building blocks.
 
 | BOOLEAN
 | boolean
-|
+| bool
 | bool
 | boolean
 | bool
@@ -622,7 +622,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_BOOLEAN
 | boolean[]
-|
+| bool[]
 | boost::optional<std::vector<bool>>
 | boolean[] \| null
 | Optional[list[bool]]
@@ -631,7 +631,7 @@ Up to eight booleans are packed into a single byte.
 
 | NULLABLE_BOOLEAN
 | Boolean
-| 
+| bool?
 | boost::optional<bool>
 | boolean \| null
 | Optional[bool]
@@ -640,7 +640,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_NULLABLE_BOOLEAN
 | Boolean[]
-| 
+| bool?[]
 | boost::optional<std::vector<boost::optional<bool>>>
 | (boolean \| null)[] \| null
 | Optional[list[Optional[bool]]]
@@ -649,7 +649,7 @@ Up to eight booleans are packed into a single byte.
 
 | INT8
 | byte
-|
+| sbyte
 | int8_t
 | number
 | int
@@ -658,7 +658,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_INT8
 | byte[]
-| 
+| sbyte[]
 | boost::optional<std::vector<int8_t>>
 | Buffer \| null
 | Optional[list[int]]
@@ -667,7 +667,7 @@ Up to eight booleans are packed into a single byte.
 
 | NULLABLE_INT8
 | Byte
-|
+| sbyte?
 | boost::optional<int8_t>
 | number \| null
 | Optional[int]
@@ -676,7 +676,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_NULLABLE_INT8
 | Byte[]
-|
+| sbyte?[]
 | boost::optional<std::vector<boost::optional<int8_t>>>
 | (number \| null)[] \| null
 | Optional[list[Optional[int]]]
@@ -685,7 +685,7 @@ Up to eight booleans are packed into a single byte.
 
 | INT16
 | short
-|
+| short
 | int16_t
 | number
 | int
@@ -694,7 +694,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_INT16
 | short[]
-|
+| short[]
 | boost::optional<std::vector<int16_t>>
 | number[] \| null
 | Optional[list[int]]
@@ -703,7 +703,7 @@ Up to eight booleans are packed into a single byte.
 
 | NULLABLE_INT16
 | Short
-|
+| short?
 | boost::optional<int16_t>
 | number \| null
 | Optional[int]
@@ -712,7 +712,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_NULLABLE_INT16
 | Short[]
-|
+| short?[]
 | boost::optional<std::vector<boost::optional<int16_t>>>
 | (number \| null)[] \| null
 | Optional[list[Optional[int]]]
@@ -721,7 +721,7 @@ Up to eight booleans are packed into a single byte.
 
 | INT32
 | int
-|
+| int
 | int32_t
 | number
 | int
@@ -730,7 +730,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_INT32
 | int[]
-|
+| int[]
 | boost::optional<std::vector<int32_t>>
 | number[] \| null
 | Optional[list[int]]
@@ -739,7 +739,7 @@ Up to eight booleans are packed into a single byte.
 
 | NULLABLE_INT32
 | Integer
-|
+| int?
 | boost::optional<int32_t>
 | number \| null
 | Optional[int]
@@ -748,7 +748,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_NULLABLE_INT32
 | Integer[]
-|
+| int?[]
 | boost::optional<std::vector<boost::optional<int32_t>>>
 | (number \| null)[] \| null
 | Optional[list[Optional[int]]]
@@ -757,7 +757,7 @@ Up to eight booleans are packed into a single byte.
 
 | INT64
 | long
-|
+| long
 | int64_t
 | Long
 | int
@@ -766,7 +766,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_INT64
 | long[]
-|
+| long[]
 | boost::optional<std::vector<int64_t>>
 | Long[] \| null
 | Optional[list[int]]
@@ -775,7 +775,7 @@ Up to eight booleans are packed into a single byte.
 
 | NULLABLE_INT64
 | Long
-|
+| long?
 | boost::optional<int64_t>
 | Long \| null
 | Optional[int]
@@ -784,7 +784,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_NULLABLE_INT64
 | Long[]
-|
+| long?[]
 | boost::optional<std::vector<boost::optional<int64_t>>>
 | (Long \| null)[] \| null
 | Optional[list[Optional[int]]]
@@ -793,7 +793,7 @@ Up to eight booleans are packed into a single byte.
 
 | FLOAT32
 | float
-|
+| float
 | float
 | number
 | float
@@ -802,7 +802,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_FLOAT32
 | float[]
-|
+| float[]
 | boost::optional<std::vector<float>>
 | number[] \| null
 | Optional[list[float]]
@@ -811,7 +811,7 @@ Up to eight booleans are packed into a single byte.
 
 | NULLABLE_FLOAT32
 | Float
-|
+| float?
 | boost::optional<float>
 | number \| null
 | Optional[float]
@@ -820,7 +820,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_NULLABLE_FLOAT32
 | Float[]
-|
+| float?[]
 | boost::optional<std::vector<boost::optional<float>>>
 | (number \| null)[] \| null
 | Optional[list[Optional[float]]]
@@ -829,7 +829,7 @@ Up to eight booleans are packed into a single byte.
 
 | FLOAT64
 | double
-|
+| double
 | double
 | number
 | float
@@ -838,7 +838,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_FLOAT64
 | double[]
-|
+| double[]
 | boost::optional<std::vector<double>>
 | number[] \| null
 | Optional[list[float]]
@@ -847,7 +847,7 @@ Up to eight booleans are packed into a single byte.
 
 | NULLABLE_FLOAT64
 | Double
-|
+| double?
 | boost::optional<double>
 | number \| null
 | Optional[float]
@@ -856,7 +856,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_NULLABLE_FLOAT64
 | Double[]
-|
+| double?[]
 | boost::optional<std::vector<boost::optional<double>>>
 | (number \| null)[] \| null
 | Optional[list[Optional[float]]]
@@ -865,7 +865,7 @@ Up to eight booleans are packed into a single byte.
 
 | STRING
 | String
-|
+| string
 | std::string
 | string \| null
 | Optional[str]
@@ -874,7 +874,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_STRING
 | String[]
-|
+| string[]
 | boost::optional<std::vector<std::string>>
 | (string \| null)[] \| null
 | Optional[list[Optional[str]]]
@@ -883,7 +883,7 @@ Up to eight booleans are packed into a single byte.
 
 | DECIMAL
 | BigDecimal
-|
+| HBigDecimal
 | boost::optional<hazelcast::client::big_decimal>
 | BigDecimal \| null
 | Optional[decimal.Decimal]
@@ -892,7 +892,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_DECIMAL
 | BigDecimal[]
-|
+| HBigDecimal[]
 | boost::optional<std::vector<boost::optional<hazelcast::client::big_decimal>>>
 | (BigDecimal \| null)[] \| null
 | Optional[list[decimal.Decimal]]
@@ -901,7 +901,7 @@ Up to eight booleans are packed into a single byte.
 
 | TIME
 | LocalTime
-|
+| HLocalTime
 | boost::optional<hazelcast::client::local_time>
 | LocalTime \| null
 | Optional[datetime.time]
@@ -910,7 +910,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_TIME
 | LocalTime[]
-|
+| HLocalTime[]
 | boost::optional<std::vector<boost::optional<local_time>>>
 | (LocalTime \| null)[] \| null
 | Optional[list[Optional[datetime.time]]]
@@ -919,7 +919,7 @@ Up to eight booleans are packed into a single byte.
 
 | DATE
 | LocalDate
-|
+| HLocalDate
 | boost::optional<hazelcast::client::local_date>
 | LocalDate \| null
 | Optional[datetime.date]
@@ -928,7 +928,7 @@ Up to eight booleans are packed into a single byte.
 
 | ARRAY_OF_DATE
 | LocalDate[]
-|  
+| HLocalDate[]
 | boost::optional<std::vector<boost::optional<local_date>>>
 | (LocalDate \| null)[] \| null
 | Optional[list[Optional[datetime.date]]]
@@ -937,7 +937,7 @@ Up to eight booleans are packed into a single byte.
 
 | TIMESTAMP
 | LocalDateTime
-|
+| HLocalDateTime
 | boost::optional<hazelcast::client::local_date_time>
 | LocalDateTime \| null
 | Optional[datetime.datetime]
@@ -947,7 +947,7 @@ and nanoseconds or null.
 
 | ARRAY_OF_TIMESTAMP
 | LocalDateTime[]
-|
+| HLocalDateTime[]
 | boost::optional<std::vector<boost::optional<hazelcast::client::local_date_time>>>
 | (LocalDateTime \| null)[] \| null
 | Optional[list[Optional[datetime.datetime]]]
@@ -956,7 +956,7 @@ and nanoseconds or null.
 
 | TIMESTAMP_WITH_TIMEZONE
 | OffsetDateTime
-|
+| HOffsetDateTime
 | 
 | OffsetDateTime \| null
 | Optional[datetime.datetime]
@@ -966,7 +966,7 @@ nanoseconds, and offset seconds or null.
 
 | ARRAY_OF_TIMESTAMP_WITH_TIMEZONE
 | OffsetDateTime[]
-|
+| HOffsetDateTime[]
 |
 | (OffsetDateTime \| null)[] \| null
 | Optional[list[Optional[datetime.datetime]]]

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -1100,7 +1100,11 @@ C++::
 --
 [source,cpp]
 ----
-
+struct employee
+{
+    int64_t id;
+    std::string name;
+};
 ----
 --
 
@@ -1167,7 +1171,12 @@ C++::
 --
 [source,cpp]
 ----
-
+struct employee
+{
+    int64_t id;
+    std::string name;
+    int32_t age;
+};
 ----
 --
 
@@ -1243,7 +1252,21 @@ C++::
 --
 [source,cpp]
 ----
-
+template<>
+struct hz_serializer<employee> : compact_serializer
+{
+    employee& read(compact_reader& reader)
+    {
+        employee e;
+        
+        e.id = reader.read_int32("id");
+        e.name = reader.read_string("name");
+        
+        return e;
+    }
+    
+    // ...
+};
 ----
 --
 
@@ -1330,7 +1353,26 @@ C++::
 --
 [source,cpp]
 ----
-
+template<>
+struct hz_serializer<employee> : compact_serializer
+{
+    employee& read(compact_reader& reader)
+    {
+        employee e;
+        
+        e.id = reader.read_int64("id");
+        e.name = reader.read_string("name");
+        
+        if (reader.get_field_kind("age") == field_kind::INT32)
+        {
+            age = reader.read_int32("age");
+        } else {
+            age = 0;
+        }
+        
+        return e;
+    }
+};
 ----
 --
 

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -139,7 +139,8 @@ Go::
 --
 [source,go]
 ----
-
+var cfg hazelcast.Config
+cfg.Serialization.Compact.SetSerializers(&FooSerializer{})
 ----
 --
 
@@ -433,7 +434,10 @@ Go::
 --
 [source,go]
 ----
-
+type Employee struct {
+    ID int64
+    Name *string
+}
 ----
 --
 
@@ -586,7 +590,26 @@ Go::
 --
 [source,go]
 ----
+func (em EmployeeSerializer) Read(reader serialization.CompactReader) any {
+    id := reader.ReadInt64("id")
+    name := reader.ReadString("name")
+    return &Employee{ID: id, Name: name}
+}
 
+func (em EmployeeSerializer) Write(writer serialization.CompactWriter, value any) {
+    employee := value.(*Employee)
+    writer.WriteInt64(employee.ID)
+    writer.WriteString(employee.Name)
+}
+
+func (em EmployeeSerializer) TypeName() string {
+    return "employee"
+}
+
+func (em EmployeeSerializer) Type() reflect.Type {
+    var e *Employee
+    return reflect.TypeOf(e)
+}
 ----
 --
 
@@ -616,7 +639,7 @@ can be implemented on top of these, by using these types as building blocks.
 | bool
 | boolean
 | bool
-|
+| bool
 | True or false represented by a single bit as either 1 or 0.
 Up to eight booleans are packed into a single byte.
 
@@ -626,7 +649,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<bool>>
 | boolean[] \| null
 | Optional[list[bool]]
-|
+| []bool
 | Array of booleans or null. Up to eight boolean array items are packed into a single byte.
 
 | NULLABLE_BOOLEAN
@@ -635,7 +658,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<bool>
 | boolean \| null
 | Optional[bool]
-|
+| *bool
 | A boolean that can also be null.
 
 | ARRAY_OF_NULLABLE_BOOLEAN
@@ -644,7 +667,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<boost::optional<bool>>>
 | (boolean \| null)[] \| null
 | Optional[list[Optional[bool]]]
-|
+| []*bool
 | Array of nullable booleans or null.
 
 | INT8
@@ -653,7 +676,7 @@ Up to eight booleans are packed into a single byte.
 | int8_t
 | number
 | int
-|
+| int8
 | 8-bit two's complement signed integer.
 
 | ARRAY_OF_INT8
@@ -662,7 +685,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<int8_t>>
 | Buffer \| null
 | Optional[list[int]]
-|
+| []int8
 | Array of int8s or null.
 
 | NULLABLE_INT8
@@ -671,7 +694,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<int8_t>
 | number \| null
 | Optional[int]
-|
+| *int8
 | An int8 that can also be null.
 
 | ARRAY_OF_NULLABLE_INT8
@@ -680,7 +703,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<boost::optional<int8_t>>>
 | (number \| null)[] \| null
 | Optional[list[Optional[int]]]
-|
+| []*int8
 | Array of nullable int8s or null.
 
 | INT16
@@ -689,7 +712,7 @@ Up to eight booleans are packed into a single byte.
 | int16_t
 | number
 | int
-|
+| int16
 | 16-bit two's complement signed integer.
 
 | ARRAY_OF_INT16
@@ -698,7 +721,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<int16_t>>
 | number[] \| null
 | Optional[list[int]]
-|
+| []int16
 | Array of int16s or null.
 
 | NULLABLE_INT16
@@ -707,7 +730,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<int16_t>
 | number \| null
 | Optional[int]
-|
+| *int16
 | An int16 that can also be null.
 
 | ARRAY_OF_NULLABLE_INT16
@@ -716,7 +739,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<boost::optional<int16_t>>>
 | (number \| null)[] \| null
 | Optional[list[Optional[int]]]
-|
+| []*int16
 | Array of nullable int16s or null.
 
 | INT32
@@ -725,7 +748,7 @@ Up to eight booleans are packed into a single byte.
 | int32_t
 | number
 | int
-|
+| int32
 | 32-bit two's complement signed integer.
 
 | ARRAY_OF_INT32
@@ -734,7 +757,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<int32_t>>
 | number[] \| null
 | Optional[list[int]]
-|
+| []int32
 | Array of int32s or null.
 
 | NULLABLE_INT32
@@ -743,7 +766,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<int32_t>
 | number \| null
 | Optional[int]
-|
+| *int32
 | An int32 that can also be null.
 
 | ARRAY_OF_NULLABLE_INT32
@@ -752,7 +775,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<boost::optional<int32_t>>>
 | (number \| null)[] \| null
 | Optional[list[Optional[int]]]
-|
+| []*int32
 | Array of nullable int32s or null.
 
 | INT64
@@ -761,7 +784,7 @@ Up to eight booleans are packed into a single byte.
 | int64_t
 | Long
 | int
-|
+| int64
 | 64-bit two's complement signed integer.
 
 | ARRAY_OF_INT64
@@ -770,7 +793,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<int64_t>>
 | Long[] \| null
 | Optional[list[int]]
-|
+| []int64
 | Array of int64s or null.
 
 | NULLABLE_INT64
@@ -779,7 +802,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<int64_t>
 | Long \| null
 | Optional[int]
-|
+| *int64
 | An int64 that can also be null.
 
 | ARRAY_OF_NULLABLE_INT64
@@ -788,7 +811,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<boost::optional<int64_t>>>
 | (Long \| null)[] \| null
 | Optional[list[Optional[int]]]
-|
+| []*int64
 | Array of nullable int64s or null.
 
 | FLOAT32
@@ -797,7 +820,7 @@ Up to eight booleans are packed into a single byte.
 | float
 | number
 | float
-|
+| float32
 | 32-bit IEEE 754 floating point number.
 
 | ARRAY_OF_FLOAT32
@@ -806,7 +829,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<float>>
 | number[] \| null
 | Optional[list[float]]
-|
+| []float32
 | Array of float32s or null.
 
 | NULLABLE_FLOAT32
@@ -815,7 +838,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<float>
 | number \| null
 | Optional[float]
-|
+| *float32
 | A float32 that can also be null.
 
 | ARRAY_OF_NULLABLE_FLOAT32
@@ -824,7 +847,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<boost::optional<float>>>
 | (number \| null)[] \| null
 | Optional[list[Optional[float]]]
-|
+| []*float32
 | Array of nullable float32s or null.
 
 | FLOAT64
@@ -833,7 +856,7 @@ Up to eight booleans are packed into a single byte.
 | double
 | number
 | float
-|
+| float64
 | 64-bit IEEE 754 floating point number.
 
 | ARRAY_OF_FLOAT64
@@ -842,7 +865,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<double>>
 | number[] \| null
 | Optional[list[float]]
-|
+| []float64
 | Array of float64s or null.
 
 | NULLABLE_FLOAT64
@@ -851,7 +874,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<double>
 | number \| null
 | Optional[float]
-|
+| *float64
 | A float64 that can also be null.
 
 | ARRAY_OF_NULLABLE_FLOAT64
@@ -860,7 +883,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<boost::optional<double>>>
 | (number \| null)[] \| null
 | Optional[list[Optional[float]]]
-|
+| []*float64
 | Array of nullable float64s or null.
 
 | STRING
@@ -869,7 +892,7 @@ Up to eight booleans are packed into a single byte.
 | std::string
 | string \| null
 | Optional[str]
-|
+| *string
 | A UTF-8 encoded string or null.
 
 | ARRAY_OF_STRING
@@ -878,7 +901,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<std::string>>
 | (string \| null)[] \| null
 | Optional[list[Optional[str]]]
-|
+| []*string
 | Array of strings or null.
 
 | DECIMAL
@@ -887,7 +910,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<hazelcast::client::big_decimal>
 | BigDecimal \| null
 | Optional[decimal.Decimal]
-|
+| *types.Decimal
 | Arbitrary precision and scale floating point number or null.
 
 | ARRAY_OF_DECIMAL
@@ -896,7 +919,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<boost::optional<hazelcast::client::big_decimal>>>
 | (BigDecimal \| null)[] \| null
 | Optional[list[decimal.Decimal]]
-|
+| []*types.Decimal
 | Array of decimals or null.
 
 | TIME
@@ -905,7 +928,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<hazelcast::client::local_time>
 | LocalTime \| null
 | Optional[datetime.time]
-|
+| *types.LocalTime
 | Time consisting of hours, minutes, seconds, and nanoseconds or null.
 
 | ARRAY_OF_TIME
@@ -914,7 +937,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<boost::optional<local_time>>>
 | (LocalTime \| null)[] \| null
 | Optional[list[Optional[datetime.time]]]
-|
+| []*types.LocalTime
 | Array of times or null.
 
 | DATE
@@ -923,7 +946,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<hazelcast::client::local_date>
 | LocalDate \| null
 | Optional[datetime.date]
-|
+| *types.LocalDate
 | Date consisting of year, month, and day of the month or null.
 
 | ARRAY_OF_DATE
@@ -932,7 +955,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<std::vector<boost::optional<local_date>>>
 | (LocalDate \| null)[] \| null
 | Optional[list[Optional[datetime.date]]]
-|
+| []*types.LocalDate
 | Array of dates or null.
 
 | TIMESTAMP
@@ -941,7 +964,7 @@ Up to eight booleans are packed into a single byte.
 | boost::optional<hazelcast::client::local_date_time>
 | LocalDateTime \| null
 | Optional[datetime.datetime]
-|
+| *types.LocalDateTime
 | Timestamp consisting of year, month, day of the month, hour, minutes, seconds,
 and nanoseconds or null.
 
@@ -951,16 +974,16 @@ and nanoseconds or null.
 | boost::optional<std::vector<boost::optional<hazelcast::client::local_date_time>>>
 | (LocalDateTime \| null)[] \| null
 | Optional[list[Optional[datetime.datetime]]]
-|
+| []*types.LocalDateTime
 | Array of timestamps or null.
 
 | TIMESTAMP_WITH_TIMEZONE
 | OffsetDateTime
 | HOffsetDateTime
-| 
+|
 | OffsetDateTime \| null
 | Optional[datetime.datetime]
-|
+| *types.OffsetDateTime
 | Timestamp with timezone consisting of year, month, day of the month, hour, minutes, seconds,
 nanoseconds, and offset seconds or null.
 
@@ -970,7 +993,7 @@ nanoseconds, and offset seconds or null.
 |
 | (OffsetDateTime \| null)[] \| null
 | Optional[list[Optional[datetime.datetime]]]
-|
+| []*types.OffsetDateTime
 | Array of timestamp with timezones or null.
 
 | COMPACT
@@ -979,7 +1002,7 @@ nanoseconds, and offset seconds or null.
 | Can be any user type.
 | Can be any user type.
 | Can be any user type.
-| Can be any user type.
+| any
 | A user defined nested Compact serializable object or null.
 
 | ARRAY_OF_COMPACT
@@ -988,7 +1011,7 @@ nanoseconds, and offset seconds or null.
 | Can be an array of any user type.
 | Can be an array of any user type.
 | Can be an array of any user type.
-| Can be an array of any user type.
+| []any
 | Array of user defined Compact serializable objects or null.
 
 |===
@@ -1195,7 +1218,10 @@ Go::
 --
 [source,go]
 ----
-
+type Employee struct {
+    ID int64
+    Name *string
+}
 ----
 --
 
@@ -1276,6 +1302,11 @@ Go::
 --
 [source,go]
 ----
+type Employee struct {
+    ID int64
+    Name *string
+    Age int32 // Newly added field
+}
 
 ----
 --
@@ -1389,7 +1420,13 @@ Go::
 --
 [source,go]
 ----
-
+func (em EmployeeSerializer) Read(reader serialization.CompactReader) any {
+    id := reader.ReadInt64("id")
+    name := reader.ReadString("name")
+    // The new "age" field is there, but the old reader does not
+    // know anything about it. Hence, it will simply ignore that field.
+    return &Employee{ID: id, Name: name}
+}
 ----
 --
 
@@ -1531,6 +1568,18 @@ Go::
 --
 [source,go]
 ----
+func (em EmployeeSerializer) Read(reader serialization.CompactReader) any {
+    id := reader.ReadInt64("id")
+    name := reader.ReadString("name")
+    // Read the "age" if it exists, or use the default value 0.
+    // reader.ReadInt32("age") would panic if the "age" field
+    // does not exist in data.
+    var age int32
+    if reader.getFieldKind("age") == serialization.FieldKindInt32 {
+        age = reader.ReadInt32("age")
+    }
+    return &Employee{ID: id, Name: name, Age: age}
+}
 
 ----
 --

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -590,7 +590,7 @@ can be implemented on top of these, by using these types as building blocks.
 | boolean
 |
 | bool
-|
+| boolean
 | bool
 |
 | True or false represented by a single bit as either 1 or 0.
@@ -600,25 +600,25 @@ Up to eight booleans are packed into a single byte.
 | boolean[]
 |
 | boost::optional<std::vector<bool>>
-|
+| boolean[]
 | Optional[list[bool]]
 |
 | Array of booleans or null. Up to eight boolean array items are packed into a single byte.
 
 | NULLABLE_BOOLEAN
 | Boolean
-|
+| 
 | boost::optional<bool>
-|
+| boolean
 | Optional[bool]
 |
 | A boolean that can also be null.
 
 | ARRAY_OF_NULLABLE_BOOLEAN
 | Boolean[]
-|
+| 
 | boost::optional<std::vector<boost::optional<bool>>>
-|
+| boolean[]
 | Optional[list[Optional[bool]]]
 |
 | Array of nullable booleans or null.
@@ -627,16 +627,16 @@ Up to eight booleans are packed into a single byte.
 | byte
 |
 | int8_t
-|
+| number
 | int
 |
 | 8-bit two's complement signed integer.
 
 | ARRAY_OF_INT8
 | byte[]
-|
+| 
 | boost::optional<std::vector<int8_t>>
-|
+| number[]
 | Optional[list[int]]
 |
 | Array of int8s or null.
@@ -645,7 +645,7 @@ Up to eight booleans are packed into a single byte.
 | Byte
 |
 | boost::optional<int8_t>
-|
+| number
 | Optional[int]
 |
 | An int8 that can also be null.
@@ -654,7 +654,7 @@ Up to eight booleans are packed into a single byte.
 | Byte[]
 |
 | boost::optional<std::vector<boost::optional<int8_t>>>
-|
+| number[]
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int8s or null.
@@ -663,7 +663,7 @@ Up to eight booleans are packed into a single byte.
 | short
 |
 | int16_t
-|
+| number
 | int
 |
 | 16-bit two's complement signed integer.
@@ -672,7 +672,7 @@ Up to eight booleans are packed into a single byte.
 | short[]
 |
 | boost::optional<std::vector<int16_t>>
-|
+| number[]
 | Optional[list[int]]
 |
 | Array of int16s or null.
@@ -681,7 +681,7 @@ Up to eight booleans are packed into a single byte.
 | Short
 |
 | boost::optional<int16_t>
-|
+| number
 | Optional[int]
 |
 | An int16 that can also be null.
@@ -690,7 +690,7 @@ Up to eight booleans are packed into a single byte.
 | Short[]
 |
 | boost::optional<std::vector<boost::optional<int16_t>>>
-|
+| number[]
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int16s or null.
@@ -699,7 +699,7 @@ Up to eight booleans are packed into a single byte.
 | int
 |
 | int32_t
-|
+| number
 | int
 |
 | 32-bit two's complement signed integer.
@@ -708,7 +708,7 @@ Up to eight booleans are packed into a single byte.
 | int[]
 |
 | boost::optional<std::vector<int32_t>>
-|
+| number[]
 | Optional[list[int]]
 |
 | Array of int32s or null.
@@ -717,7 +717,7 @@ Up to eight booleans are packed into a single byte.
 | Integer
 |
 | boost::optional<int32_t>
-|
+| number
 | Optional[int]
 |
 | An int32 that can also be null.
@@ -726,7 +726,7 @@ Up to eight booleans are packed into a single byte.
 | Integer[]
 |
 | boost::optional<std::vector<boost::optional<int32_t>>>
-|
+| number[]
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int32s or null.
@@ -735,7 +735,7 @@ Up to eight booleans are packed into a single byte.
 | long
 |
 | int64_t
-|
+| number
 | int
 |
 | 64-bit two's complement signed integer.
@@ -744,7 +744,7 @@ Up to eight booleans are packed into a single byte.
 | long[]
 |
 | boost::optional<std::vector<int64_t>>
-|
+| number[]
 | Optional[list[int]]
 |
 | Array of int64s or null.
@@ -753,7 +753,7 @@ Up to eight booleans are packed into a single byte.
 | Long
 |
 | boost::optional<int64_t>
-|
+| number
 | Optional[int]
 |
 | An int64 that can also be null.
@@ -762,7 +762,7 @@ Up to eight booleans are packed into a single byte.
 | Long[]
 |
 | boost::optional<std::vector<boost::optional<int64_t>>>
-|
+| number[]
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int64s or null.
@@ -771,7 +771,7 @@ Up to eight booleans are packed into a single byte.
 | float
 |
 | float
-|
+| number
 | float
 |
 | 32-bit IEEE 754 floating point number.
@@ -780,7 +780,7 @@ Up to eight booleans are packed into a single byte.
 | float[]
 |
 | boost::optional<std::vector<float>>
-|
+| number[]
 | Optional[list[float]]
 |
 | Array of float32s or null.
@@ -789,7 +789,7 @@ Up to eight booleans are packed into a single byte.
 | Float
 |
 | boost::optional<float>
-|
+| number
 | Optional[float]
 |
 | A float32 that can also be null.
@@ -798,7 +798,7 @@ Up to eight booleans are packed into a single byte.
 | Float[]
 |
 | boost::optional<std::vector<boost::optional<float>>>
-|
+| number[]
 | Optional[list[Optional[float]]]
 |
 | Array of nullable float32s or null.
@@ -807,7 +807,7 @@ Up to eight booleans are packed into a single byte.
 | double
 |
 | double
-|
+| number
 | float
 |
 | 64-bit IEEE 754 floating point number.
@@ -816,7 +816,7 @@ Up to eight booleans are packed into a single byte.
 | double[]
 |
 | boost::optional<std::vector<double>>
-|
+| number[]
 | Optional[list[float]]
 |
 | Array of float64s or null.
@@ -825,7 +825,7 @@ Up to eight booleans are packed into a single byte.
 | Double
 |
 | boost::optional<double>
-|
+| number
 | Optional[float]
 |
 | A float64 that can also be null.
@@ -834,7 +834,7 @@ Up to eight booleans are packed into a single byte.
 | Double[]
 |
 | boost::optional<std::vector<boost::optional<double>>>
-|
+| number[]
 | Optional[list[Optional[float]]]
 |
 | Array of nullable float64s or null.
@@ -843,7 +843,7 @@ Up to eight booleans are packed into a single byte.
 | String
 |
 | std::string
-|
+| string
 | Optional[str]
 |
 | A UTF-8 encoded string or null.
@@ -852,7 +852,7 @@ Up to eight booleans are packed into a single byte.
 | String[]
 |
 | boost::optional<std::vector<std::string>>
-|
+| string[]
 | Optional[list[Optional[str]]]
 |
 | Array of strings or null.
@@ -861,7 +861,7 @@ Up to eight booleans are packed into a single byte.
 | BigDecimal
 |
 | boost::optional<hazelcast::client::big_decimal>
-|
+| BigDecimal
 | Optional[decimal.Decimal]
 |
 | Arbitrary precision and scale floating point number or null.
@@ -870,7 +870,7 @@ Up to eight booleans are packed into a single byte.
 | BigDecimal[]
 |
 | boost::optional<std::vector<boost::optional<hazelcast::client::big_decimal>>>
-|
+| BigDecimal[]
 | Optional[list[decimal.Decimal]]
 |
 | Array of decimals or null.
@@ -879,7 +879,7 @@ Up to eight booleans are packed into a single byte.
 | LocalTime
 |
 | boost::optional<hazelcast::client::local_time>
-|
+| LocalTime
 | Optional[datetime.time]
 |
 | Time consisting of hours, minutes, seconds, and nanoseconds or null.
@@ -888,7 +888,7 @@ Up to eight booleans are packed into a single byte.
 | LocalTime[]
 |
 | boost::optional<std::vector<boost::optional<local_time>>>
-|
+| LocalTime[]
 | Optional[list[Optional[datetime.time]]]
 |
 | Array of times or null.
@@ -897,16 +897,16 @@ Up to eight booleans are packed into a single byte.
 | LocalDate
 |
 | boost::optional<hazelcast::client::local_date>
-|
+| LocalDate
 | Optional[datetime.date]
 |
 | Date consisting of year, month, and day of the month or null.
 
 | ARRAY_OF_DATE
 | LocalDate[]
-|
+|  
 | boost::optional<std::vector<boost::optional<local_date>>>
-|
+| LocalDate[]
 | Optional[list[Optional[datetime.date]]]
 |
 | Array of dates or null.
@@ -915,7 +915,7 @@ Up to eight booleans are packed into a single byte.
 | LocalDateTime
 |
 | boost::optional<hazelcast::client::local_date_time>
-|
+| LocalDateTime
 | Optional[datetime.datetime]
 |
 | Timestamp consisting of year, month, day of the month, hour, minutes, seconds,
@@ -925,7 +925,7 @@ and nanoseconds or null.
 | LocalDateTime[]
 |
 | boost::optional<std::vector<boost::optional<hazelcast::client::local_date_time>>>
-|
+| LocalDateTime[]
 | Optional[list[Optional[datetime.datetime]]]
 |
 | Array of timestamps or null.
@@ -934,7 +934,7 @@ and nanoseconds or null.
 | OffsetDateTime
 |
 | 
-|
+| OffsetDateTime
 | Optional[datetime.datetime]
 |
 | Timestamp with timezone consisting of year, month, day of the month, hour, minutes, seconds,
@@ -944,7 +944,7 @@ nanoseconds, and offset seconds or null.
 | OffsetDateTime[]
 |
 |
-|
+| OffsetDateTime[]
 | Optional[list[Optional[datetime.datetime]]]
 |
 | Array of timestamp with timezones or null.
@@ -1220,7 +1220,7 @@ Node.js::
 class Employee {
     id;
     name;
-    age;
+    age; // Newly added field
 };
 ----
 --
@@ -1315,6 +1315,8 @@ class EmployeeSerializer extends CompactSerializer {
     read(reader){
         const id = reader.readInt64('id');
         const name = reader.readString('name');
+        // The new "age" field is there, but the old reader does not
+        // know anything about it. Hence, it will simply ignore that field.
         return new Employee(id, name);
     }
 }
@@ -1427,6 +1429,9 @@ class EmployeeSerializer extends CompactSerializer {
     read(reader){
         const id = reader.readInt64('id');
         const name = reader.readString('name');
+        // Read the "age" if it exists, or use the default value 0.
+        // reader.readInt32("age") would throw if the "age" field
+        // does not exist in data.
         let age;
         if (reader.getFieldKind("age") == FieldKind.INT32) {
             age = reader.readInt32("age");

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -103,15 +103,6 @@ clientConfig.getSerializationConfig()
 ----
 --
 
-C++::
-+
---
-[source,cpp]
-----
-
-----
---
-
 Node.js::
 +
 --
@@ -390,7 +381,11 @@ C++::
 --
 [source,cpp]
 ----
-
+struct employee
+{
+    int64_t id;
+    std::string name;
+};
 ----
 --
 
@@ -477,7 +472,27 @@ C++::
 --
 [source,cpp]
 ----
+template<>
+struct hz_serializer<employee> : public compact_serializer
+{
+    static employee read(compact_reader& reader)
+    {
+        employee e;
+        
+        e.id = reader.read_int64("id");
+        e.name = reader.read_string("name");
+        
+        return e;
+    }
 
+    static void write(const employee& e, compact_writer& writer)
+    {
+        writer.write_int64("id", e.id);
+        writer.write_string("name", e.name);
+    } 
+
+    static std::string type_name() { return "employee"; }    
+};
 ----
 --
 
@@ -545,7 +560,7 @@ can be implemented on top of these, by using these types as building blocks.
 | BOOLEAN
 | boolean
 |
-|
+| bool
 |
 | bool
 |
@@ -555,7 +570,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_BOOLEAN
 | boolean[]
 |
-|
+| boost::optional<std::vector<bool>>
 |
 | Optional[list[bool]]
 |
@@ -564,7 +579,7 @@ Up to eight booleans are packed into a single byte.
 | NULLABLE_BOOLEAN
 | Boolean
 |
-|
+| boost::optional<bool>
 |
 | Optional[bool]
 |
@@ -573,7 +588,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_NULLABLE_BOOLEAN
 | Boolean[]
 |
-|
+| boost::optional<std::vector<boost::optional<bool>>>
 |
 | Optional[list[Optional[bool]]]
 |
@@ -582,7 +597,7 @@ Up to eight booleans are packed into a single byte.
 | INT8
 | byte
 |
-|
+| int8_t
 |
 | int
 |
@@ -591,7 +606,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_INT8
 | byte[]
 |
-|
+| boost::optional<std::vector<int8_t>>
 |
 | Optional[list[int]]
 |
@@ -600,7 +615,7 @@ Up to eight booleans are packed into a single byte.
 | NULLABLE_INT8
 | Byte
 |
-|
+| boost::optional<int8_t>
 |
 | Optional[int]
 |
@@ -609,7 +624,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_NULLABLE_INT8
 | Byte[]
 |
-|
+| boost::optional<std::vector<boost::optional<int8_t>>>
 |
 | Optional[list[Optional[int]]]
 |
@@ -618,7 +633,7 @@ Up to eight booleans are packed into a single byte.
 | INT16
 | short
 |
-|
+| int16_t
 |
 | int
 |
@@ -627,7 +642,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_INT16
 | short[]
 |
-|
+| boost::optional<std::vector<int16_t>>
 |
 | Optional[list[int]]
 |
@@ -636,7 +651,7 @@ Up to eight booleans are packed into a single byte.
 | NULLABLE_INT16
 | Short
 |
-|
+| boost::optional<int16_t>
 |
 | Optional[int]
 |
@@ -645,7 +660,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_NULLABLE_INT16
 | Short[]
 |
-|
+| boost::optional<std::vector<boost::optional<int16_t>>>
 |
 | Optional[list[Optional[int]]]
 |
@@ -654,7 +669,7 @@ Up to eight booleans are packed into a single byte.
 | INT32
 | int
 |
-|
+| int32_t
 |
 | int
 |
@@ -663,7 +678,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_INT32
 | int[]
 |
-|
+| boost::optional<std::vector<int32_t>>
 |
 | Optional[list[int]]
 |
@@ -672,7 +687,7 @@ Up to eight booleans are packed into a single byte.
 | NULLABLE_INT32
 | Integer
 |
-|
+| boost::optional<int32_t>
 |
 | Optional[int]
 |
@@ -681,7 +696,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_NULLABLE_INT32
 | Integer[]
 |
-|
+| boost::optional<std::vector<boost::optional<int32_t>>>
 |
 | Optional[list[Optional[int]]]
 |
@@ -690,7 +705,7 @@ Up to eight booleans are packed into a single byte.
 | INT64
 | long
 |
-|
+| int64_t
 |
 | int
 |
@@ -699,7 +714,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_INT64
 | long[]
 |
-|
+| boost::optional<std::vector<int64_t>>
 |
 | Optional[list[int]]
 |
@@ -708,7 +723,7 @@ Up to eight booleans are packed into a single byte.
 | NULLABLE_INT64
 | Long
 |
-|
+| boost::optional<int64_t>
 |
 | Optional[int]
 |
@@ -717,7 +732,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_NULLABLE_INT64
 | Long[]
 |
-|
+| boost::optional<std::vector<boost::optional<int64_t>>>
 |
 | Optional[list[Optional[int]]]
 |
@@ -726,7 +741,7 @@ Up to eight booleans are packed into a single byte.
 | FLOAT32
 | float
 |
-|
+| float
 |
 | float
 |
@@ -735,7 +750,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_FLOAT32
 | float[]
 |
-|
+| boost::optional<std::vector<float>>
 |
 | Optional[list[float]]
 |
@@ -744,7 +759,7 @@ Up to eight booleans are packed into a single byte.
 | NULLABLE_FLOAT32
 | Float
 |
-|
+| boost::optional<float>
 |
 | Optional[float]
 |
@@ -753,7 +768,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_NULLABLE_FLOAT32
 | Float[]
 |
-|
+| boost::optional<std::vector<boost::optional<float>>>
 |
 | Optional[list[Optional[float]]]
 |
@@ -762,7 +777,7 @@ Up to eight booleans are packed into a single byte.
 | FLOAT64
 | double
 |
-|
+| double
 |
 | float
 |
@@ -771,7 +786,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_FLOAT64
 | double[]
 |
-|
+| boost::optional<std::vector<double>>
 |
 | Optional[list[float]]
 |
@@ -780,7 +795,7 @@ Up to eight booleans are packed into a single byte.
 | NULLABLE_FLOAT64
 | Double
 |
-|
+| boost::optional<double>
 |
 | Optional[float]
 |
@@ -789,7 +804,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_NULLABLE_FLOAT64
 | Double[]
 |
-|
+| boost::optional<std::vector<boost::optional<double>>>
 |
 | Optional[list[Optional[float]]]
 |
@@ -798,7 +813,7 @@ Up to eight booleans are packed into a single byte.
 | STRING
 | String
 |
-|
+| std::string
 |
 | Optional[str]
 |
@@ -807,7 +822,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_STRING
 | String[]
 |
-|
+| boost::optional<std::vector<std::string>>
 |
 | Optional[list[Optional[str]]]
 |
@@ -816,7 +831,7 @@ Up to eight booleans are packed into a single byte.
 | DECIMAL
 | BigDecimal
 |
-|
+| boost::optional<hazelcast::client::big_decimal>
 |
 | Optional[decimal.Decimal]
 |
@@ -825,7 +840,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_DECIMAL
 | BigDecimal[]
 |
-|
+| boost::optional<std::vector<boost::optional<hazelcast::client::big_decimal>>>
 |
 | Optional[list[decimal.Decimal]]
 |
@@ -834,7 +849,7 @@ Up to eight booleans are packed into a single byte.
 | TIME
 | LocalTime
 |
-|
+| boost::optional<hazelcast::client::local_time>
 |
 | Optional[datetime.time]
 |
@@ -843,7 +858,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_TIME
 | LocalTime[]
 |
-|
+| boost::optional<std::vector<boost::optional<local_time>>>
 |
 | Optional[list[Optional[datetime.time]]]
 |
@@ -852,7 +867,7 @@ Up to eight booleans are packed into a single byte.
 | DATE
 | LocalDate
 |
-|
+| boost::optional<hazelcast::client::local_date>
 |
 | Optional[datetime.date]
 |
@@ -861,7 +876,7 @@ Up to eight booleans are packed into a single byte.
 | ARRAY_OF_DATE
 | LocalDate[]
 |
-|
+| boost::optional<std::vector<boost::optional<local_date>>>
 |
 | Optional[list[Optional[datetime.date]]]
 |
@@ -870,7 +885,7 @@ Up to eight booleans are packed into a single byte.
 | TIMESTAMP
 | LocalDateTime
 |
-|
+| boost::optional<hazelcast::client::local_date_time>
 |
 | Optional[datetime.datetime]
 |
@@ -880,7 +895,7 @@ and nanoseconds or null.
 | ARRAY_OF_TIMESTAMP
 | LocalDateTime[]
 |
-|
+| boost::optional<std::vector<boost::optional<hazelcast::client::local_date_time>>>
 |
 | Optional[list[Optional[datetime.datetime]]]
 |
@@ -889,7 +904,7 @@ and nanoseconds or null.
 | TIMESTAMP_WITH_TIMEZONE
 | OffsetDateTime
 |
-|
+| 
 |
 | Optional[datetime.datetime]
 |

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -624,7 +624,7 @@ Up to eight booleans are packed into a single byte.
 | boolean[]
 |
 | boost::optional<std::vector<bool>>
-| boolean[] | null
+| boolean[] \| null
 | Optional[list[bool]]
 |
 | Array of booleans or null. Up to eight boolean array items are packed into a single byte.
@@ -633,7 +633,7 @@ Up to eight booleans are packed into a single byte.
 | Boolean
 | 
 | boost::optional<bool>
-| boolean | null
+| boolean \| null
 | Optional[bool]
 |
 | A boolean that can also be null.
@@ -642,7 +642,7 @@ Up to eight booleans are packed into a single byte.
 | Boolean[]
 | 
 | boost::optional<std::vector<boost::optional<bool>>>
-| (boolean | null)[] | null
+| (boolean \| null)[] \| null
 | Optional[list[Optional[bool]]]
 |
 | Array of nullable booleans or null.
@@ -660,7 +660,7 @@ Up to eight booleans are packed into a single byte.
 | byte[]
 | 
 | boost::optional<std::vector<int8_t>>
-| Buffer
+| Buffer \| null
 | Optional[list[int]]
 |
 | Array of int8s or null.
@@ -669,7 +669,7 @@ Up to eight booleans are packed into a single byte.
 | Byte
 |
 | boost::optional<int8_t>
-| number | null
+| number \| null
 | Optional[int]
 |
 | An int8 that can also be null.
@@ -678,7 +678,7 @@ Up to eight booleans are packed into a single byte.
 | Byte[]
 |
 | boost::optional<std::vector<boost::optional<int8_t>>>
-| (number | null)[] | null
+| (number \| null)[] \| null
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int8s or null.
@@ -696,7 +696,7 @@ Up to eight booleans are packed into a single byte.
 | short[]
 |
 | boost::optional<std::vector<int16_t>>
-| number[] | null
+| number[] \| null
 | Optional[list[int]]
 |
 | Array of int16s or null.
@@ -705,7 +705,7 @@ Up to eight booleans are packed into a single byte.
 | Short
 |
 | boost::optional<int16_t>
-| number | null
+| number \| null
 | Optional[int]
 |
 | An int16 that can also be null.
@@ -714,7 +714,7 @@ Up to eight booleans are packed into a single byte.
 | Short[]
 |
 | boost::optional<std::vector<boost::optional<int16_t>>>
-| (number | null)[] | null
+| (number \| null)[] \| null
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int16s or null.
@@ -732,7 +732,7 @@ Up to eight booleans are packed into a single byte.
 | int[]
 |
 | boost::optional<std::vector<int32_t>>
-| number[] | null
+| number[] \| null
 | Optional[list[int]]
 |
 | Array of int32s or null.
@@ -741,7 +741,7 @@ Up to eight booleans are packed into a single byte.
 | Integer
 |
 | boost::optional<int32_t>
-| number | null
+| number \| null
 | Optional[int]
 |
 | An int32 that can also be null.
@@ -750,7 +750,7 @@ Up to eight booleans are packed into a single byte.
 | Integer[]
 |
 | boost::optional<std::vector<boost::optional<int32_t>>>
-| (number | null)[] | null
+| (number \| null)[] \| null
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int32s or null.
@@ -768,7 +768,7 @@ Up to eight booleans are packed into a single byte.
 | long[]
 |
 | boost::optional<std::vector<int64_t>>
-| Long[] | null
+| Long[] \| null
 | Optional[list[int]]
 |
 | Array of int64s or null.
@@ -777,7 +777,7 @@ Up to eight booleans are packed into a single byte.
 | Long
 |
 | boost::optional<int64_t>
-| Long | null
+| Long \| null
 | Optional[int]
 |
 | An int64 that can also be null.
@@ -786,7 +786,7 @@ Up to eight booleans are packed into a single byte.
 | Long[]
 |
 | boost::optional<std::vector<boost::optional<int64_t>>>
-| (Long | null)[] | null
+| (Long \| null)[] \| null
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int64s or null.
@@ -804,7 +804,7 @@ Up to eight booleans are packed into a single byte.
 | float[]
 |
 | boost::optional<std::vector<float>>
-| number[] | null
+| number[] \| null
 | Optional[list[float]]
 |
 | Array of float32s or null.
@@ -813,7 +813,7 @@ Up to eight booleans are packed into a single byte.
 | Float
 |
 | boost::optional<float>
-| number | null
+| number \| null
 | Optional[float]
 |
 | A float32 that can also be null.
@@ -822,7 +822,7 @@ Up to eight booleans are packed into a single byte.
 | Float[]
 |
 | boost::optional<std::vector<boost::optional<float>>>
-| (number | null)[] | null
+| (number \| null)[] \| null
 | Optional[list[Optional[float]]]
 |
 | Array of nullable float32s or null.
@@ -840,7 +840,7 @@ Up to eight booleans are packed into a single byte.
 | double[]
 |
 | boost::optional<std::vector<double>>
-| number[] | null
+| number[] \| null
 | Optional[list[float]]
 |
 | Array of float64s or null.
@@ -849,7 +849,7 @@ Up to eight booleans are packed into a single byte.
 | Double
 |
 | boost::optional<double>
-| number | null
+| number \| null
 | Optional[float]
 |
 | A float64 that can also be null.
@@ -858,7 +858,7 @@ Up to eight booleans are packed into a single byte.
 | Double[]
 |
 | boost::optional<std::vector<boost::optional<double>>>
-| (number | null)[] | null
+| (number \| null)[] \| null
 | Optional[list[Optional[float]]]
 |
 | Array of nullable float64s or null.
@@ -867,7 +867,7 @@ Up to eight booleans are packed into a single byte.
 | String
 |
 | std::string
-| string | null
+| string \| null
 | Optional[str]
 |
 | A UTF-8 encoded string or null.
@@ -876,7 +876,7 @@ Up to eight booleans are packed into a single byte.
 | String[]
 |
 | boost::optional<std::vector<std::string>>
-| (string | null)[] | null
+| (string \| null)[] \| null
 | Optional[list[Optional[str]]]
 |
 | Array of strings or null.
@@ -885,7 +885,7 @@ Up to eight booleans are packed into a single byte.
 | BigDecimal
 |
 | boost::optional<hazelcast::client::big_decimal>
-| BigDecimal | null
+| BigDecimal \| null
 | Optional[decimal.Decimal]
 |
 | Arbitrary precision and scale floating point number or null.
@@ -894,7 +894,7 @@ Up to eight booleans are packed into a single byte.
 | BigDecimal[]
 |
 | boost::optional<std::vector<boost::optional<hazelcast::client::big_decimal>>>
-| (BigDecimal | null)[] | null
+| (BigDecimal \| null)[] \| null
 | Optional[list[decimal.Decimal]]
 |
 | Array of decimals or null.
@@ -903,7 +903,7 @@ Up to eight booleans are packed into a single byte.
 | LocalTime
 |
 | boost::optional<hazelcast::client::local_time>
-| LocalTime | null
+| LocalTime \| null
 | Optional[datetime.time]
 |
 | Time consisting of hours, minutes, seconds, and nanoseconds or null.
@@ -912,7 +912,7 @@ Up to eight booleans are packed into a single byte.
 | LocalTime[]
 |
 | boost::optional<std::vector<boost::optional<local_time>>>
-| (LocalTime | null)[] | null
+| (LocalTime \| null)[] \| null
 | Optional[list[Optional[datetime.time]]]
 |
 | Array of times or null.
@@ -921,7 +921,7 @@ Up to eight booleans are packed into a single byte.
 | LocalDate
 |
 | boost::optional<hazelcast::client::local_date>
-| LocalDate | null
+| LocalDate \| null
 | Optional[datetime.date]
 |
 | Date consisting of year, month, and day of the month or null.
@@ -930,7 +930,7 @@ Up to eight booleans are packed into a single byte.
 | LocalDate[]
 |  
 | boost::optional<std::vector<boost::optional<local_date>>>
-| (LocalDate | null)[] | null
+| (LocalDate \| null)[] \| null
 | Optional[list[Optional[datetime.date]]]
 |
 | Array of dates or null.
@@ -939,7 +939,7 @@ Up to eight booleans are packed into a single byte.
 | LocalDateTime
 |
 | boost::optional<hazelcast::client::local_date_time>
-| LocalDateTime | null
+| LocalDateTime \| null
 | Optional[datetime.datetime]
 |
 | Timestamp consisting of year, month, day of the month, hour, minutes, seconds,
@@ -949,7 +949,7 @@ and nanoseconds or null.
 | LocalDateTime[]
 |
 | boost::optional<std::vector<boost::optional<hazelcast::client::local_date_time>>>
-| (LocalDateTime | null)[] | null
+| (LocalDateTime \| null)[] \| null
 | Optional[list[Optional[datetime.datetime]]]
 |
 | Array of timestamps or null.
@@ -958,7 +958,7 @@ and nanoseconds or null.
 | OffsetDateTime
 |
 | 
-| OffsetDateTime | null
+| OffsetDateTime \| null
 | Optional[datetime.datetime]
 |
 | Timestamp with timezone consisting of year, month, day of the month, hour, minutes, seconds,
@@ -968,7 +968,7 @@ nanoseconds, and offset seconds or null.
 | OffsetDateTime[]
 |
 |
-| (OffsetDateTime | null)[] | null
+| (OffsetDateTime \| null)[] \| null
 | Optional[list[Optional[datetime.datetime]]]
 |
 | Array of timestamp with timezones or null.

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -980,7 +980,7 @@ and nanoseconds or null.
 | TIMESTAMP_WITH_TIMEZONE
 | OffsetDateTime
 | HOffsetDateTime
-|
+| boost::optional<hazelcast::client::offset_date_time>
 | OffsetDateTime \| null
 | Optional[datetime.datetime]
 | *types.OffsetDateTime
@@ -990,7 +990,7 @@ nanoseconds, and offset seconds or null.
 | ARRAY_OF_TIMESTAMP_WITH_TIMEZONE
 | OffsetDateTime[]
 | HOffsetDateTime[]
-|
+| boost::optional<std::vector<boost::optional<offset_date_time>>>
 | (OffsetDateTime \| null)[] \| null
 | Optional[list[Optional[datetime.datetime]]]
 | []*types.OffsetDateTime
@@ -1266,7 +1266,7 @@ struct employee
 {
     int64_t id;
     std::string name;
-    int32_t age;
+    int32_t age; // Newly added field
 };
 ----
 --
@@ -1373,7 +1373,8 @@ struct hz_serializer<employee> : compact_serializer
         
         e.id = reader.read_int32("id");
         e.name = reader.read_string("name");
-        
+        // The new "age" field is there, but the old reader does not
+        // know anything about it. Hence, it will simply ignore that field.
         return e;
     }
     
@@ -1505,11 +1506,14 @@ struct hz_serializer<employee> : compact_serializer
         e.id = reader.read_int64("id");
         e.name = reader.read_string("name");
         
+        // read the "age" field if it exists, else use the default value 0
+        // reader.read_int32("age") would throw if the "age" field
+        // does not exist in data.
         if (reader.get_field_kind("age") == field_kind::INT32)
         {
-            age = reader.read_int32("age");
+            e.age = reader.read_int32("age");
         } else {
-            age = 0;
+            e.age = 0;
         }
         
         return e;

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -108,7 +108,12 @@ Node.js::
 --
 [source,javascript]
 ----
-
+Client.newHazelcastClient(
+    compact: {
+        serializers: [
+            new FooSerializer()
+        ] 
+)
 ----
 --
 
@@ -394,7 +399,12 @@ Node.js::
 --
 [source,javascript]
 ----
-
+class Employee {
+    constructor(id, name) {
+        this.id = id;
+        this.name = name;
+    }
+};
 ----
 --
 
@@ -501,7 +511,26 @@ Node.js::
 --
 [source,javascript]
 ----
+class EmployeeSerializer extends CompactSerializer {
+    read(reader) {
+        const id = reader.readInt64('id');
+        const name = reader.readString('name');
+        return new Employee(id, name);
+    }
 
+    write(writer, employee) {
+        writer.writeInt64('id', employee.id);
+        writer.writeString('name', employee.name);
+    }
+
+    getClass() {
+        return Employee;
+    }
+
+    getTypeName() {
+        return 'employee';
+    }
+};
 ----
 --
 
@@ -1113,7 +1142,10 @@ Node.js::
 --
 [source,javascript]
 ----
-
+class Employee {
+    id;
+    name;
+};
 ----
 --
 
@@ -1185,7 +1217,11 @@ Node.js::
 --
 [source,javascript]
 ----
-
+class Employee {
+    id;
+    name;
+    age;
+};
 ----
 --
 
@@ -1275,7 +1311,13 @@ Node.js::
 --
 [source,javascript]
 ----
-
+class EmployeeSerializer extends CompactSerializer {
+    read(reader){
+        const id = reader.readInt64('id');
+        const name = reader.readString('name');
+        return new Employee(id, name);
+    }
+}
 ----
 --
 
@@ -1381,7 +1423,19 @@ Node.js::
 --
 [source,javascript]
 ----
-
+class EmployeeSerializer extends CompactSerializer {
+    read(reader){
+        const id = reader.readInt64('id');
+        const name = reader.readString('name');
+        let age;
+        if (reader.getFieldKind("age") == FieldKind.INT32) {
+            age = reader.readInt32("age");
+        } else {
+            age = 0;
+        }
+        return new Employee(id, name, age);
+    }
+}
 ----
 --
 

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -808,7 +808,7 @@ for the subsequent serializations and deserializations.
 The same holds true for the Java records. Hazelcast supports serializing and deserializing
 Java records, without an extra configuration as well.
 
-Assuming the `Employee` class above were a Java record:
+Assuming the `Employee` class was a Java record:
 
 [source,java]
 ----
@@ -864,12 +864,10 @@ per field, one for keys and one for values, represented by their respective arra
 value types. The names of those arrays are of the form `fieldName + '!keys'` and
 `fieldName + '!values'`.
 
-For Java, zero-config Compact serializer uses reflection to read and write to fields of
-objects, regardless they are public or not. That results in hard error on JDK16 and onwards,
-as illegal reflective access is denied by default in JDK16 and that option is removed altogether
-in JDK17. The solution to these problems is to open your module that the class you are
-serializing with zero-config reflective serializer to Hazelcast. Or, you can write your
-own Compact serializer, as described above.
+For Java APIs, a zero-config Compact serializer uses reflection to read and write to fields of
+objects, regardless of whether those fields are public. If you use Java 9 onwards, you must
+enable reflective access for packages of your module by using the `opens` statement in the
+module declaration:
 
 [source,text]
 ----
@@ -1232,10 +1230,7 @@ that their read and write methods are compatible, and they have the same type na
 NOTE: If you evolve your class in the later versions of your application, by adding
 or removing fields, you should continue using the same type name for that class.
 
-When a class is serialized using the zero-config Compact serializer, Hazelcast will choose the
-fully qualified class name for Java as the type name automatically.
-
-Below is the way to register an explicit serializer for a certain class.
+To register an explicit serializer for a certain class, add the following configuration:
 
 **Programmatic Configuration:**
 
@@ -1394,6 +1389,9 @@ serializer for a certain class, without implementing an explicit serializer.
 This way, one can override other serialization mechanisms for a certain class
 such as Java serializable, using zero-config serializer.
 
+When a class is serialized using the zero-config Compact serializer, Hazelcast will choose the
+fully qualified class name for Java as the type name automatically.
+
 **Programmatic Configuration:**
 
 [tabs]
@@ -1507,7 +1505,7 @@ hazelcast-client:
 
 If you want to override the serialization mechanism used for `Serializable` or
 `Externalizable` classes and use Compact serialization without writing any
-serializer in Java, you must add those classes to the configuration as described above.
+serializer in Java, you must add those classes to the configuration.
 
 == GenericRecord Representation
 
@@ -1548,14 +1546,13 @@ new as 5.2.
 
 == Serialization Priority
 
-As described in the xref:serialization:serialization.adoc#steps[Serialization priority]
-section, Compact serialization has the highest priority in the serialization mechanisms supported
-by Hazelcast.
-
-That allows one to override other serialization mechanisms with Compact serialization.
+Compact serialization has the highest xref:serialization:serialization.adoc#steps[priority] of
+all serialization mechanisms that are supported by Hazelcast. As a result, you can override other serialization
+mechanisms with Compact serialization.
 
 That is especially useful when an interface signature forces you to implement other serialization
-mechanisms in Java. For example, you can define the `Employee` class above as below
+mechanisms in Java. For example, you can define the following `Employee` class and still use
+the Compact serializer that you registered in your configuration.
 
 [source,java]
 ----
@@ -1563,6 +1560,3 @@ public class Employee implements Serializable {
     ...
 }
 ----
-
-and still be able to use the Compact serializer you wrote for it, provided that you have registered
-it as described in the previous sections.

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -99,7 +99,11 @@ clientConfig.getSerializationConfig()
 --
 [source,cs]
 ----
-
+HazelcastOptions options = ...;
+options
+    .Serialization
+    .Compact
+    .AddSerializer(new FooSerializer());
 ----
 --
 
@@ -255,7 +259,11 @@ clientConfig.getSerializationConfig()
 --
 [source,cs]
 ----
-
+HazelcastOptions options = ...;
+options
+    .Serialization
+    .Compact
+    .AddType<Bar>();
 ----
 --
 
@@ -377,7 +385,7 @@ public class Employee {
 --
 [source,cs]
 ----
-
+public record Employee(long Id, string Name);
 ----
 --
 
@@ -473,7 +481,23 @@ public class EmployeeSerializer implements CompactSerializer<Employee> {
 --
 [source,cs]
 ----
+public class EmployeeSerializer : ICompactSerializer<Employee>
+{
+    public string TypeName => "employee";
 
+    public Employee Read(ICompactReader reader)
+    {
+        var id = reader.ReadInt64("id");
+        var name = reader.ReadString("name");
+        return new Employee(id, name);
+    }
+
+    public void Write(ICompactWriter writer, Employee value)
+    {
+        writer.WriteInt64("id", value.Id);
+        writer.WriteString("name", value.Name);
+    }
+}
 ----
 --
 
@@ -1035,7 +1059,12 @@ Employee employeeFromMap = map.get(1L);
 --
 [source,cs]
 ----
-
+HazelcastOptions options = ...;
+var client = await HazelcastClientFactory.StartNewClientAsync(options);
+var map = await client.GetMap<long, Employee>("employees");
+var employee = new Employee(1, "John Doe");
+await map.SetAsync(1, employee);
+var employeeFromMap = await map.GetAsync(1);
 ----
 --
 
@@ -1120,7 +1149,7 @@ public class Employee {
 --
 [source,cs]
 ----
-
+public record Employee(long Id, string Name);
 ----
 --
 
@@ -1194,7 +1223,11 @@ public class Employee {
 --
 [source,cs]
 ----
-
+public record Employee(
+    long Id, 
+    string Name,
+    int Age // newly-added field
+);
 ----
 --
 
@@ -1279,7 +1312,19 @@ public class EmployeeSerializer implements CompactSerializer<Employee> {
 --
 [source,cs]
 ----
+public class EmployeeSerializer : ICompactSerializer<Employee>
+{
+    public Employee Read(ICompactReader reader)
+    {
+        var id = reader.ReadInt64("id");
+        var name = reader.ReadString("name");
+        // the new 'age' field is there, but the old reader does not 
+        // know anything about it, and ignores the field.
+        return new Employee(id, name);
+    }
 
+    // ...
+}
 ----
 --
 
@@ -1388,7 +1433,23 @@ public class EmployeeSerializer implements CompactSerializer<Employee> {
 --
 [source,cs]
 ----
+public class EmployeeSerializer : ICompactSerializer<Employee>
+{
+    public Employee Read(ICompactReader reader)
+    {
+        var id = reader.ReadInt64("id");
+        var name = reader.ReadString("name");
+        // read the "age" field if it exists, else use the default value 0
+        // reader.readInt32("age") would throw if the "age" field
+        // does not exist in data.
+        var age = reader.GetFieldKind("age") == FieldKind.Int32
+            ? reader.ReadInt32("age")
+            : 0;
+        return new Employee(id, name, age);
+    }
 
+    // ...
+}
 ----
 --
 

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -600,7 +600,7 @@ Up to eight booleans are packed into a single byte.
 | boolean[]
 |
 | boost::optional<std::vector<bool>>
-| boolean[]
+| boolean[] | null
 | Optional[list[bool]]
 |
 | Array of booleans or null. Up to eight boolean array items are packed into a single byte.
@@ -618,7 +618,7 @@ Up to eight booleans are packed into a single byte.
 | Boolean[]
 | 
 | boost::optional<std::vector<boost::optional<bool>>>
-| (boolean | null)[]
+| (boolean | null)[] | null
 | Optional[list[Optional[bool]]]
 |
 | Array of nullable booleans or null.
@@ -654,7 +654,7 @@ Up to eight booleans are packed into a single byte.
 | Byte[]
 |
 | boost::optional<std::vector<boost::optional<int8_t>>>
-| (number | null)[]
+| (number | null)[] | null
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int8s or null.
@@ -672,7 +672,7 @@ Up to eight booleans are packed into a single byte.
 | short[]
 |
 | boost::optional<std::vector<int16_t>>
-| number[]
+| number[] | null
 | Optional[list[int]]
 |
 | Array of int16s or null.
@@ -690,7 +690,7 @@ Up to eight booleans are packed into a single byte.
 | Short[]
 |
 | boost::optional<std::vector<boost::optional<int16_t>>>
-| (number | null)[]
+| (number | null)[] | null
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int16s or null.
@@ -708,7 +708,7 @@ Up to eight booleans are packed into a single byte.
 | int[]
 |
 | boost::optional<std::vector<int32_t>>
-| number[]
+| number[] | null
 | Optional[list[int]]
 |
 | Array of int32s or null.
@@ -726,7 +726,7 @@ Up to eight booleans are packed into a single byte.
 | Integer[]
 |
 | boost::optional<std::vector<boost::optional<int32_t>>>
-| (number | null)[]
+| (number | null)[] | null
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int32s or null.
@@ -735,7 +735,7 @@ Up to eight booleans are packed into a single byte.
 | long
 |
 | int64_t
-| number
+| Long
 | int
 |
 | 64-bit two's complement signed integer.
@@ -744,7 +744,7 @@ Up to eight booleans are packed into a single byte.
 | long[]
 |
 | boost::optional<std::vector<int64_t>>
-| number[]
+| Long[] | null
 | Optional[list[int]]
 |
 | Array of int64s or null.
@@ -762,7 +762,7 @@ Up to eight booleans are packed into a single byte.
 | Long[]
 |
 | boost::optional<std::vector<boost::optional<int64_t>>>
-| (Long | null)[]
+| (Long | null)[] | null
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int64s or null.
@@ -780,7 +780,7 @@ Up to eight booleans are packed into a single byte.
 | float[]
 |
 | boost::optional<std::vector<float>>
-| number[]
+| number[] | null
 | Optional[list[float]]
 |
 | Array of float32s or null.
@@ -798,7 +798,7 @@ Up to eight booleans are packed into a single byte.
 | Float[]
 |
 | boost::optional<std::vector<boost::optional<float>>>
-| (number | null)[]
+| (number | null)[] | null
 | Optional[list[Optional[float]]]
 |
 | Array of nullable float32s or null.
@@ -816,7 +816,7 @@ Up to eight booleans are packed into a single byte.
 | double[]
 |
 | boost::optional<std::vector<double>>
-| number[]
+| number[] | null
 | Optional[list[float]]
 |
 | Array of float64s or null.
@@ -834,7 +834,7 @@ Up to eight booleans are packed into a single byte.
 | Double[]
 |
 | boost::optional<std::vector<boost::optional<double>>>
-| (number | null)[]
+| (number | null)[] | null
 | Optional[list[Optional[float]]]
 |
 | Array of nullable float64s or null.
@@ -843,7 +843,7 @@ Up to eight booleans are packed into a single byte.
 | String
 |
 | std::string
-| string
+| string | null
 | Optional[str]
 |
 | A UTF-8 encoded string or null.
@@ -852,7 +852,7 @@ Up to eight booleans are packed into a single byte.
 | String[]
 |
 | boost::optional<std::vector<std::string>>
-| string[]
+| (string | null)[] | null
 | Optional[list[Optional[str]]]
 |
 | Array of strings or null.
@@ -861,7 +861,7 @@ Up to eight booleans are packed into a single byte.
 | BigDecimal
 |
 | boost::optional<hazelcast::client::big_decimal>
-| BigDecimal
+| BigDecimal | null
 | Optional[decimal.Decimal]
 |
 | Arbitrary precision and scale floating point number or null.
@@ -870,7 +870,7 @@ Up to eight booleans are packed into a single byte.
 | BigDecimal[]
 |
 | boost::optional<std::vector<boost::optional<hazelcast::client::big_decimal>>>
-| BigDecimal[]
+| (BigDecimal | null)[] | null
 | Optional[list[decimal.Decimal]]
 |
 | Array of decimals or null.
@@ -879,7 +879,7 @@ Up to eight booleans are packed into a single byte.
 | LocalTime
 |
 | boost::optional<hazelcast::client::local_time>
-| LocalTime
+| LocalTime | null
 | Optional[datetime.time]
 |
 | Time consisting of hours, minutes, seconds, and nanoseconds or null.
@@ -888,7 +888,7 @@ Up to eight booleans are packed into a single byte.
 | LocalTime[]
 |
 | boost::optional<std::vector<boost::optional<local_time>>>
-| LocalTime[]
+| (LocalTime | null)[] | null
 | Optional[list[Optional[datetime.time]]]
 |
 | Array of times or null.
@@ -897,7 +897,7 @@ Up to eight booleans are packed into a single byte.
 | LocalDate
 |
 | boost::optional<hazelcast::client::local_date>
-| LocalDate
+| LocalDate | null
 | Optional[datetime.date]
 |
 | Date consisting of year, month, and day of the month or null.
@@ -906,7 +906,7 @@ Up to eight booleans are packed into a single byte.
 | LocalDate[]
 |  
 | boost::optional<std::vector<boost::optional<local_date>>>
-| LocalDate[]
+| (LocalDate | null)[] | null
 | Optional[list[Optional[datetime.date]]]
 |
 | Array of dates or null.
@@ -915,7 +915,7 @@ Up to eight booleans are packed into a single byte.
 | LocalDateTime
 |
 | boost::optional<hazelcast::client::local_date_time>
-| LocalDateTime
+| LocalDateTime | null
 | Optional[datetime.datetime]
 |
 | Timestamp consisting of year, month, day of the month, hour, minutes, seconds,
@@ -925,7 +925,7 @@ and nanoseconds or null.
 | LocalDateTime[]
 |
 | boost::optional<std::vector<boost::optional<hazelcast::client::local_date_time>>>
-| LocalDateTime[]
+| (LocalDateTime | null)[] | null
 | Optional[list[Optional[datetime.datetime]]]
 |
 | Array of timestamps or null.
@@ -934,7 +934,7 @@ and nanoseconds or null.
 | OffsetDateTime
 |
 | 
-| OffsetDateTime
+| OffsetDateTime | null
 | Optional[datetime.datetime]
 |
 | Timestamp with timezone consisting of year, month, day of the month, hour, minutes, seconds,
@@ -944,7 +944,7 @@ nanoseconds, and offset seconds or null.
 | OffsetDateTime[]
 |
 |
-| OffsetDateTime[]
+| (OffsetDateTime | null)[] | null
 | Optional[list[Optional[datetime.datetime]]]
 |
 | Array of timestamp with timezones or null.

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -44,6 +44,303 @@ The older versions released under the BETA status are not compatible with stable
 For future versions, the backward compatibility will be maintained, just like any other
 Hazelcast feature.
 
+== Configuration
+
+The configuration can be used to register either
+
+- an explicit `CompactSerializer`
+- a zero-config serializer for a class to override other serialization mechanisms,
+for languages that provide zero-config Compact serialization.
+
+In case of an explicit serializer, you have to supply a unique type name for the class
+in the serializer.
+
+Choosing a type name will associate that name with the schema and will make the
+polyglot use cases, where there are multiple clients from different languages,
+possible. Serializers in different languages can work on the same data, provided
+that their read and write methods are compatible, and they have the same type name.
+
+NOTE: If you evolve your class in the later versions of your application, by adding
+or removing fields, you should continue using the same type name for that class.
+
+To register an explicit serializer for a certain class, add the following configuration:
+
+**Programmatic Configuration:**
+
+[tabs]
+====
+
+Java - Member::
++
+--
+[source,java]
+----
+Config config = new Config();
+config.getSerializationConfig()
+        .getCompactSerializationConfig()
+        .addSerializer(new FooSerializer());
+----
+--
+
+Java - Client::
++
+--
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.getSerializationConfig()
+        .getCompactSerializationConfig()
+        .addSerializer(new FooSerializer());
+----
+--
+
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
+C++::
++
+--
+[source,cpp]
+----
+
+----
+--
+
+Node.js::
++
+--
+[source,javascript]
+----
+
+----
+--
+
+Python::
++
+--
+[source,python]
+----
+hazelcast.HazelcastClient(
+    compact_serializers=[
+        FooSerializer(),
+    ],
+)
+----
+--
+
+Go::
++
+--
+[source,go]
+----
+
+----
+--
+
+====
+
+**Declarative Configuration:**
+
+[tabs]
+====
+
+Java - Member - XML::
++
+--
+[source,xml]
+----
+<hazelcast>
+    <serialization>
+        <compact-serialization>
+            <serializers>
+                <serializer>
+                    com.example.FooSerializer
+                </serializer>
+            </serializers>
+        </compact-serialization>
+    </serialization>
+</hazelcast>
+----
+--
+
+Java - Member - YAML::
++
+--
+[source,yaml]
+----
+hazelcast:
+  serialization:
+    compact-serialization:
+      serializers:
+        - serializer: com.example.FooSerializer
+----
+--
+
+Java - Client - XML::
++
+--
+[source,xml]
+----
+<hazelcast-client>
+    <serialization>
+        <compact-serialization>
+            <serializers>
+                <serializer>
+                    com.example.FooSerializer
+                </serializer>
+            </serializers>
+        </compact-serialization>
+    </serialization>
+</hazelcast-client>
+----
+--
+
+Java - Client - YAML::
++
+--
+[source,yaml]
+----
+hazelcast-client:
+  serialization:
+    compact-serialization:
+      serializers:
+        - serializer: com.example.FooSerializer
+----
+--
+
+====
+
+Lastly, the following is a sample configuration that registers zero-config
+serializer for a certain class, without implementing an explicit serializer.
+
+This way, one can override other the serializer of a certain class such as Java
+`Serializable` serializer with the zero-config serializer.
+
+When a class is serialized using the zero-config Compact serializer, Hazelcast will choose the
+fully qualified class name for Java as the type name automatically.
+
+**Programmatic Configuration:**
+
+[tabs]
+====
+
+Java - Member::
++
+--
+[source,java]
+----
+Config config = new Config();
+config.getSerializationConfig()
+        .getCompactSerializationConfig()
+        .addClass(Bar.class);
+----
+--
+
+Java - Client::
++
+--
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.getSerializationConfig()
+        .getCompactSerializationConfig()
+        .addClass(Bar.class);
+----
+--
+
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
+====
+
+**Declarative Configuration:**
+
+[tabs]
+====
+
+Java - Member - XML::
++
+--
+[source,xml]
+----
+<hazelcast>
+    <serialization>
+        <compact-serialization>
+            <classes>
+                <class>
+                    com.example.Bar
+                </class>
+            </classes>
+        </compact-serialization>
+    </serialization>
+</hazelcast>
+----
+--
+
+Java - Member - YAML::
++
+--
+[source,yaml]
+----
+hazelcast:
+  serialization:
+    compact-serialization:
+      classes:
+        - class: com.example.Bar
+----
+--
+
+Java - Client - XML::
++
+--
+[source,xml]
+----
+<hazelcast-client>
+    <serialization>
+        <compact-serialization>
+            <classes>
+                <class>
+                    com.example.Bar
+                </class>
+            </classes>
+        </compact-serialization>
+    </serialization>
+</hazelcast-client>
+----
+--
+
+Java - Client - YAML::
++
+--
+[source,yaml]
+----
+hazelcast-client:
+  serialization:
+    compact-serialization:
+      classes:
+        - class: com.example.Bar
+----
+--
+
+====
+
+If you want to override the serialization mechanism used for `Serializable` or
+`Externalizable` classes and use Compact serialization without writing any
+serializer in Java, you must add those classes to the configuration.
+
+
 == Implementing CompactSerializer
 
 Compact serialization can be used by implementing a `CompactSerializer` for a class
@@ -227,164 +524,14 @@ Go::
 
 ====
 
-The last step is to register the serializer in the member or client configuration.
+The last step is to register the serializer in the member or client configuration, as shown
+in the <<configuration>> section.
 
-**Programmatic Configuration:**
+Upon serialization, a schema will be created from the serializer, and a unique schema identifier
+will be assigned to it automatically.
 
-[tabs]
-====
-
-Java - Member::
-+
---
-[source,java]
-----
-Config config = new Config();
-config.getSerializationConfig()
-        .getCompactSerializationConfig()
-        .addSerializer(new EmployeeSerializer());
-----
---
-
-Java - Client::
-+
---
-[source,java]
-----
-ClientConfig clientConfig = new ClientConfig();
-clientConfig.getSerializationConfig()
-        .getCompactSerializationConfig()
-        .addSerializer(new EmployeeSerializer());
-----
---
-
-.NET::
-+
---
-[source,cs]
-----
-
-----
---
-
-C++::
-+
---
-[source,cpp]
-----
-
-----
---
-
-Node.js::
-+
---
-[source,javascript]
-----
-
-----
---
-
-Python::
-+
---
-[source,python]
-----
-hazelcast.HazelcastClient(
-    compact_serializers=[
-        EmployeeSerializer(),
-    ],
-)
-----
---
-
-Go::
-+
---
-[source,go]
-----
-
-----
---
-
-====
-
-**Declarative Configuration:**
-
-[tabs]
-====
-
-Java - Member - XML::
-+
---
-[source,xml]
-----
-<hazelcast>
-    <serialization>
-        <compact-serialization>
-            <serializers>
-                <serializer>
-                    com.example.EmployeeSerializer
-                </serializer>
-            </serializers>
-        </compact-serialization>
-    </serialization>
-</hazelcast>
-----
---
-
-Java - Member - YAML::
-+
---
-[source,yaml]
-----
-hazelcast:
-  serialization:
-    compact-serialization:
-      serializers:
-         - serializer: com.example.EmployeeSerializer
-----
---
-
-Java - Client - XML::
-+
---
-[source,xml]
-----
-<hazelcast-client>
-    <serialization>
-        <compact-serialization>
-            <serializers>
-                <serializer>
-                    com.example.EmployeeSerializer
-                </serializer>
-            </serializers>
-        </compact-serialization>
-    </serialization>
-</hazelcast-client>
-----
---
-
-Java - Client - YAML::
-+
---
-[source,yaml]
-----
-hazelcast-client:
-  serialization:
-    compact-serialization:
-      serializers:
-         - serializer: com.example.EmployeeSerializer
-----
---
-
-====
-
-A schema will be created from the serializer, and a unique schema identifier will be
-assigned to it automatically.
-
-From now on, Hazelcast will serialize instances of the `Employee` class using the
-`EmployeeSerializer`.
+After the configuration registration, Hazelcast will serialize instances of the `Employee`
+class using the `EmployeeSerializer`.
 
 == Supported Types
 
@@ -448,7 +595,7 @@ Up to eight booleans are packed into a single byte.
 |
 | Optional[list[int]]
 |
-| Array of int8s or null..
+| Array of int8s or null.
 
 | NULLABLE_INT8
 | Byte
@@ -759,22 +906,22 @@ nanoseconds, and offset seconds or null.
 | Array of timestamp with timezones or null.
 
 | COMPACT
-| Can be any type.
-| Can be any type.
-| Can be any type.
-| Can be any type.
-| Can be any type.
-| Can be any type.
+| Can be any user type.
+| Can be any user type.
+| Can be any user type.
+| Can be any user type.
+| Can be any user type.
+| Can be any user type.
 | A user defined nested Compact serializable object or null.
 
 | ARRAY_OF_COMPACT
-| Can be an array of any type.
-| Can be an array of any type.
-| Can be an array of any type.
-| Can be an array of any type.
-| Can be an array of any type.
-| Can be an array of any type.
-| Array of Compact serializable objects or null.
+| Can be an array of any user type.
+| Can be an array of any user type.
+| Can be an array of any user type.
+| Can be an array of any user type.
+| Can be an array of any user type.
+| Can be an array of any user type.
+| Array of user defined Compact serializable objects or null.
 
 |===
 
@@ -785,6 +932,11 @@ ends at some point on runtime by some null value.
 
 NOTE: The ability to use Compact serialization with no configuration is only available in
 Java and .NET.
+
+NOTE: Using zero-config Compact serialization is not recommended for performance-critical
+applications, as the feature relies heavily on reflection to read and write data. +
+It is recommended to use explicit Compact serializers in production for performance
+considerations.
 
 Compact serialization can also be used without registering a serializer in the member
 or client configuration.
@@ -854,15 +1006,22 @@ first class types:
 * `char`, represented as an `INT16`
 * `Character`, represented as a `NULLABLE_INT16`
 * Enum, represented as a `STRING`, using the names of the enum members.
-* Arrays of the types listed above, represented by their respective arrays.
+* Arrays of the types listed above, represented by their respective arrays. *
 * `List` or `ArrayList` of the types listed above and first class types, represented by their
-respective arrays with the same field name.
+respective arrays with the same field name. Fields of type `List` are deserialized as
+`ArrayList` upon reads. *
 * `Set` or `HashSet` of the types listed above and first class types, represented by their
-respective arrays with the same field name.
-* `Map` or `HashMap` or the types listed above and first class types, represented by two arrays
-per field, one for keys and one for values, represented by their respective arrays for key and
+respective arrays with the same field name. Fields of type `Set` are deserialized as
+`HashSet` upon reads. *
+* `Map` or `HashMap` or the types listed above and first class types, represented by two arrays,
+one for keys and one for values, represented by their respective arrays for key and
 value types. The names of those arrays are of the form `fieldName + '!keys'` and
-`fieldName + '!values'`.
+`fieldName + '!values'`. Fields of type `Map` are deserialized as `HashMap` upon reads. *
+
+NOTE: * Arrays of arrays, or collections of collections are not supported by default. An explicit
+serializer must be written to support such field types. In that serializer, the inner array
+type must be defined as a separate class which stores the array type as a field. Then, the
+array of array type can be serialized/deserialized as an array of that separate class.
 
 For Java APIs, a zero-config Compact serializer uses reflection to read and write to fields of
 objects, regardless of whether those fields are public. If you use Java 9 onwards, you must
@@ -1211,302 +1370,6 @@ method of the serializer to extract a schema out of the object, hence any condit
 that may or may not run depending on the object in that method might result in an undefined
 behavior.
 
-== Configuration
-
-The configuration can be used to register either
-
-- an explicit `CompactSerializer`
-- a zero-config serializer for a class to override other serialization mechanisms,
-for languages that provide zero-config Compact serialization.
-
-In case of an explicit serializer, you have to supply a unique type name for the class
-in the serializer.
-
-Choosing a type name will associate that name with the schema and will make the
-polyglot use cases, where there are multiple clients from different languages,
-possible. Serializers in different languages can work on the same data, provided
-that their read and write methods are compatible, and they have the same type name.
-
-NOTE: If you evolve your class in the later versions of your application, by adding
-or removing fields, you should continue using the same type name for that class.
-
-To register an explicit serializer for a certain class, add the following configuration:
-
-**Programmatic Configuration:**
-
-[tabs]
-====
-
-Java - Member::
-+
---
-[source,java]
-----
-Config config = new Config();
-config.getSerializationConfig()
-        .getCompactSerializationConfig()
-        .addSerializer(new FooSerializer());
-----
---
-
-Java - Client::
-+
---
-[source,java]
-----
-ClientConfig clientConfig = new ClientConfig();
-clientConfig.getSerializationConfig()
-        .getCompactSerializationConfig()
-        .addSerializer(new FooSerializer());
-----
---
-
-.NET::
-+
---
-[source,cs]
-----
-
-----
---
-
-C++::
-+
---
-[source,cpp]
-----
-
-----
---
-
-Node.js::
-+
---
-[source,javascript]
-----
-
-----
---
-
-Python::
-+
---
-[source,python]
-----
-hazelcast.HazelcastClient(
-    compact_serializers=[
-        FooSerializer(),
-    ],
-)
-----
---
-
-Go::
-+
---
-[source,go]
-----
-
-----
---
-
-====
-
-**Declarative Configuration:**
-
-[tabs]
-====
-
-Java - Member - XML::
-+
---
-[source,xml]
-----
-<hazelcast>
-    <serialization>
-        <compact-serialization>
-            <serializers>
-                <serializer>
-                    com.example.FooSerializer
-                </serializer>
-            </serializers>
-        </compact-serialization>
-    </serialization>
-</hazelcast>
-----
---
-
-Java - Member - YAML::
-+
---
-[source,yaml]
-----
-hazelcast:
-  serialization:
-    compact-serialization:
-      serializers:
-        - serializer: com.example.FooSerializer
-----
---
-
-Java - Client - XML::
-+
---
-[source,xml]
-----
-<hazelcast-client>
-    <serialization>
-        <compact-serialization>
-            <serializers>
-                <serializer>
-                    com.example.FooSerializer
-                </serializer>
-            </serializers>
-        </compact-serialization>
-    </serialization>
-</hazelcast-client>
-----
---
-
-Java - Client - YAML::
-+
---
-[source,yaml]
-----
-hazelcast-client:
-  serialization:
-    compact-serialization:
-      serializers:
-        - serializer: com.example.FooSerializer
-----
---
-
-====
-
-Lastly, the following is a sample configuration that registers zero-config
-serializer for a certain class, without implementing an explicit serializer.
-
-This way, one can override other serialization mechanisms for a certain class
-such as Java serializable, using zero-config serializer.
-
-When a class is serialized using the zero-config Compact serializer, Hazelcast will choose the
-fully qualified class name for Java as the type name automatically.
-
-**Programmatic Configuration:**
-
-[tabs]
-====
-
-Java - Member::
-+
---
-[source,java]
-----
-Config config = new Config();
-config.getSerializationConfig()
-        .getCompactSerializationConfig()
-        .addClass(Bar.class);
-----
---
-
-Java - Client::
-+
---
-[source,java]
-----
-ClientConfig clientConfig = new ClientConfig();
-clientConfig.getSerializationConfig()
-        .getCompactSerializationConfig()
-        .addClass(Bar.class);
-----
---
-
-.NET::
-+
---
-[source,cs]
-----
-
-----
---
-
-====
-
-**Declarative Configuration:**
-
-[tabs]
-====
-
-Java - Member - XML::
-+
---
-[source,xml]
-----
-<hazelcast>
-    <serialization>
-        <compact-serialization>
-            <classes>
-                <class>
-                    com.example.Bar
-                </class>
-            </classes>
-        </compact-serialization>
-    </serialization>
-</hazelcast>
-----
---
-
-Java - Member - YAML::
-+
---
-[source,yaml]
-----
-hazelcast:
-  serialization:
-    compact-serialization:
-      classes:
-        - class: com.example.Bar
-----
---
-
-Java - Client - XML::
-+
---
-[source,xml]
-----
-<hazelcast-client>
-    <serialization>
-        <compact-serialization>
-            <classes>
-                <class>
-                    com.example.Bar
-                </class>
-            </classes>
-        </compact-serialization>
-    </serialization>
-</hazelcast-client>
-----
---
-
-Java - Client - YAML::
-+
---
-[source,yaml]
-----
-hazelcast-client:
-  serialization:
-    compact-serialization:
-      classes:
-        - class: com.example.Bar
-----
---
-
-====
-
-If you want to override the serialization mechanism used for `Serializable` or
-`Externalizable` classes and use Compact serialization without writing any
-serializer in Java, you must add those classes to the configuration.
-
 == GenericRecord Representation
 
 Compact serialized objects can also be represented by a `GenericRecord`, without requiring
@@ -1515,8 +1378,8 @@ the class in the classpath. See xref:clusters:accessing-domain-objects.adoc[].
 == SQL Support
 
 Compact serialized objects can be used in SQL statements, provided that a mappings are created,
-similar to other serialization formats. See xref:sql:mapping-to-maps.adoc[], to learn more
-about Compact serialization mappings.
+similar to other serialization formats. See
+xref:sql:mapping-to-maps.adoc#compact-objects[Compact Object mappings] section to learn more.
 
 == WAN Support
 
@@ -1524,12 +1387,11 @@ Hazelcast supports WAN replication of the Compact serialized objects between dif
 
 However, since the Compact serialization is promoted to the stable status in 5.2, and it is not
 compatible with the previous BETA versions, one has to make sure that the whole WAN cluster
-topology, including all senders and receivers, is at least as new as 5.2, before start replicating data structures containing Compact
-serialized objects.
+topology members, including all senders and receivers, are at least as new as 5.2, before starting to
+replicate data structures containing Compact serialized objects.
 
-Since it has promoted to the stable status, it will be possible in the future releases to
-replicate Compact serialized objects between different WAN clusters of versions at least as
-new as 5.2.
+Since the Compact serialization has promoted to the stable status, it will be possible to
+replicate Compact serialized objects between different WAN clusters in the future releases.
 
 == Persistence Support
 

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -1,6 +1,7 @@
 = Compact Serialization
 
-As an enhancement to existing serialization methods, Hazelcast offers Compact Serialization, with the following main features.
+As an enhancement to existing serialization methods, Hazelcast offers Compact
+serialization, with the following main features:
 
 * Separates the schema from the data and stores it per type, not per object which
 results in less memory and bandwidth usage compared to other formats
@@ -9,12 +10,11 @@ the class in any way
 * Supports schema evolution which permits adding or removing fields, or changing
 the types of fields
 * Can work with no configuration or any kind of factory/serializer registration for
-Java classes and Java records
+Java classes, Java records, and .NET classes
 * Platform and language independent
-* Supports partial deserialization of fields, without deserializing the whole objects during
-queries or indexing
+* Supports partial deserialization of fields during queries or indexing
 
-Hazelcast achieves these features by having a well-known schema of objects and replicating
+Hazelcast achieves these features by having well-known schemas of objects and replicating
 them across the cluster which enables members and clients to fetch schemas they don't
 have in their local registries. Each serialized object carries just a schema identifier and
 relies on the schema distribution service or configuration to match identifiers with the
@@ -22,7 +22,7 @@ actual schema. Once the schemas are fetched, they are cached locally on the memb
 so that the next operations that use the schema do not incur extra costs.
 
 Schemas help Hazelcast to identify the locations of the fields on the serialized binary data.
-With this information, Hazelcast can deserialize individual fields of the data, without reading
+With this information, Hazelcast can deserialize individual fields of the data, without deserializing
 the whole binary. This results in a better query and indexing performance.
 
 Schemas can evolve freely by adding or removing fields. Even, the types of the fields can be changed.
@@ -35,33 +35,28 @@ a class to implement a particular interface. Serializers might be implemented an
 separately from the classes.
 
 It also supports zero-configuration use cases by automatically extracting schemas out of the
-classes and Java records using reflection, which is cached and reused later, with no extra cost.
+Java classes and records, and .NET classes which are cached and reused later, with no extra cost.
 
 The underlying format of the Compact serialized objects is platform and language independent.
 
-== Using Compact Serialization With Zero-Configuration
+NOTE: Compact serialization is promoted to the stable status in the 5.2 Hazelcast release.
+The older versions released under the BETA status are not compatible with stable the 5.2 version. +
+For future versions, the backward compatibility will be maintained, just like any other
+Hazelcast feature.
 
-Compact serialization can be used without a registering the serializer in the member or client
-configuration. Hazelcast tries
-to extract a schema out of the class, using reflection. If successful, it registers the
-reflective serializer associated with the extracted schema and uses it while
-serializing and deserializing instances of that class. If the automatic schema
-extraction fails, Hazelcast throws an exception.
+== Implementing CompactSerializer
 
-Currently, Hazelcast supports extracting schemas out of classes that have the following
-field types:
+Compact serialization can be used by implementing a `CompactSerializer` for a class
+and registering it in the configuration.
 
-* Primitive types: `boolean`, `byte`, `char`, `short`, `int`, `long`, `float`, and `double`
-* Wrapper classes of primitive types: `Boolean`, `Byte`, `Character`, `Short`, `Integer`, `Long`, `Float`, and `Double`
-* `String`
-* `java.time.LocalDate`, `java.time.LocalTime`, `java.time.LocalDateTime`, and `java.time.OffsetDateTime`
-* `java.math.BigDecimal`
-* Enums
-* Array, `List`, `ArrayList`, `Set`, `HashSet`, `Map`, `HashMap` of the types shown above
-* Nested classes that contain the fields above and arrays of them
+For example, assume that you have the following `Employee` class.
 
-Assume that you have the following `Employee` class.
+[tabs]
+====
 
+Java::
++
+--
 [source,java]
 ----
 public class Employee {
@@ -82,41 +77,66 @@ public class Employee {
     }
 }
 ----
+--
 
-If you don't perform any kind of configuration changes and use the instances of the class
-directly, no exceptions are thrown. Hazelcast will generate a schema out of the
-`Employee` class the first time you try to serialize an object, cache it, and reuse it
-for the subsequent serializations and deserializations.
-
-The same holds true for the Java records. Hazelcast supports serializing and deserializing
-Java records, without an extra configuration as well.
-
-Assuming the `Employee` class above were a Java record:
-
-[source,java]
-----
-public record Employee(long id, String name) {
-}
+.NET::
++
+--
+[source,cs]
 ----
 
-The following code would work for both of them.
-
-[source,java]
 ----
-HazelcastInstance client = HazelcastClient.newHazelcastClient();
-IMap<Long, Employee> map = client.getMap("employees");
-Employee employee = new Employee(1, "John Doe");
-map.set(1L, employee);
-Employee employeeFromMap = map.get(1L);
+--
+
+C++::
++
+--
+[source,cpp]
 ----
 
-== Implementing CompactSerializer
+----
+--
 
-Another way to use compact serialization is to implement the `CompactSerializer` interface for a class
-and register it in the configuration.
+Node.js::
++
+--
+[source,javascript]
+----
 
-For example, assume that you have the same `Employee` class. Then, a Compact serializer can be implemented as such.
+----
+--
 
+Python::
++
+--
+[source,python]
+----
+class Employee:
+    def __init__(self, id: int, name: str):
+        self.id = id
+        self.name = name
+----
+--
+
+Go::
++
+--
+[source,go]
+----
+
+----
+--
+
+====
+
+Then, a Compact serializer can be implemented as below.
+
+[tabs]
+====
+
+Java::
++
+--
 [source,java]
 ----
 public class EmployeeSerializer implements CompactSerializer<Employee> {
@@ -144,29 +164,162 @@ public class EmployeeSerializer implements CompactSerializer<Employee> {
     }
 }
 ----
+--
+
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
+C++::
++
+--
+[source,cpp]
+----
+
+----
+--
+
+Node.js::
++
+--
+[source,javascript]
+----
+
+----
+--
+
+Python::
++
+--
+[source,python]
+----
+class EmployeeSerializer(CompactSerializer[Employee]):
+    def read(self, reader: CompactReader):
+        id = reader.read_int64("id")
+        name = reader.read_string("name")
+        return Employee(id, name)
+
+    def write(self, writer: CompactWriter, employee: Employee):
+        writer.write_int64("id", employee.id)
+        writer.write_string("name", employee.name)
+
+    def get_type_name(self):
+        return "employee"
+
+    def get_class(self):
+        return Employee
+----
+--
+
+Go::
++
+--
+[source,go]
+----
+
+----
+--
+
+====
 
 The last step is to register the serializer in the member or client configuration.
 
 **Programmatic Configuration:**
 
+[tabs]
+====
+
+Java - Member::
++
+--
 [source,java]
 ----
-SerializationConfig serializationConfig = new SerializationConfig();
-serializationConfig.getCompactSerializationConfig()
+Config config = new Config();
+config.getSerializationConfig()
+        .getCompactSerializationConfig()
         .addSerializer(new EmployeeSerializer());
 ----
+--
+
+Java - Client::
++
+--
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.getSerializationConfig()
+        .getCompactSerializationConfig()
+        .addSerializer(new EmployeeSerializer());
+----
+--
+
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
+C++::
++
+--
+[source,cpp]
+----
+
+----
+--
+
+Node.js::
++
+--
+[source,javascript]
+----
+
+----
+--
+
+Python::
++
+--
+[source,python]
+----
+hazelcast.HazelcastClient(
+    compact_serializers=[
+        EmployeeSerializer(),
+    ],
+)
+----
+--
+
+Go::
++
+--
+[source,go]
+----
+
+----
+--
+
+====
 
 **Declarative Configuration:**
 
 [tabs]
 ====
-XML::
+
+Java - Member - XML::
 +
 --
 [source,xml]
 ----
 <hazelcast>
-    ...
     <serialization>
         <compact-serialization>
             <serializers>
@@ -176,13 +329,13 @@ XML::
             </serializers>
         </compact-serialization>
     </serialization>
-    ...
 </hazelcast>
 ----
 --
 
-YAML::
+Java - Member - YAML::
 +
+--
 [source,yaml]
 ----
 hazelcast:
@@ -191,12 +344,539 @@ hazelcast:
       serializers:
          - serializer: com.example.EmployeeSerializer
 ----
+--
+
+Java - Client - XML::
++
+--
+[source,xml]
+----
+<hazelcast-client>
+    <serialization>
+        <compact-serialization>
+            <serializers>
+                <serializer>
+                    com.example.EmployeeSerializer
+                </serializer>
+            </serializers>
+        </compact-serialization>
+    </serialization>
+</hazelcast-client>
+----
+--
+
+Java - Client - YAML::
++
+--
+[source,yaml]
+----
+hazelcast-client:
+  serialization:
+    compact-serialization:
+      serializers:
+         - serializer: com.example.EmployeeSerializer
+----
+--
+
 ====
 
 A schema will be created from the serializer, and a unique schema identifier will be
 assigned to it automatically.
 
-From now on, Hazelcast will serialize instances of the `Employee` class using the `EmployeeSerializer`.
+From now on, Hazelcast will serialize instances of the `Employee` class using the
+`EmployeeSerializer`.
+
+== Supported Types
+
+Compact serialization supports the following list as first class types. Any other type
+can be implemented on top of these, by using these types as building blocks.
+
+[cols="1m,1a,1a,1a,1a,1a,1a,1a]
+|===
+| Type | Java | .NET | C++ | Node.js | Python | Go | Description
+
+| BOOLEAN
+| boolean
+|
+|
+|
+| bool
+|
+| True or false represented by a single bit as either 1 or 0.
+Up to eight booleans are packed into a single byte.
+
+| ARRAY_OF_BOOLEAN
+| boolean[]
+|
+|
+|
+| Optional[list[bool]]
+|
+| Array of booleans or null. Up to eight boolean array items are packed into a single byte.
+
+| NULLABLE_BOOLEAN
+| Boolean
+|
+|
+|
+| Optional[bool]
+|
+| A boolean that can also be null.
+
+| ARRAY_OF_NULLABLE_BOOLEAN
+| Boolean[]
+|
+|
+|
+| Optional[list[Optional[bool]]]
+|
+| Array of nullable booleans or null.
+
+| INT8
+| byte
+|
+|
+|
+| int
+|
+| 8-bit two's complement signed integer.
+
+| ARRAY_OF_INT8
+| byte[]
+|
+|
+|
+| Optional[list[int]]
+|
+| Array of int8s or null..
+
+| NULLABLE_INT8
+| Byte
+|
+|
+|
+| Optional[int]
+|
+| An int8 that can also be null.
+
+| ARRAY_OF_NULLABLE_INT8
+| Byte[]
+|
+|
+|
+| Optional[list[Optional[int]]]
+|
+| Array of nullable int8s or null.
+
+| INT16
+| short
+|
+|
+|
+| int
+|
+| 16-bit two's complement signed integer.
+
+| ARRAY_OF_INT16
+| short[]
+|
+|
+|
+| Optional[list[int]]
+|
+| Array of int16s or null.
+
+| NULLABLE_INT16
+| Short
+|
+|
+|
+| Optional[int]
+|
+| An int16 that can also be null.
+
+| ARRAY_OF_NULLABLE_INT16
+| Short[]
+|
+|
+|
+| Optional[list[Optional[int]]]
+|
+| Array of nullable int16s or null.
+
+| INT32
+| int
+|
+|
+|
+| int
+|
+| 32-bit two's complement signed integer.
+
+| ARRAY_OF_INT32
+| int[]
+|
+|
+|
+| Optional[list[int]]
+|
+| Array of int32s or null.
+
+| NULLABLE_INT32
+| Integer
+|
+|
+|
+| Optional[int]
+|
+| An int32 that can also be null.
+
+| ARRAY_OF_NULLABLE_INT32
+| Integer[]
+|
+|
+|
+| Optional[list[Optional[int]]]
+|
+| Array of nullable int32s or null.
+
+| INT64
+| long
+|
+|
+|
+| int
+|
+| 64-bit two's complement signed integer.
+
+| ARRAY_OF_INT64
+| long[]
+|
+|
+|
+| Optional[list[int]]
+|
+| Array of int64s or null.
+
+| NULLABLE_INT64
+| Long
+|
+|
+|
+| Optional[int]
+|
+| An int64 that can also be null.
+
+| ARRAY_OF_NULLABLE_INT64
+| Long[]
+|
+|
+|
+| Optional[list[Optional[int]]]
+|
+| Array of nullable int64s or null.
+
+| FLOAT32
+| float
+|
+|
+|
+| float
+|
+| 32-bit IEEE 754 floating point number.
+
+| ARRAY_OF_FLOAT32
+| float[]
+|
+|
+|
+| Optional[list[float]]
+|
+| Array of float32s or null.
+
+| NULLABLE_FLOAT32
+| Float
+|
+|
+|
+| Optional[float]
+|
+| A float32 that can also be null.
+
+| ARRAY_OF_NULLABLE_FLOAT32
+| Float[]
+|
+|
+|
+| Optional[list[Optional[float]]]
+|
+| Array of nullable float32s or null.
+
+| FLOAT64
+| double
+|
+|
+|
+| float
+|
+| 64-bit IEEE 754 floating point number.
+
+| ARRAY_OF_FLOAT64
+| double[]
+|
+|
+|
+| Optional[list[float]]
+|
+| Array of float64s or null.
+
+| NULLABLE_FLOAT64
+| Double
+|
+|
+|
+| Optional[float]
+|
+| A float64 that can also be null.
+
+| ARRAY_OF_NULLABLE_FLOAT64
+| Double[]
+|
+|
+|
+| Optional[list[Optional[float]]]
+|
+| Array of nullable float64s or null.
+
+| STRING
+| String
+|
+|
+|
+| Optional[str]
+|
+| A UTF-8 encoded string or null.
+
+| ARRAY_OF_STRING
+| String[]
+|
+|
+|
+| Optional[list[Optional[str]]]
+|
+| Array of strings or null.
+
+| DECIMAL
+| BigDecimal
+|
+|
+|
+| Optional[decimal.Decimal]
+|
+| Arbitrary precision and scale floating point number or null.
+
+| ARRAY_OF_DECIMAL
+| BigDecimal[]
+|
+|
+|
+| Optional[list[decimal.Decimal]]
+|
+| Array of decimals or null.
+
+| TIME
+| LocalTime
+|
+|
+|
+| Optional[datetime.time]
+|
+| Time consisting of hours, minutes, seconds, and nanoseconds or null.
+
+| ARRAY_OF_TIME
+| LocalTime[]
+|
+|
+|
+| Optional[list[Optional[datetime.time]]]
+|
+| Array of times or null.
+
+| DATE
+| LocalDate
+|
+|
+|
+| Optional[datetime.date]
+|
+| Date consisting of year, month, and day of the month or null.
+
+| ARRAY_OF_DATE
+| LocalDate[]
+|
+|
+|
+| Optional[list[Optional[datetime.date]]]
+|
+| Array of dates or null.
+
+| TIMESTAMP
+| LocalDateTime
+|
+|
+|
+| Optional[datetime.datetime]
+|
+| Timestamp consisting of year, month, day of the month, hour, minutes, seconds,
+and nanoseconds or null.
+
+| ARRAY_OF_TIMESTAMP
+| LocalDateTime[]
+|
+|
+|
+| Optional[list[Optional[datetime.datetime]]]
+|
+| Array of timestamps or null.
+
+| TIMESTAMP_WITH_TIMEZONE
+| OffsetDateTime
+|
+|
+|
+| Optional[datetime.datetime]
+|
+| Timestamp with timezone consisting of year, month, day of the month, hour, minutes, seconds,
+nanoseconds, and offset seconds or null.
+
+| ARRAY_OF_TIMESTAMP_WITH_TIMEZONE
+| OffsetDateTime[]
+|
+|
+|
+| Optional[list[Optional[datetime.datetime]]]
+|
+| Array of timestamp with timezones or null.
+
+| COMPACT
+| Can be any type.
+| Can be any type.
+| Can be any type.
+| Can be any type.
+| Can be any type.
+| Can be any type.
+| A user defined nested Compact serializable object or null.
+
+| ARRAY_OF_COMPACT
+| Can be an array of any type.
+| Can be an array of any type.
+| Can be an array of any type.
+| Can be an array of any type.
+| Can be an array of any type.
+| Can be an array of any type.
+| Array of Compact serializable objects or null.
+
+|===
+
+NOTE: Compact serialization supports circularly-dependent types, provided that the cycle
+ends at some point on runtime by some null value.
+
+== Using Compact Serialization With Zero-Configuration
+
+NOTE: The ability to use Compact serialization with no configuration is only available in
+Java and .NET.
+
+Compact serialization can also be used without registering a serializer in the member
+or client configuration.
+
+When Hazelcast cannot associate a class with any other serialization mechanism, instead of
+throwing an exception directly, it tries to use zero-configuration Compact serialization
+as a last effort.
+
+Hazelcast tries to extract a schema out of the class. If successful, it registers the 
+zero-config serializer associated with the extracted schema and uses it while serializing 
+and deserializing instances of that class. If the automatic schema extraction fails,
+Hazelcast throws an exception.
+
+For example, assume that you have the same `Employee` class.
+
+If you don't perform any kind of configuration change and use the instances of the class
+directly, no exceptions will be thrown. Hazelcast will generate a schema out of the
+`Employee` class the first time you try to serialize an object, cache it, and reuse it
+for the subsequent serializations and deserializations.
+
+The same holds true for the Java records. Hazelcast supports serializing and deserializing
+Java records, without an extra configuration as well.
+
+Assuming the `Employee` class above were a Java record:
+
+[source,java]
+----
+public record Employee(long id, String name) {
+}
+----
+
+The following code would work for both of them.
+
+[tabs]
+====
+
+Java::
++
+--
+[source,java]
+----
+HazelcastInstance client = HazelcastClient.newHazelcastClient();
+IMap<Long, Employee> map = client.getMap("employees");
+Employee employee = new Employee(1L, "John Doe");
+map.set(1L, employee);
+Employee employeeFromMap = map.get(1L);
+----
+--
+
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
+====
+
+Currently, Hazelcast supports extracting schemas out of classes that have the field types shown
+above and some others, for user convenience.
+
+For Java, the zero-config serializer supports the following extra field types on top of the
+first class types:
+
+* `char`, represented as an `INT16`
+* `Character`, represented as a `NULLABLE_INT16`
+* Enum, represented as a `STRING`, using the names of the enum members.
+* Arrays of the types listed above, represented by their respective arrays.
+* `List` or `ArrayList` of the types listed above and first class types, represented by their
+respective arrays with the same field name.
+* `Set` or `HashSet` of the types listed above and first class types, represented by their
+respective arrays with the same field name.
+* `Map` or `HashMap` or the types listed above and first class types, represented by two arrays
+per field, one for keys and one for values, represented by their respective arrays for key and
+value types. The names of those arrays are of the form `fieldName + '!keys'` and
+`fieldName + '!values'`.
+
+For Java, zero-config Compact serializer uses reflection to read and write to fields of
+objects, regardless they are public or not. That results in hard error on JDK16 and onwards,
+as illegal reflective access is denied by default in JDK16 and that option is removed altogether
+in JDK17. The solution to these problems is to open your module that the class you are
+serializing with zero-config reflective serializer to Hazelcast. Or, you can write your
+own Compact serializer, as described above.
+
+[source,text]
+----
+module org.example.Foo {
+    opens org.example to com.hazelcast.core;
+}
+----
 
 == Schema Evolution
 
@@ -209,8 +889,8 @@ or serializers apart from the added, removed, or changed fields.
 
 Hazelcast achieves this by identifying each version of the class by a unique fingerprint. Any change
 in a class results in a different fingerprint. Hazelcast uses a 64-bit
-https://en.wikipedia.org/wiki/Rabin_fingerprint[Rabin Fingerprint] to assign identifiers to schemas, which
-has an extremely low collision rate.
+https://en.wikipedia.org/wiki/Rabin_fingerprint[Rabin Fingerprint] to assign identifiers to schemas,
+which has an extremely low collision rate.
 
 Different versions of the schema with different identifiers are replicated in the cluster and can be
 fetched by clients or members internally. That allows old readers to read fields of the classes they
@@ -219,90 +899,435 @@ fields of the classes available in the data, when they try to read data serializ
 
 Assume that the two versions of the following `Employee` class lives in the cluster.
 
+[tabs]
+====
+
+Java::
++
+--
 [source,java]
 ----
-class Employee {
-    long id;
-    String name;
+public class Employee {
+    private long id;
+    private String name;
 }
 ----
+--
 
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
+C++::
++
+--
+[source,cpp]
+----
+
+----
+--
+
+Node.js::
++
+--
+[source,javascript]
+----
+
+----
+--
+
+Python::
++
+--
+[source,python]
+----
+class Employee:
+    def __init__(self, id: int, name: str):
+        self.id = id
+        self.name = name
+----
+--
+
+Go::
++
+--
+[source,go]
+----
+
+----
+--
+
+====
+
+
+[tabs]
+====
+
+Java::
++
+--
 [source,java]
 ----
-class Employee {
+public class Employee {
     private long id;
     private String name;
     private int age; // Newly added field
 }
 ----
+--
+
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
+C++::
++
+--
+[source,cpp]
+----
+
+----
+--
+
+Node.js::
++
+--
+[source,javascript]
+----
+
+----
+--
+
+Python::
++
+--
+[source,python]
+----
+class Employee:
+    def __init__(self, id: int, name: str, age: int):
+        self.id = id
+        self.name = name
+        self.age = age # Newly added field
+----
+--
+
+Go::
++
+--
+[source,go]
+----
+
+----
+--
+
+====
 
 Then, when faced with binary data serialized by the new writer, old readers will be able to
 read the following fields.
 
+[tabs]
+====
+
+Java::
++
+--
 [source,java]
 ----
-public Employee read(CompactReader reader) {
-    long id = reader.readInt64("id");
-    String name = reader.readString("name");
-    // The new "age" field is there, but the old reader does not
-    // know anything about it. Hence, it will simply ignore that field.
-    return new Employee(id, name);
+public class EmployeeSerializer implements CompactSerializer<Employee> {
+    @Override
+    public Employee read(CompactReader reader) {
+        long id = reader.readInt64("id");
+        String name = reader.readString("name");
+        // The new "age" field is there, but the old reader does not
+        // know anything about it. Hence, it will simply ignore that field.
+        return new Employee(id, name);
+    }
+    ...
 }
 ----
+--
+
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
+C++::
++
+--
+[source,cpp]
+----
+
+----
+--
+
+Node.js::
++
+--
+[source,javascript]
+----
+
+----
+--
+
+Python::
++
+--
+[source,python]
+----
+class EmployeeSerializer(CompactSerializer[Employee]):
+    def read(self, reader: CompactReader):
+        id = reader.read_int64("id")
+        name = reader.read_string("name")
+        # The new "age" field is there, but the old reader does not
+        # know anything about it. Hence, it will simply ignore that field.
+        return Employee(id, name)
+    ...
+----
+--
+
+Go::
++
+--
+[source,go]
+----
+
+----
+--
+
+====
 
 Then, when faced with binary data serialized by the old writer, new readers will be able to
 read the following fields. Also, Hazelcast provides convenient APIs to check the
 existence of fields in the data when there is no such field.
 
+[tabs]
+====
+
+Java::
++
+--
 [source,java]
 ----
-public Employee read(CompactReader reader) {
-    long id = reader.readInt64("id");
-    String name = reader.readString("name");
-    // Read the "age" if it exists, or use the default value 0.
-    // reader.readInt32("age") would throw if the "age" field
-    // does not exist in data.
-    int age;
-    if (reader.getFieldKind("age") == FieldKind.INT32) {
-        age = reader.readInt32("age");
-    } else {
-        age = 0;
+public class EmployeeSerializer implements CompactSerializer<Employee> {
+    @Override
+    public Employee read(CompactReader reader) {
+        long id = reader.readInt64("id");
+        String name = reader.readString("name");
+        // Read the "age" if it exists, or use the default value 0.
+        // reader.readInt32("age") would throw if the "age" field
+        // does not exist in data.
+        int age;
+        if (reader.getFieldKind("age") == FieldKind.INT32) {
+            age = reader.readInt32("age");
+        } else {
+            age = 0;
+        }
+        return new Employee(id, name, age);
     }
-    return new Employee(id, name, age);
+    ...
 }
 ----
+--
+
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
+C++::
++
+--
+[source,cpp]
+----
+
+----
+--
+
+Node.js::
++
+--
+[source,javascript]
+----
+
+----
+--
+
+Python::
++
+--
+[source,python]
+----
+class EmployeeSerializer(CompactSerializer[Employee]):
+    def read(self, reader: CompactReader):
+        id = reader.read_int64("id")
+        name = reader.read_string("name")
+        # Read the "age" if it exists, or use the default value 0.
+        # reader.read_int32("age") would throw if the "age" field
+        # does not exist in data.
+        if reader.get_field_kind("age") == FieldKind.INT32:
+            age = reader.read_int32("age")
+        else:
+            age = 0
+        return Employee(id, name, age)
+    ...
+----
+--
+
+Go::
++
+--
+[source,go]
+----
+
+----
+--
+
+====
 
 Note that, when an old reader reads data written by an old writer, or a new reader reads a data
-written by a new writer, they will be able to read all fields.
+written by a new writer, they will be able to read all fields written.
 
-== CompactSerializationConfig
+One thing to be careful while evolving the class is to not have any conditional code
+in the `write` method. That method must write all the fields available in the current version
+of the class to the writer, with appropriate field names and types. Hazelcast uses the `write`
+method of the serializer to extract a schema out of the object, hence any conditional code
+that may or may not run depending on the object in that method might result in an undefined
+behavior.
+
+== Configuration
 
 The configuration can be used to register either
 
 - an explicit `CompactSerializer`
-- a reflective serializer for a class to override other serialization mechanisms.
+- a zero-config serializer for a class to override other serialization mechanisms,
+for languages that provide zero-config Compact serialization.
 
-In case of an explicit serializer, you have to supply a type name for the class
+In case of an explicit serializer, you have to supply a unique type name for the class
 in the serializer.
 
 Choosing a type name will associate that name with the schema and will make the
 polyglot use cases, where there are multiple clients from different languages,
-easier.
+possible. Serializers in different languages can work on the same data, provided
+that their read and write methods are compatible, and they have the same type name.
 
-When a class is serialized using the reflective serializer, Hazelcast will choose the
-fully qualified class name as the type name automatically.
+NOTE: If you evolve your class in the later versions of your application, by adding
+or removing fields, you should continue using the same type name for that class.
+
+When a class is serialized using the zero-config Compact serializer, Hazelcast will choose the
+fully qualified class name for Java as the type name automatically.
 
 Below is the way to register an explicit serializer for a certain class.
 
+**Programmatic Configuration:**
+
 [tabs]
 ====
-XML::
+
+Java - Member::
++
+--
+[source,java]
+----
+Config config = new Config();
+config.getSerializationConfig()
+        .getCompactSerializationConfig()
+        .addSerializer(new FooSerializer());
+----
+--
+
+Java - Client::
++
+--
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.getSerializationConfig()
+        .getCompactSerializationConfig()
+        .addSerializer(new FooSerializer());
+----
+--
+
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
+C++::
++
+--
+[source,cpp]
+----
+
+----
+--
+
+Node.js::
++
+--
+[source,javascript]
+----
+
+----
+--
+
+Python::
++
+--
+[source,python]
+----
+hazelcast.HazelcastClient(
+    compact_serializers=[
+        FooSerializer(),
+    ],
+)
+----
+--
+
+Go::
++
+--
+[source,go]
+----
+
+----
+--
+
+====
+
+**Declarative Configuration:**
+
+[tabs]
+====
+
+Java - Member - XML::
 +
 --
 [source,xml]
 ----
 <hazelcast>
-    ...
     <serialization>
         <compact-serialization>
             <serializers>
@@ -312,12 +1337,11 @@ XML::
             </serializers>
         </compact-serialization>
     </serialization>
-    ...
 </hazelcast>
 ----
 --
 
-YAML::
+Java - Member - YAML::
 +
 --
 [source,yaml]
@@ -329,46 +1353,112 @@ hazelcast:
         - serializer: com.example.FooSerializer
 ----
 --
-Java::
+
+Java - Client - XML::
++
+--
+[source,xml]
+----
+<hazelcast-client>
+    <serialization>
+        <compact-serialization>
+            <serializers>
+                <serializer>
+                    com.example.FooSerializer
+                </serializer>
+            </serializers>
+        </compact-serialization>
+    </serialization>
+</hazelcast-client>
+----
+--
+
+Java - Client - YAML::
++
+--
+[source,yaml]
+----
+hazelcast-client:
+  serialization:
+    compact-serialization:
+      serializers:
+        - serializer: com.example.FooSerializer
+----
+--
+
+====
+
+Lastly, the following is a sample configuration that registers zero-config
+serializer for a certain class, without implementing an explicit serializer.
+
+This way, one can override other serialization mechanisms for a certain class
+such as Java serializable, using zero-config serializer.
+
+**Programmatic Configuration:**
+
+[tabs]
+====
+
+Java - Member::
 +
 --
 [source,java]
 ----
-SerializationConfig serializationConfig = new SerializationConfig();
-serializationConfig.getCompactSerializationConfig()
-        .addSerializer(new FooSerializer());
+Config config = new Config();
+config.getSerializationConfig()
+        .getCompactSerializationConfig()
+        .addClass(Bar.class);
 ----
 --
+
+Java - Client::
++
+--
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.getSerializationConfig()
+        .getCompactSerializationConfig()
+        .addClass(Bar.class);
+----
+--
+
+.NET::
++
+--
+[source,cs]
+----
+
+----
+--
+
 ====
 
-Lastly, the following is a sample configuration that registers reflective
-serializer for a certain class, without implementing an explicit serializer.
-
-This way, one can override other serialization mechanisms for a certain class
-such as Java serializable.
+**Declarative Configuration:**
 
 [tabs]
 ====
-XML::
+
+Java - Member - XML::
 +
 --
 [source,xml]
 ----
 <hazelcast>
-    ...
     <serialization>
         <compact-serialization>
             <classes>
-                <class>com.example.Bar</class>
+                <class>
+                    com.example.Bar
+                </class>
             </classes>
         </compact-serialization>
     </serialization>
-    ...
 </hazelcast>
 ----
 --
 
-YAML::
+Java - Member - YAML::
 +
 --
 [source,yaml]
@@ -380,23 +1470,99 @@ hazelcast:
         - class: com.example.Bar
 ----
 --
-Java::
+
+Java - Client - XML::
 +
 --
-[source,java]
+[source,xml]
 ----
-SerializationConfig serializationConfig = new SerializationConfig();
-serializationConfig.getCompactSerializationConfig()
-        .addClass(Bar.class); // Uses the fully qualified class name as the type name
+<hazelcast-client>
+    <serialization>
+        <compact-serialization>
+            <classes>
+                <class>
+                    com.example.Bar
+                </class>
+            </classes>
+        </compact-serialization>
+    </serialization>
+</hazelcast-client>
 ----
 --
+
+Java - Client - YAML::
++
+--
+[source,yaml]
+----
+hazelcast-client:
+  serialization:
+    compact-serialization:
+      classes:
+        - class: com.example.Bar
+----
+--
+
 ====
 
 If you want to override the serialization mechanism used for `Serializable` or
 `Externalizable` classes and use Compact serialization without writing any
-serializer, you must add those classes to the configuration.
+serializer in Java, you must add those classes to the configuration as described above.
 
 == GenericRecord Representation
 
-Compact serialized objects
-can also be represented by a `GenericRecord`, without requiring the class in the classpath. See xref:clusters:accessing-domain-objects.adoc[].
+Compact serialized objects can also be represented by a `GenericRecord`, without requiring
+the class in the classpath. See xref:clusters:accessing-domain-objects.adoc[].
+
+== SQL Support
+
+Compact serialized objects can be used in SQL statements, provided that a mappings are created,
+similar to other serialization formats. See xref:sql:mapping-to-maps.adoc[], to learn more
+about Compact serialization mappings.
+
+== WAN Support
+
+Hazelcast supports WAN replication of the Compact serialized objects between different clusters.
+
+However, since the Compact serialization is promoted to the stable status in 5.2, and it is not
+compatible with the previous BETA versions, one has to make sure that the whole WAN cluster
+topology, including all senders and receivers, is at least as new as 5.2, before start replicating data structures containing Compact
+serialized objects.
+
+Since it has promoted to the stable status, it will be possible in the future releases to
+replicate Compact serialized objects between different WAN clusters of versions at least as
+new as 5.2.
+
+== Persistence Support
+
+Hazelcast supports persisting Compact serialized objects and reading the persisted data on startup.
+
+However, since the Compact serialization is promoted to the stable status in 5.2, and it is not
+compatible with the previous BETA versions, it is not possible to recover the Hazelcast members
+with the persisted data of Compact serialized objects of the previous Hazelcast versions, where
+this feature was in BETA.
+
+Since it has promoted to the stable status, it will be possible in the future releases to
+persist and recover Compact serialized objects of different Hazelcast versions, at least as
+new as 5.2.
+
+== Serialization Priority
+
+As described in the xref:serialization:serialization.adoc#steps[Serialization priority]
+section, Compact serialization has the highest priority in the serialization mechanisms supported
+by Hazelcast.
+
+That allows one to override other serialization mechanisms with Compact serialization.
+
+That is especially useful when an interface signature forces you to implement other serialization
+mechanisms in Java. For example, you can define the `Employee` class above as below
+
+[source,java]
+----
+public class Employee implements Serializable {
+    ...
+}
+----
+
+and still be able to use the Compact serializer you wrote for it, provided that you have registered
+it as described in the previous sections.

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -40,7 +40,7 @@ Java classes and records, and .NET classes which are cached and reused later, wi
 The underlying format of the Compact serialized objects is platform and language independent.
 
 NOTE: Compact serialization is promoted to the stable status in the 5.2 Hazelcast release.
-The older versions released under the BETA status are not compatible with stable the 5.2 version. +
+The older versions released under the BETA status are not compatible with the stable 5.2 version. +
 For future versions, the backward compatibility will be maintained, just like any other
 Hazelcast feature.
 
@@ -1607,7 +1607,7 @@ the class in the classpath. See xref:clusters:accessing-domain-objects.adoc[].
 
 == SQL Support
 
-Compact serialized objects can be used in SQL statements, provided that a mappings are created,
+Compact serialized objects can be used in SQL statements, provided that mappings are created,
 similar to other serialization formats. See
 xref:sql:mapping-to-maps.adoc#compact-objects[Compact Object mappings] section to learn more.
 

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -609,7 +609,7 @@ Up to eight booleans are packed into a single byte.
 | Boolean
 | 
 | boost::optional<bool>
-| boolean
+| boolean | null
 | Optional[bool]
 |
 | A boolean that can also be null.
@@ -618,7 +618,7 @@ Up to eight booleans are packed into a single byte.
 | Boolean[]
 | 
 | boost::optional<std::vector<boost::optional<bool>>>
-| boolean[]
+| (boolean | null)[]
 | Optional[list[Optional[bool]]]
 |
 | Array of nullable booleans or null.
@@ -636,7 +636,7 @@ Up to eight booleans are packed into a single byte.
 | byte[]
 | 
 | boost::optional<std::vector<int8_t>>
-| number[]
+| Buffer
 | Optional[list[int]]
 |
 | Array of int8s or null.
@@ -645,7 +645,7 @@ Up to eight booleans are packed into a single byte.
 | Byte
 |
 | boost::optional<int8_t>
-| number
+| number | null
 | Optional[int]
 |
 | An int8 that can also be null.
@@ -654,7 +654,7 @@ Up to eight booleans are packed into a single byte.
 | Byte[]
 |
 | boost::optional<std::vector<boost::optional<int8_t>>>
-| number[]
+| (number | null)[]
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int8s or null.
@@ -681,7 +681,7 @@ Up to eight booleans are packed into a single byte.
 | Short
 |
 | boost::optional<int16_t>
-| number
+| number | null
 | Optional[int]
 |
 | An int16 that can also be null.
@@ -690,7 +690,7 @@ Up to eight booleans are packed into a single byte.
 | Short[]
 |
 | boost::optional<std::vector<boost::optional<int16_t>>>
-| number[]
+| (number | null)[]
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int16s or null.
@@ -717,7 +717,7 @@ Up to eight booleans are packed into a single byte.
 | Integer
 |
 | boost::optional<int32_t>
-| number
+| number | null
 | Optional[int]
 |
 | An int32 that can also be null.
@@ -726,7 +726,7 @@ Up to eight booleans are packed into a single byte.
 | Integer[]
 |
 | boost::optional<std::vector<boost::optional<int32_t>>>
-| number[]
+| (number | null)[]
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int32s or null.
@@ -753,7 +753,7 @@ Up to eight booleans are packed into a single byte.
 | Long
 |
 | boost::optional<int64_t>
-| number
+| Long | null
 | Optional[int]
 |
 | An int64 that can also be null.
@@ -762,7 +762,7 @@ Up to eight booleans are packed into a single byte.
 | Long[]
 |
 | boost::optional<std::vector<boost::optional<int64_t>>>
-| number[]
+| (Long | null)[]
 | Optional[list[Optional[int]]]
 |
 | Array of nullable int64s or null.
@@ -789,7 +789,7 @@ Up to eight booleans are packed into a single byte.
 | Float
 |
 | boost::optional<float>
-| number
+| number | null
 | Optional[float]
 |
 | A float32 that can also be null.
@@ -798,7 +798,7 @@ Up to eight booleans are packed into a single byte.
 | Float[]
 |
 | boost::optional<std::vector<boost::optional<float>>>
-| number[]
+| (number | null)[]
 | Optional[list[Optional[float]]]
 |
 | Array of nullable float32s or null.
@@ -825,7 +825,7 @@ Up to eight booleans are packed into a single byte.
 | Double
 |
 | boost::optional<double>
-| number
+| number | null
 | Optional[float]
 |
 | A float64 that can also be null.
@@ -834,7 +834,7 @@ Up to eight booleans are packed into a single byte.
 | Double[]
 |
 | boost::optional<std::vector<boost::optional<double>>>
-| number[]
+| (number | null)[]
 | Optional[list[Optional[float]]]
 |
 | Array of nullable float64s or null.

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -990,7 +990,7 @@ nanoseconds, and offset seconds or null.
 | ARRAY_OF_TIMESTAMP_WITH_TIMEZONE
 | OffsetDateTime[]
 | HOffsetDateTime[]
-| boost::optional<std::vector<boost::optional<offset_date_time>>>
+| boost::optional<std::vector<boost::optional<hazelcast::client::offset_date_time>>>
 | (OffsetDateTime \| null)[] \| null
 | Optional[list[Optional[datetime.datetime]]]
 | []*types.OffsetDateTime


### PR DESCRIPTION
This PR updates the Compact serialization documentation by
- making it more polyglot friendly
- adding frequently requested sections including information for
	- zero-config interoperability
	- WAN support
	- links to SQL mappings
- fully describing the types supported