### PR TITLE
Fixes#594 5.2 JDBC driver support for MySQL

### DIFF
--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -35,7 +35,7 @@ The JDBC connector does not yet support permissions.
 Before you can create a mapping to an external data store, you must have the following:
 
 - A JDBC driver that's compatible with your data store. This driver must be on the classpath of your cluster members:
-** The full distribution of Hazelcast comes with a JDBC driver for MySQL, PostgreSQL, and H2 data stores.
+** The full distribution of Hazelcast comes with a JDBC driver for MySQL, PostgreSQL, and H2 data stores, but currently Hazelcast Enterprise does not include a JDBC driver for MySQL.
 ** The slim distribution of Hazelcast does not come with a JDBC driver.
 - A xref:external-data-stores:external-data-stores.adoc[data store connection] that's configured on all cluster members.
 - Create the database that you'll use as your external data store.


### PR DESCRIPTION
Fixes #594 (5.2). Incorrect backport label was added to previous PR. Change has currently only been applied to 5.3-Snapshot.