### PR TITLE
Update MapStore configuration-guide.adoc

### DIFF
--- a/docs/modules/mapstore/pages/configuration-guide.adoc
+++ b/docs/modules/mapstore/pages/configuration-guide.adoc
@@ -485,11 +485,9 @@ XML::
 ----
 <hazelcast>
   <map name="default">
-    <map-store enabled="true">
+    <map-store enabled="true" initial-mode="LAZY">
       <class-name>com.hazelcast.examples.DummyStore
       </class-name>
-      <initial-mode>LAZY
-      </initial-mode>
     </map-store>
 </hazelcast>
 ----


### PR DESCRIPTION
The MapStore `initial-mode` should be an attribute of the `map-store` element rather than a sub-element as specified [here](https://github.com/hazelcast/hazelcast/blob/9d5bb00710e1aafa7c528d81be43d97bfc7d240f/hazelcast/src/main/resources/hazelcast-config-5.3.xsd#L2026).