### PR TITLE
Increase width for mapping parameter examples

### DIFF
--- a/docs/modules/sql/pages/create-mapping.adoc
+++ b/docs/modules/sql/pages/create-mapping.adoc
@@ -27,7 +27,7 @@ You must provide the following:
 - `mapping_name`
 - `type_identifier`
 
-[cols="1a,2a,1a"]
+[cols="1a,2a,2a"]
 |===
 |Parameter | Description | Example
 


### PR DESCRIPTION
Mapping examples are not readable in narrow column, narrow column makes them also needlessly long.