### PR TITLE
DOCS-408 Jet Job Improvements

### DIFF
--- a/docs/modules/events/pages/distributed-events.adoc
+++ b/docs/modules/events/pages/distributed-events.adoc
@@ -48,3 +48,7 @@ For Hazelcast clients:
 * **Lifecycle Listener**
 * **Membership Listener**
 * **Distributed Object Listener**
+
+For monitoring Hazelcast jobs:
+
+* xref:pipelines:job-monitoring.adoc[Job Status Listener]

--- a/docs/modules/pipelines/pages/job-management.adoc
+++ b/docs/modules/pipelines/pages/job-management.adoc
@@ -155,9 +155,8 @@ Resuming job id=0401-9f77-b9c0-0001, name=hello-world, submissionTime=2020-03-07
 Job resumed.
 ```
 
-To configure a job to be suspended automatically if its
-execution fails, see
-link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/jet/config/JobConfig.html#setSuspendOnFailure(boolean)[JobConfig.setSuspendOnFailure].
+For fault tolerance, streaming jobs are automatically suspended on failure. For more details, see xref:troubleshoot:error-handling.adoc#processing-guarantees[]
+
 --
 SQL:: 
 + 

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -13,16 +13,32 @@ The `JobStatusListener` has several advantages over polling for the job status.
 
 - You can write custom code for execution on status change. For example, triggering an alert or writing the changed status to a dashboard.
 
-- You can also identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error or user canceled. Use the suspension cause to filter out all jobs canceled by a user. 
+- You can also identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error description or requested by a user. 
 
-NOTE: The suspension cause is also displayed on the Jobs page in Management Center.
+NOTE: The reason for the job suspension is also displayed on the Jobs page in Management Center.
 
 === Adding a JobStatusListener
 
 To register the listener for a job, add the following to your client code:
 
 ```java
-addStatusListener(JobStatusListener)
+myJob.addStatusListener(JobStatusListener)
+```
+The following example creates a new job, registers the `JobStatusListener`, and uses a lambda expression to print out status changes to the stdout console, including whether they were requested by a user.
+
+```java
+JetService jet1 = hz1.getJet();
+JobConfig jobConfig = new JobConfig();
+String jobName = "sampleJob";
+jobConfig.setName(jobName);
+Job job = jet1.newJob(p, jobConfig);
+
+job.addStatusListener(event ->
+        System.out.printf("Job status changed: %s -> %s. User requested? %b%n",
+                event.getPreviousStatus(),
+                event.getNewStatus(),
+                event.isUserRequested())
+);
 ```
 
 === Removing a JobStatusListener
@@ -30,5 +46,5 @@ addStatusListener(JobStatusListener)
 To de-register the listener from a job, add the following to your client code:
 
 ```java
-removeStatusListener(JobStatusListener)
+myJob.removeStatusListener(JobStatusListener)
 ```

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -1,5 +1,5 @@
 = Monitoring Jobs
-:description: Monitor the status of streaming jobs to quickly identify job failures for troubleshooting.
+:description: To ensure the reliability of streaming jobs and their workloads, try implementing some basic monitoring. With Hazelcast, you can monitor the status of streaming jobs to quickly identify job failures for troubleshooting.
 
 {description}
 
@@ -9,11 +9,11 @@ There are two ways to monitor for job status changes. You can either poll the `J
 
 == Using a JobStatusListener
 
-The `JobStatusListener` has several advantages. 
+The `JobStatusListener` has several advantages over polling for the job status. 
 
-You can write custom code for execution on status change. For example, triggering an alert or writing the changed status to a dashboard.
+- You can write custom code for execution on status change. For example, triggering an alert or writing the changed status to a dashboard.
 
-You can also identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error or user canceled. Use the suspension cause to filter out all jobs canceled by a user. 
+- You can also identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error or user canceled. Use the suspension cause to filter out all jobs canceled by a user. 
 
 NOTE: The suspension cause is also displayed on the Jobs page in Management Center.
 

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -17,7 +17,7 @@ The `JobStatusListener` has several advantages over polling for the job status.
 
 NOTE: The reasons for job suspensions and failures are also displayed on the Jobs page in Management Center.
 
-The `JobStatusListener` also has a limitation. The listener may be attached to the job after its status changes to `RUNNING`. To cope with this situation, add the following code to your listener.
+The `JobStatusListener` also has a limitation. The listener can be attached to a job at any time after job submission. If the attachment occurs before the job starts, the `RUNNING` status will be caught. If the attachment is delayed, the listener will miss the (initial) notification of the status change. To cope with this situation, add the following to your code:
 
 ```java
 example required

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -22,7 +22,7 @@ NOTE: The reasons for job suspensions and failures are also displayed on the Job
 To register the listener for a job, add the following to your client code:
 
 ```java
-myJob.addStatusListener(JobStatusListener)
+statusListenerId = myJob.addStatusListener(JobStatusListener)
 ```
 The following example creates a new job, registers the `JobStatusListener`, and uses a lambda expression to print out status changes to the stdout console, including whether they were requested by a user.
 

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -1,0 +1,34 @@
+= Monitoring Jobs
+:description: Monitor the status of streaming jobs to quickly identify job failures for troubleshooting.
+
+{description}
+
+== Monitoring for Status Changes
+
+There are two ways to monitor for job status changes. You can either poll the `Job.getStatus()` method separately for each job or add a `JobStatusListener` to your jobs.
+
+== Using a JobStatusListener
+
+The `JobStatusListener` has several advantages. 
+
+You can write custom code for execution on status change. For example, triggering an alert or writing the changed status to a dashboard.
+
+You can also identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error or user canceled. Use the suspension cause to filter out all jobs canceled by a user. 
+
+NOTE: The suspension cause is also displayed on the Jobs page in Management Center.
+
+=== Adding a JobStatusListener
+
+To register the listener for a job, add the following to your client code:
+
+```java
+addStatusListener(JobStatusListener)
+```
+
+=== Removing a JobStatusListener
+
+To de-register the listener from a job, add the following to your client code:
+
+```java
+removeStatusListener(JobStatusListener)
+```

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -15,7 +15,7 @@ The `JobStatusListener` has several advantages over polling for the job status.
 
 - You can identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error description or requested by a user. 
 
-- You can work out which were jobs canceled by a user, by calling the `isUserCancelled();` method. This method returns `true` if the user stopped the job, even though the job status is `FAILED`. 
+- You can also work out which were jobs canceled by a user, by calling the `isUserCancelled();` method. This method returns `true` if the user stopped the job, even though the job status is `FAILED`. 
 
 NOTE: The reasons for job suspensions and failures are also displayed on the Jobs page in Management Center.
 

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -15,8 +15,6 @@ The `JobStatusListener` has several advantages over polling for the job status.
 
 - You can identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error description or requested by a user. 
 
-- You can also work out which were jobs canceled by a user, by calling the `isUserCancelled();` method. This method returns `true` if the user stopped the job, even though the job status is `FAILED`. 
-
 NOTE: The reasons for job suspensions and failures are also displayed on the Jobs page in Management Center.
 
 === Adding a JobStatusListener
@@ -33,7 +31,7 @@ JetService jet1 = hz1.getJet();
 JobConfig jobConfig = new JobConfig();
 String jobName = "sampleJob";
 jobConfig.setName(jobName);
-Job job = jet1.newJob(p, jobConfig);
+Job job = jet1.newJob(pipeline, jobConfig);
 
 job.addStatusListener(event ->
         System.out.printf("Job status changed: %s -> %s. User requested? %b%n",
@@ -48,5 +46,11 @@ job.addStatusListener(event ->
 To de-register the listener from a job, add the following to your client code:
 
 ```java
-myJob.removeStatusListener(JobStatusListener)
+myJob.removeStatusListener(statusListenerId)
 ```
+
+== Monitoring for Canceled Jobs
+
+A job with `FAILED` status may have been canceled by a user. To monitor for canceled jobs, use the `Job.isUserCancelled();` method, which returns `true` if a user stopped the job.
+
+

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -13,9 +13,11 @@ The `JobStatusListener` has several advantages over polling for the job status.
 
 - You can write custom code for execution on status change. For example, triggering an alert or writing the changed status to a dashboard.
 
-- You can also identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error description or requested by a user. 
+- You can identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error description or requested by a user. 
 
-NOTE: The reason for the job suspension is also displayed on the Jobs page in Management Center.
+- You can work out which were jobs canceled by a user, by calling the `isUserCancelled();` method. This method returns `true` if the user stopped the job, even though the job status is `FAILED`. 
+
+NOTE: The reasons for job suspensions and failures are also displayed on the Jobs page in Management Center.
 
 === Adding a JobStatusListener
 

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -51,6 +51,6 @@ myJob.removeStatusListener(statusListenerId)
 
 == Monitoring for Canceled Jobs
 
-A job with `FAILED` status may have been canceled by a user. To monitor for canceled jobs, use the `Job.isUserCancelled();` method, which returns `true` if a user stopped the job.
+A job with `FAILED` status may have been canceled by a user. To monitor for canceled jobs, use the `Job.isUserCancelled()` method, which returns `true` if a user stopped the job.
 
 

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -11,17 +11,14 @@ There are two ways to monitor for job status changes. You can either poll the `J
 
 The `JobStatusListener` has several advantages over polling for the job status. 
 
-- The listener is notified immediately when a status change occurs. To achieve a similar result with polling, you might increase the polling frequency which would decrease performance.  
+- The listener is notified immediately when a status change occurs. To achieve a similar result with polling, you might increase the polling frequency, which would decrease performance.
 
 - You can identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error description or requested by a user. 
 
 NOTE: The reasons for job suspensions and failures are also displayed on the Jobs page in Management Center.
 
-The `JobStatusListener` also has a limitation. The listener can be attached to a job at any time after job submission. If the attachment occurs before the job starts, the `RUNNING` status will be caught. If the attachment is delayed, the listener will miss the (initial) notification of the status change. To cope with this situation, add the following to your code:
+NOTE: The `JobStatusListener` cannot be used to wait for a job to start running since the listener attachment might occur after the job starts running. For such use cases, `assertJobStatusEventually(Job, JobStatus)` should be used as explained in xref:test:testing.adoc#waiting-for-a-job-to-be-in-a-desired-state[Waiting for a job to be in a desired state].
 
-```java
-example required
-```
 === Adding a JobStatusListener
 
 To register the listener for a job, add the following to your client code:

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -17,7 +17,7 @@ The `JobStatusListener` has several advantages over polling for the job status.
 
 NOTE: The reasons for job suspensions and failures are also displayed on the Jobs page in Management Center.
 
-NOTE: The `JobStatusListener` cannot be used to wait for a job to start running since the listener attachment might occur after the job starts running. For such use cases, `assertJobStatusEventually(Job, JobStatus)` should be used as explained in xref:test:testing.adoc#waiting-for-a-job-to-be-in-a-desired-state[Waiting for a job to be in a desired state].
+NOTE: The listener may be attached to a job after it starts. For this reason, you cannot use the `JobStatusListener` to wait for a job to move to the `RUNNING` status. To cope with this situation, use `assertJobStatusEventually(Job, JobStatus)`. See xref:test:testing.adoc#waiting-for-a-job-to-be-in-a-desired-state[Waiting for a Job to be in a Desired State] for more details.
 
 === Adding a JobStatusListener
 

--- a/docs/modules/pipelines/pages/job-monitoring.adoc
+++ b/docs/modules/pipelines/pages/job-monitoring.adoc
@@ -5,18 +5,23 @@
 
 == Monitoring for Status Changes
 
-There are two ways to monitor for job status changes. You can either poll the `Job.getStatus()` method separately for each job or add a `JobStatusListener` to your jobs.
+There are two ways to monitor for job status changes. You can either poll the `Job.getStatus()` method separately for each job or add a `JobStatusListener` to your jobs. In both cases, you can write custom code for execution on status change. For example, triggering an alert or writing the changed status to a dashboard. 
 
 == Using a JobStatusListener
 
 The `JobStatusListener` has several advantages over polling for the job status. 
 
-- You can write custom code for execution on status change. For example, triggering an alert or writing the changed status to a dashboard.
+- The listener is notified immediately when a status change occurs. To achieve a similar result with polling, you might increase the polling frequency which would decrease performance.  
 
 - You can identify jobs in an error state. By default, xref:troubleshoot:error-handling.adoc#processing-guarantees[all streaming jobs are suspended on failure]. When a job moves to the suspended status, the listener is passed a suspension cause; either an error description or requested by a user. 
 
 NOTE: The reasons for job suspensions and failures are also displayed on the Jobs page in Management Center.
 
+The `JobStatusListener` also has a limitation. The listener may be attached to the job after its status changes to `RUNNING`. To cope with this situation, add the following code to your listener.
+
+```java
+example required
+```
 === Adding a JobStatusListener
 
 To register the listener for a job, add the following to your client code:

--- a/docs/modules/pipelines/partials/nav.adoc
+++ b/docs/modules/pipelines/partials/nav.adoc
@@ -33,6 +33,7 @@
 ** xref:pipelines:job-security.adoc[]
 ** xref:pipelines:submitting-jobs.adoc[]
 ** xref:pipelines:job-management.adoc[]
+** xref:pipelines:job-monitoring.adoc[]
 ** xref:pipelines:job-update.adoc[]
 ** xref:pipelines:xa.adoc[]
 

--- a/docs/modules/troubleshoot/pages/error-handling.adoc
+++ b/docs/modules/troubleshoot/pages/error-handling.adoc
@@ -54,19 +54,12 @@ reprocess their input.
 === Processing Guarantees
 
 Streaming jobs with mutable state, those with a xref:fault-tolerance:fault-tolerance.adoc#processing-guarantee-is-a-shared-concern[processing guarantee]
-set, achieve fault tolerance by periodically saving xref:fault-tolerance:fault-tolerance.adoc#distributed-snapshot[recovery snapshots]. When
-such a job fails, not only does its execution stop but also its
-snapshots get deleted. This makes it impossible to resume it without
-loss.
-
-To cope with this situation, you can configure a job to be suspended in
-the case of a failure, instead of failing completely. For details see
-link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/jet/config/JobConfig.html#setSuspendOnFailure(boolean)[`JobConfig.setSuspendOnFailure`]
+set, achieve fault tolerance by periodically saving xref:fault-tolerance:fault-tolerance.adoc#distributed-snapshot[recovery snapshots]. If a streaming job was allowed to fail, the snapshots would be deleted. For this reason, by default all streaming jobs are suspended on failure, instead of failing completely. For more details, see link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/jet/config/JobConfig.html#setSuspendOnFailure(boolean)[`JobConfig.setSuspendOnFailure`]
 and
 link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/jet/Job.html#getSuspensionCause()[`Job.getSuspensionCause`].
 
-A job in the suspended state has preserved its snapshot, and you can
-resume it without loss once you have addressed the root cause of the
+A job in the suspended state has its snapshot preserved, and you can
+resume it without data loss once you have addressed the root cause of the
 failure.
 
 In the open-source version of Hazelcast, this scenario is limited to fixing the

--- a/docs/modules/troubleshoot/pages/error-handling.adoc
+++ b/docs/modules/troubleshoot/pages/error-handling.adoc
@@ -58,6 +58,8 @@ set, achieve fault tolerance by periodically saving xref:fault-tolerance:fault-t
 and
 link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/jet/Job.html#getSuspensionCause()[`Job.getSuspensionCause`].
 
+NOTE: If you use the xref:sql:create-job.adoc#using-a-jobstatuslistener[CREATE JOB statement] to submit a job to your Hazelcast cluster, the job is automatically set to suspend on failure. 
+
 A job in the suspended state has its snapshot preserved, and you can
 resume it without data loss once you have addressed the root cause of the
 failure.


### PR DESCRIPTION
This is an early draft of docs for the Jet job improvements (5.3) for review. See list of JIRAs below.

Questions
- Does the `JobStatusListener` listener need more implementation details. If so, can you provide these?
- Does a new category of listener need to be created for the JobStatusListener? (See https://docs.hazelcast.com/hazelcast/5.3-snapshot/events/distributed-events)

JIRAs
https://hazelcast.atlassian.net/browse/HZ-1606, including:

- https://hazelcast.atlassian.net/browse/HZ-1646
- https://hazelcast.atlassian.net/browse/HZ-1648
- https://hazelcast.atlassian.net/browse/HZ-1350
- https://hazelcast.atlassian.net/browse/HZ-1220

