### PR TITLE
DOCS-238 Backport changes applied to other versions

### DIFF
--- a/docs/modules/data-structures/pages/managing-map-memory.adoc
+++ b/docs/modules/data-structures/pages/managing-map-memory.adoc
@@ -253,9 +253,9 @@ To set a maximum idle timeout for specific map entries, use the `maxIdle` and `m
 
 Here `ttl` is set as 50 seconds and `maxIdle` is set as 40 seconds.
 
-As well as the method parameters, you can also use the `map.setTTL()` method to change the time-to-live value of an existing entry.
+As well as the method parameters, you can also use the `map.setTtl()` method to change the time-to-live value of an existing entry.
 
-`myMap.setTTL( "1", 50, TimeUnit.SECONDS )`
+`myMap.setTtl( "1", 50, TimeUnit.SECONDS )`
 
 [[forced-eviction]]
 == Forced Eviction for the HD Memory Store


### PR DESCRIPTION
`Backport to all versions` label was used but the change was not applied to v5.2. See related PR https://github.com/hazelcast/hz-docs/pull/603.