### PR TITLE
Fix header styling in compact binary specification document

### DIFF
--- a/docs/modules/ROOT/pages/compact-binary-specification.adoc
+++ b/docs/modules/ROOT/pages/compact-binary-specification.adoc
@@ -30,6 +30,7 @@ You cannot redefine the endianness in Compact Serialization; it is inherited fro
 [cols="1,1,1,1,1,1,1,1,3,1"]
 |===
 |Type |Java |C++ |C# |Python |Node.js |Go |SQL |Description| Fixed Size
+
 |boolean
 |boolean
 |bool


### PR DESCRIPTION
According to https://docs.asciidoctor.org/asciidoc/latest/tables/build-a-basic-table/#add-a-header-row-to-the-table there should be a newline after the header line. 


Should be backported to all other branches that it is backported in the main [PR](https://github.com/hazelcast/hz-docs/pull/628).