### PR TITLE
Add a note about the write method of the CompactSerializer [API-1948]

### DIFF
--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -624,6 +624,12 @@ will be assigned to it automatically.
 After the configuration registration, Hazelcast will serialize instances of the `Employee`
 class using the `EmployeeSerializer`.
 
+WARNING: Hazelcast uses the `write` method of the `CompactSerializer` to generate a schema
+for Compact serializable classes. Therefore, the `write` method should be repeatable, i.e.
+it should call the same methods of the `CompactWriter` no matter the provided instance. Hence,
+it should not contain any conditional code. Failing to follow this rule might result in undefined
+behavior.
+
 == Supported Types
 
 Compact serialization supports the following list as first class types. Any other type

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -625,10 +625,11 @@ After the configuration registration, Hazelcast will serialize instances of the 
 class using the `EmployeeSerializer`.
 
 WARNING: Hazelcast uses the `write` method of the `CompactSerializer` to generate a schema
-for Compact serializable classes. Therefore, the `write` method should be repeatable, i.e.
-it should call the same methods of the `CompactWriter` no matter the provided instance. Hence,
-it should not contain any conditional code. Failing to follow this rule might result in undefined
-behavior.
+for Compact serializable classes. When you implement the `write` method for this purpose,
+this implementation should be able generate the same schema regardless of the parameters
+you pass; it should not contain any conditional code. This means, your `write` implementation
+should be repeatable, such that it should call the same methods of `CompactWriter` no matter
+the provided instance. Failing to follow this rule might result in an undefined behavior.
 
 == Supported Types
 


### PR DESCRIPTION
We have seen some misuse of the Compact serializer and decided to add a warning about it to make it less likely for our users.