### PR TITLE
Update support.adoc

### DIFF
--- a/docs/modules/getting-started/pages/support.adoc
+++ b/docs/modules/getting-started/pages/support.adoc
@@ -57,7 +57,6 @@ functionality in play when the problem occurred.
 * Attach Hazelcast process logs.
 * Attach Hazelcast health monitor logs.
 * Attach thread dumps from all members.
-* Attach heap dumps.
 * Add networking logs.
 * Specify the time of incident.
 * When providing Hazelcast logs, please make sure that the system and


### PR DESCRIPTION
removing "add heap dump" suggestion as it has legal repercussions since a heap dump can contain sensitive data.  We ask for heap dumps not in all cases but as needed basis (from lower env's)