### PR TITLE
DOCS-356_Support_for_Intel_Optane_Discontinued

### DIFF
--- a/docs/modules/cache/pages/overview.adoc
+++ b/docs/modules/cache/pages/overview.adoc
@@ -8,7 +8,6 @@
 :url-spring: https://spring.io/projects/spring-framework
 :url-jetty: https://www.eclipse.org/jetty/documentation/current/configuring-sessions-hazelcast.html
 :blog-caching-patterns: https://hazelcast.com/blog/a-hitchhikers-guide-to-caching-patterns/
-:blog-intel: https://hazelcast.com/blog/in-memory-computing-and-intel-optane/
 :glossary-hibernate: https://hazelcast.com/glossary/hibernate-second-level-cache/
 :use-cases-jcache: https://hazelcast.com/use-cases/jcache-provider/
 :guides-spring-boot: https://guides.hazelcast.org/hazelcast-embedded-springboot/
@@ -28,7 +27,7 @@ The purpose of a cache is to improve the performance of your applications by doi
 - Reducing network calls to a primary data store.
 - Saving the results of queries or computations to avoid resubmitting them.
 
-Data stored in a cache is often kept in random-access memory (RAM) because its faster to read. However, other storage solutions are also available such as link:{blog-intel}[Intel Optane].
+Data stored in a cache is often kept in random-access memory (RAM) because its faster to read.
 
 In Hazelcast, the RAM of all cluster members is combined into a single in-memory data store to provide fast access to data. This distributed model is called a _cache cluster_, and it makes your data fault-tolerant and scalable. If a member goes down, your data is repartitioned across the remaining members. And, if you need more or fewer resources, you can add or remove members as necessary.
 

--- a/docs/modules/data-structures/pages/backing-up-maps.adoc
+++ b/docs/modules/data-structures/pages/backing-up-maps.adoc
@@ -143,7 +143,7 @@ hazelcast:
 
 Hazelcast offers several features for backing up your in-memory maps to files located on the local cluster member disk, in persistent memory, or to a system of record such as an external database. 
 
-* xref:storage:persistence.adoc[Persistence] provides for data recovery in the event of a planned or unplanned complete cluster shutdown. When enabled, each cluster member periodically writes a copy of all local map data to either the local disk drive or to persistent memory (such as Intel(R) Optane (TM)). When the cluster is restarted, each member reads the stored data back into memory. If all cluster members successfully recover the stored data, cluster operations resume as usual.
+* xref:storage:persistence.adoc[Persistence] provides for data recovery in the event of a planned or unplanned complete cluster shutdown. When enabled, each cluster member periodically writes a copy of all local map data to either the local disk drive or to persistent memory. When the cluster is restarted, each member reads the stored data back into memory. If all cluster members successfully recover the stored data, cluster operations resume as usual.
 
 * xref:mapstore:working-with-external-data.adoc[MapStore] provides for automatic write-through of map changes to an external data store, and automatic loading of data from that external data store when an application calls a map. Although this can function as a data safety feature, the primary purpose of MapStore is to maintain synchronization between a system of record and the in-memory map. 
 

--- a/docs/modules/data-structures/pages/setting-data-format.adoc
+++ b/docs/modules/data-structures/pages/setting-data-format.adoc
@@ -100,6 +100,4 @@ hazelcast:
 
 Keep in mind that you should have already enabled HD memory usage for your cluster. See the xref:storage:high-density-memory.adoc#configuring-high-density-memory-store[Configuring High-Density Memory Store section].
 
-You can also benefit from the persistent memory technologies such as Intel(R) Optane(TM) DC to be used by HDMS. See the xref:storage:high-density-memory.adoc#using-persistent-memory[Using Persistent Memory section].
-
 Note that `NATIVE` memory stores data in binary format. Maps stored in the HD memory store have to be deserialized before they can be queried. A best practice is to use on-heap memory for maps that will be frequently queried when possible. 

--- a/docs/modules/storage/pages/high-density-memory.adoc
+++ b/docs/modules/storage/pages/high-density-memory.adoc
@@ -162,7 +162,7 @@ system properties.
 [[using-persistent-memory]]
 == Using the High-Density Memory Store with Persistent Memory Devices
 
-To extend the memory available to the High-Density Memory Store, you can use persistent memory devices, such as Intel(R) Optane(TM) DC. This is a cost-efficient way to provide additional storage for data structures like IMap, ICache, and Near Cache.
+To extend the memory available to the High-Density Memory Store, you can use persistent memory devices. This is a cost-efficient way to provide additional storage for data structures like IMap, ICache, and Near Cache.
 
 Importantly, the High-Density Memory Store uses the memory provided by the persistent memory device as _volatile_ memory. This means that all data stored on the device is lost when a Hazelcast member or cluster is restarted. To recover data from individual members or clusters after planned or unplanned shutdowns, you need to xref:persistence.adoc[persist data on disk].
 
@@ -171,6 +171,8 @@ To use a persistent memory device, you don't need to make any changes to your ap
 NOTE: Although the example describes the configuration of a dual socket machine, this is not a requirement for using persistent memory devices.
 
 === Configuring Intel(R) Optane(TM)
+
+CAUTION: Intel(R) has link:https://www.intel.co.uk/content/www/uk/en/support/articles/000057951/memory-and-storage/intel-optane-memory.html[discontinued support for Intel(R) Optane(TM) products]. As a result, Hazelcast does not recommend using this configuration, and it will be removed from the documentation in the upcoming release (5.3).
 
 Prerequisites:
 
@@ -264,8 +266,6 @@ set the `enabled` attribute to `true`
 +
 If you don't specify a directory for the persistent memory device, standard RAM is used instead.
 
-
-
 === Allocation Strategies
 
 Since on multi-socket machines there could be multiple mount points for persistent memory devices, the memory allocations need to follow an allocation strategy. Starting with 4.1, Hazelcast supports two allocation strategies:
@@ -330,6 +330,6 @@ Despite the above facts, whether the higher latency of the memory from persisten
 
 === Performance Impacts on Different Use Cases
 
-Hazelcast is a distributed platform so the higher latency of memory on a persistent memory device can easily be hidden by the latency variance of the network. For certain use cases there may be no observable difference in the throughput whether Hazelcast stores its data on memory from a persistent memory device or on regular memory. An example of this is caching, where accessing the entries remotely through Hazelcast clients results in a very similar throughput. Based on our tests with Intel(R) Optane(TM) DC persistent memory modules, we recommend Optane modules for the caching use case up to a 10 KB entry size.
+Hazelcast is a distributed platform so the higher latency of memory on a persistent memory device can easily be hidden by the latency variance of the network. For certain use cases there may be no observable difference in the throughput whether Hazelcast stores its data on memory from a persistent memory device or on regular memory. An example of this is caching, where accessing the entries remotely through Hazelcast clients results in a very similar throughput.
 
 Other use cases that don't involve networking, such as iterating over all entries with entry processors can be impacted by the higher latency of the memory modules on a persistent memory device, especially if the entry processors update a significant portion of the entries. For this type use case, the higher the entry size, the higher the impact on the performance. That means with smaller entry sizes the performance of Hazelcast with memory modules on a persistent memory device can be comparable to the performance with regular memory.

--- a/docs/modules/storage/pages/persistence-on-intel.adoc
+++ b/docs/modules/storage/pages/persistence-on-intel.adoc
@@ -4,6 +4,8 @@
 
 {description}
 
+CAUTION: Intel(R) has link:https://www.intel.co.uk/content/www/uk/en/support/articles/000057951/memory-and-storage/intel-optane-memory.html[discontinued support for Intel(R) Optane(TM) products]. As a result, Hazelcast does not recommend using this configuration, and it will be removed from the documentation in the upcoming release (5.3).
+
 == Before you Begin
 
 You need the following configuration tools:


### PR DESCRIPTION
I have checked with Zoltan and there is currently no alternative to the Intel Optane product.

- Where there is a reference in the general text to the product, this reference has been removed.
- Where we recommend/guide users through some configuration, a note has been added.

Just let me know if this is the right approach, or you normally do something different.

I'll add a ticket to the backlog to remove all content referencing Intel Optane for 5.3 and to update the release notes.