### PR TITLE
Fix XML config example for custom ByteArraySerializer (5.2)

### DIFF
--- a/docs/modules/serialization/pages/custom-serialization.adoc
+++ b/docs/modules/serialization/pages/custom-serialization.adoc
@@ -178,7 +178,7 @@ XML::
     ...
     <serialization>
         <serializers>
-            <serializer type-class="Employee">EmployeeByteArraySerializer</serializer>
+            <serializer type-class="EmployeeSS" class-name="EmployeeByteArraySerializer" />
         </serializers>
     </serialization>
     ...


### PR DESCRIPTION
Backports #668 to `v/5.2`