### PR TITLE
Fix best-practices.adoc - recommended heap

### DIFF
--- a/docs/modules/cluster-performance/pages/best-practices.adoc
+++ b/docs/modules/cluster-performance/pages/best-practices.adoc
@@ -4,7 +4,7 @@
 == Basic Performance Recommendations
 
 * 8 cores per Hazelcast server instance
-* Minimum of 8 GB RAM per Hazelcast member (if not using the High-Density Memory Store)
+* Maximum of 8 GB RAM per Hazelcast member (if not using the High-Density Memory Store)
 * Dedicated NIC per Hazelcast member
 * Linux—any distribution
 * All members should run within the same subnet


### PR DESCRIPTION
The recommendation is probably "maximum" heap size, rather than "minimum". Especially with the extra info about HD memory.