### PR TITLE
Add mutualAuthentication field in OpenSSL page

### DIFF
--- a/docs/modules/security/pages/integrating-openssl.adoc
+++ b/docs/modules/security/pages/integrating-openssl.adoc
@@ -191,6 +191,12 @@ that contains a collection of certificates
 * `trustStoreType`: Type of the truststore. Its default value is `JKS`. Another
 commonly used type is the `PKCS12`. Available keystore/truststore types depend on
 your operating system and the Java runtime.
+* `mutualAuthentication`: Mutual authentication configuration. It's empty
+by default which means the client side of connection is not authenticated.
+Available values are:
+** `REQUIRED` - server forces usage of a trusted client certificate
+** `OPTIONAL` - server asks for a client certificate, but it doesn't
+require it
 * `ciphersuites`: Comma-separated list of cipher suite names allowed to be used.
 * `protocol`: Name of the algorithm which is used in your TLS/SSL. Its default
 value is `TLSv1.2`. Available values are:


### PR DESCRIPTION
We probably forgot to add `mutualAuthentication` config field on OpenSSL page