### PR TITLE
Clarify backup related properties for client

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -660,7 +660,7 @@ clientConfig.setBackupAckToClientEnabled(boolean enabled)
 
 You can also fine tune this feature using the following system properties:
 
-* `hazelcast.client.operation.backup.timeout.millis`: If an operation has
+* `hazelcast.client.operation.backup.timeout.millis`: If an operation has sync
 backups, this property specifies how long (in milliseconds) the invocation waits
 for acks from the backup replicas. If acks are not received from some
 of the backups, there will not be any rollback on the other successful replicas.
@@ -2326,7 +2326,7 @@ the preferred way for controlling this setting is xref:maintain-cluster:monitori
 |`hazelcast.client.operation.backup.timeout.millis`
 |5000
 |int
-|If an operation has backups, this property specifies how long the invocation will wait for acks from the backup replicas.
+|If an operation has sync backups, this property specifies how long the invocation will wait for acks from the backup replicas.
 If acks are not received from some backups, there will not be any rollback on other successful replicas.
 
 |`hazelcast.client.operation.fail.on.indeterminate.state`


### PR DESCRIPTION
The client waits for the sync backup acks from replicas. This PR makes this fact more clear in the property documentation.