### PR TITLE
DOCS-524 Remove Striim tutorial

### DIFF
--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -80,9 +80,6 @@ content:
   - url: https://github.com/hazelcast-guides/ecs-embedded
     branches: master
     start_path: docs
-  - url: https://github.com/hazelcast-guides/striim-cdc
-    branches: master
-    start_path: docs
   - url: https://github.com/hazelcast-guides/springboot-tomcat-session-replication
     branches: master
     start_path: docs


### PR DESCRIPTION
Hazelcast no longer partner with Striim so all references to this tutorial should be removed.