### PR TITLE
DOCS 360 Fix tables for pdf generator

### DIFF
--- a/docs/modules/configuration/pages/understanding-configuration.adoc
+++ b/docs/modules/configuration/pages/understanding-configuration.adoc
@@ -32,7 +32,7 @@ Static configuration cannot be changed at runtime. However, you can add <<dynami
 
 Hazelcast members and clients looks for static configuration options in the following order:
 
-[cols="10%a,45%a,45%a"]
+[cols="a,a,a"]
 |===
 |Order|Member|Client
 

--- a/docs/modules/cp-subsystem/pages/configuration.adoc
+++ b/docs/modules/cp-subsystem/pages/configuration.adoc
@@ -184,7 +184,7 @@ You can handle loss of the response in two ways:
 Use these configuration options to configure the CP Subsystem.
 
 .CP Subsystem configuration options
-[cols="1a,1a,1m,2a",options="header"]
+[cols="a,a,m,a",options="header"]
 |===
 |Option|Description|Default|Example
 
@@ -695,7 +695,7 @@ config.getCPSubsystemConfig().addLockConfig(lockConfig);
 --
 ====
 
-[cols="1a,1a,1m,2a",options="header"]
+[cols="a,a,m,a",options="header"]
 |===
 |Option|Description|Default|Example
 
@@ -849,7 +849,7 @@ config.getCPSubsystemConfig().addSemaphoreConfig(semaphoreConfig);
 --
 ====
 
-[cols="1a,1a,1m,2a",options="header"]
+[cols="a,a,m,a",options="header"]
 |===
 |Option|Description|Default|Example
 
@@ -1056,7 +1056,7 @@ config.getCPSubsystemConfig().setRaftAlgorithmConfig(raftConfig);
 --
 ====
 
-[cols="1a,1a,1m,2a",options="header"]
+[cols="a,a,m,a",options="header"]
 |===
 |Option|Description|Default|Example
 

--- a/docs/modules/cp-subsystem/pages/cp-subsystem.adoc
+++ b/docs/modules/cp-subsystem/pages/cp-subsystem.adoc
@@ -14,7 +14,7 @@ for the following:
 
 == Glossary
 
-[cols="1e,1a"]
+[cols="e,a"]
 |===
 |Term|Definition
 

--- a/docs/modules/data-structures/pages/creating-a-map.adoc
+++ b/docs/modules/data-structures/pages/creating-a-map.adoc
@@ -198,7 +198,7 @@ capitalCities.Set(5, "Brussels")
 
 Hazelcast runs on Java, which uses defined primitive types. If you are writing data in a single field (as opposed to an object), and you do not specify the primitive type when creating your map, the Hazelcast cluster will assign the following types based on the format of the data in the value field:
 
-[cols="1m,2a"]
+[cols="m,a"]
 |===
 | Primitive Type| Data Description
 

--- a/docs/modules/data-structures/pages/distributed-data-structures.adoc
+++ b/docs/modules/data-structures/pages/distributed-data-structures.adoc
@@ -6,7 +6,7 @@ languages, Hazelcast mimics as closely as possible the natural interface of the
 structure. For example in Java, the map follows `java.util.Map` semantics.
 All of these structures are available in Java, .NET, C++, Node.js, Python, and Go.
 
-[cols="20%a,40%a,20%a,20%a"]
+[cols="a,a,a,a"]
 |===
 |Data structure |Description|Partitioned/Non-partitioned|xref:architecture:architecture.adoc#apcp[AP/CP]
 

--- a/docs/modules/data-structures/pages/listening-for-map-entries.adoc
+++ b/docs/modules/data-structures/pages/listening-for-map-entries.adoc
@@ -218,7 +218,7 @@ to learn about the methods used to intercept the changes in a map.
 
 Methods available within the `MapInterceptor` interface:
 
-[cols="1,1"]
+[cols="a,a"]
 |===
 
 |`interceptGet`

--- a/docs/modules/data-structures/pages/updating-map-entries.adoc
+++ b/docs/modules/data-structures/pages/updating-map-entries.adoc
@@ -328,7 +328,7 @@ The Hazelcast Entry Processor is an efficient way to perform updates to a map. R
 
 There are several methods available for removing individual entries from a map. The method you choose depends on the results you want to achieve, as described in the following table.
 
-[cols="1,1,1,1"]
+[cols="a,a,a,a"]
 |===
 |Method|Erase in-memory|Erase from external data store|Returns
 
@@ -422,7 +422,7 @@ studentMap.RemoveAll(ctx, predicate.Equal("GradYear", 2020))
 
 You can remove all data from a map or remove the map itself. See the table below for the different methods and their results. 
 
-[cols="1,1"]
+[cols="a,a"]
 |===
 |Method|Result
 

--- a/docs/modules/deploy/pages/configuring-kubernetes.adoc
+++ b/docs/modules/deploy/pages/configuring-kubernetes.adoc
@@ -7,7 +7,7 @@
 
 To make it easier to set up clusters in Kubernetes, Hazelcast allows members to discover each other automatically, using discovery modes. Configure your members with one of the following discovery modes to allow them to form a cluster:
 
-[cols="1a,1a,1a"]
+[cols="a,a,a"]
 |===
 | | Kubernetes API  | DNS Lookup
 

--- a/docs/modules/deploy/pages/enterprise-licenses.adoc
+++ b/docs/modules/deploy/pages/enterprise-licenses.adoc
@@ -126,7 +126,7 @@ Please quote license id CUSTOM_TEST_KEY
 This frequency of these warnings depends on how long if left until the license expires:
 
 .Frequency of warnings about license expiration
-[cols="1a,1a"]
+[cols="a,a"]
 |===
 |Time until expiry|Warning frequency
 

--- a/docs/modules/deploy/pages/versioning-compatibility.adoc
+++ b/docs/modules/deploy/pages/versioning-compatibility.adoc
@@ -222,7 +222,7 @@ Hazelcast Platform has clients implemented in the following languages:
 
 The following table lists the compatibilities between client and Platform/IMDG versions.
 
-[cols="1,2a",options="header"]
+[cols="a,a",options="header"]
 .Client Version Compatibilities
 |===
 |Client | Platform and/or IMDG

--- a/docs/modules/getting-started/pages/authenticate-clients.adoc
+++ b/docs/modules/getting-started/pages/authenticate-clients.adoc
@@ -16,7 +16,7 @@ In this tutorial, you will complete the following steps:
 
 To complete this tutorial, you need the following:
 
-[cols="1a,1a"]
+[cols="a,a"]
 |===
 |Prerequisites|Useful resources
 

--- a/docs/modules/getting-started/pages/blue-green.adoc
+++ b/docs/modules/getting-started/pages/blue-green.adoc
@@ -27,7 +27,7 @@ This tutorial gives instructions for Java and Node.js clients.
 
 To complete this tutorial, you need the following:
 
-[cols="1a,1a"]
+[cols="a,a"]
 |===
 |Prerequisites|Useful resources
 

--- a/docs/modules/getting-started/pages/get-started-binary.adoc
+++ b/docs/modules/getting-started/pages/get-started-binary.adoc
@@ -7,7 +7,7 @@
 
 To complete this tutorial, you need the following:
 
-[cols="1a,1a"]
+[cols="a,a"]
 |===
 |Prerequisites|Useful resources
 

--- a/docs/modules/getting-started/pages/get-started-java.adoc
+++ b/docs/modules/getting-started/pages/get-started-java.adoc
@@ -7,7 +7,7 @@
 
 To complete this tutorial, you need the following:
 
-[cols="1a,1a"]
+[cols="a,a"]
 |===
 |Prerequisites|Useful resources
 

--- a/docs/modules/getting-started/pages/persistence.adoc
+++ b/docs/modules/getting-started/pages/persistence.adoc
@@ -20,7 +20,7 @@ In this tutorial, you will complete the following steps:
 
 To complete this tutorial, you need the following:
 
-[cols="1a,1a"]
+[cols="a,a"]
 |===
 |Prerequisites|Useful resources
 

--- a/docs/modules/getting-started/pages/wan.adoc
+++ b/docs/modules/getting-started/pages/wan.adoc
@@ -22,7 +22,7 @@ In this tutorial, you will complete the following steps:
 
 To complete this tutorial, you need the following:
 
-[cols="1a,1a"]
+[cols="a,a"]
 |===
 |Prerequisites|Useful resources
 

--- a/docs/modules/maintain-cluster/pages/cluster-member-states.adoc
+++ b/docs/modules/maintain-cluster/pages/cluster-member-states.adoc
@@ -13,7 +13,7 @@ You may want to change a cluster's state to do the following:
 You should have a good understanding of data partitioning in Hazelcast clusters. See xref:overview:data-partitioning.adoc[].
 
 .Glossary
-[cols="1e,1a"]
+[cols="e,a"]
 |===
 |Term|Definition
 
@@ -34,7 +34,7 @@ By default, all clusters are in an `ACTIVE` state. In this state, the cluster op
 All other cluster states restrict the operations on a cluster:
 
 .Differences among cluster states
-[cols="1m,1a,1a,1a,1a,2a"]
+[cols="m,a,a,a,a,a"]
 |===
 |State|New members|Migrations|Promotions|Replica sync|Use case
 

--- a/docs/modules/maintain-cluster/pages/monitoring.adoc
+++ b/docs/modules/maintain-cluster/pages/monitoring.adoc
@@ -1056,7 +1056,7 @@ To run the `hz-healthcheck` script:
 
 You can use the following parameters to perform checks and operations on your Hazelcast clusters:
 
-[cols="2,2,5a"]
+[cols="a,a,a"]
 |===
 |Parameter | Default Value | Description
 

--- a/docs/modules/maintain-cluster/pages/rest-api.adoc
+++ b/docs/modules/maintain-cluster/pages/rest-api.adoc
@@ -431,7 +431,7 @@ Also note that the value of `$\{PASSWORD}` in the following calls is checked onl
 the security is xref:security:enabling-jaas.adoc[enabled] in Hazelcast, i.e., if you have Hazelcast Enterprise Edition.
 If the security is disabled, the `$\{PASSWORD}` can be left empty.
 
-[cols="5a"]
+[cols="a"]
 .REST API calls
 |===
 |**Open Source commands**
@@ -594,7 +594,7 @@ hazelcast:
 The following table lists all the endpoints along with the groups they belong to.
 
 .REST Endpoint Groups
-[cols="2a, 1, 5a"]
+[cols="a, a, a"]
 |===
 | Endpoint Group | Default | Endpoints
 

--- a/docs/modules/maintain-cluster/pages/rolling-upgrades.adoc
+++ b/docs/modules/maintain-cluster/pages/rolling-upgrades.adoc
@@ -15,7 +15,7 @@ For example, in version `5.1.0`, `5` is the major version, `1` is the minor vers
 
 [[terminology]]
 .Glossary
-[cols="1e,1a"]
+[cols="e,a"]
 |===
 |Term|Definition
 

--- a/docs/modules/management/pages/cluster-utilities.adoc
+++ b/docs/modules/management/pages/cluster-utilities.adoc
@@ -83,7 +83,7 @@ NOTE: The script `hz-cluster-admin` uses `curl` command and `curl` must be insta
 The script `hz-cluster-admin` takes the following parameters to operate according to your needs.
 If these parameters are not provided, the default values are used.
 
-[cols="2,2,5a"]
+[cols="a,a,a"]
 |===
 |Parameter | Default Value | Description
 

--- a/docs/modules/mapstore/pages/implement-a-mapstore.adoc
+++ b/docs/modules/mapstore/pages/implement-a-mapstore.adoc
@@ -9,7 +9,7 @@ The link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/ma
 
 If you only want to load data from external systems in a map, use the `MapLoader` interface. If you also want to save map entries to an external system, use the `MapStore` interface. 
 
-[cols="1m,5a"]
+[cols="m,a"]
 |===
 |Interface| Description
 

--- a/docs/modules/mapstore/pages/mapstore-triggers.adoc
+++ b/docs/modules/mapstore/pages/mapstore-triggers.adoc
@@ -6,7 +6,7 @@
 NOTE: If the `initial-mode` configuration is set to `LAZY`, the first time any link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/map/IMap.html[map method]
 is called, it triggers the `MapLoader.loadAllKeys()` method.
 
-[cols="1m,5a"]
+[cols="m,a"]
 |===
 |Map method|Description
 


### PR DESCRIPTION
Table format fixes to allow PDF generator to work. Equivalent of the [following commit](https://github.com/hazelcast/hz-docs/commit/1ecde8618f9d82597ea87af02cba52222b60868b#diff-13bc303027308552f30eef99ae04f12e29524f8243141a306ffb5d146702fbf5) for v/5.1