### PR TITLE
Update map-config.adoc: fixed link to yaml example

### DIFF
--- a/docs/modules/data-structures/pages/map-config.adoc
+++ b/docs/modules/data-structures/pages/map-config.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 ifndef::snapshot[]
 * link:https://github.com/hazelcast/hazelcast/blob/v{full-version}/hazelcast/src/main/resources/hazelcast-full-example.xml[hazelcast-full-example.xml]
-* link:https://github.com/hazelcast/hazelcast/blob/v{full-version}/hazelcast/src/main/resources/hazelcast-full-example.xml[hazelcast-full-example.yaml]
+* link:https://github.com/hazelcast/hazelcast/blob/v{full-version}/hazelcast/src/main/resources/hazelcast-full-example.yaml[hazelcast-full-example.yaml]
 endif::[]
 ====
 


### PR DESCRIPTION
A link to a yaml example referenced an xml one.