### PR TITLE
DOCS-392_Update_footnote_text

### DIFF
--- a/docs/modules/deploy/pages/versioning-compatibility.adoc
+++ b/docs/modules/deploy/pages/versioning-compatibility.adoc
@@ -60,10 +60,10 @@ Hazelcast Platform has been tested against the following operating systems.
 |Ubuntu
 |✓
 
-|Solarisfootnote:one-off[Tested on demand and not 100% guaranteed (One-off, best-effort support).]
+|Solarisfootnote:one-off[Tested on demand and not 100% guaranteed (One-off, commercially-reasonable efforts support).]
 |✓
 
-|IBM zOSfootnote:IBM[Tested on demand and not 100% guaranteed (One-off, commercially-reasonable efforts support).]
+|IBM zOSfootnote:one-off[]
 |✓
 
 |AIX 7.2footnote:one-off[]


### PR DESCRIPTION
Delete existing footnote 2 and make sure that footnote 3 applies to all 3 OSs (Solaris, zOS and AIX 7.2).

Apply changes to v5.2, v5.1, v5.0.