### PR TITLE
DOCS-313 Added v5.2 label

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ jobs:
   backport:
     strategy:
       matrix:
-        branch: ['v/5.0', 'v/5.1']
+        branch: ['v/5.0', 'v/5.1', 'v/5.2']
     runs-on: ubuntu-latest
     steps:
     


### PR DESCRIPTION
Changes are not being applied to v5.2 when using the label `Backport to all versions`. See [https://github.com/hazelcast/hz-docs/pull/604]