### PR TITLE
DOCS-551_Deprecation notice for transactions

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -389,7 +389,16 @@ each distributed data structure in this Reference Manual.
 === Client Transactions
 
 Transactional distributed objects are supported on the client side.
-See the xref:transactions:providing-xa-transactions.adoc[Transactions chapter] on how to use them.
+See xref:transactions:providing-xa-transactions.adoc[Transactions] for more details.
+
+[NOTE]
+.Transactions Support 5.3 onwards 
+====
+An improved version of transactions is in development, and will be available in an upcoming release (5.5).
+
+* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
+* For existing implementations, support will continue until the release of 5.5.
+====
 
 === Async Start and Reconnect Modes
 

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -391,14 +391,7 @@ each distributed data structure in this Reference Manual.
 Transactional distributed objects are supported on the client side.
 See xref:transactions:providing-xa-transactions.adoc[Transactions] for more details.
 
-[NOTE]
-.Transactions Support 5.3 Onwards 
-====
-An improved version of transactions is in development, and will be available in an upcoming release (5.5).
-
-* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
-* For existing implementations, support will continue until the release of 5.5.
-====
+NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs. 
 
 === Async Start and Reconnect Modes
 

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -392,7 +392,7 @@ Transactional distributed objects are supported on the client side.
 See xref:transactions:providing-xa-transactions.adoc[Transactions] for more details.
 
 [NOTE]
-.Transactions Support 5.3 onwards 
+.Transactions Support 5.3 Onwards 
 ====
 An improved version of transactions is in development, and will be available in an upcoming release (5.5).
 

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -391,7 +391,11 @@ each distributed data structure in this Reference Manual.
 Transactional distributed objects are supported on the client side.
 See xref:transactions:providing-xa-transactions.adoc[Transactions] for more details.
 
-NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs. 
+[CAUTION]
+.Deprecation Notice for Transactions
+====
+Hazelcast will deprecate transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+====
 
 === Async Start and Reconnect Modes
 

--- a/docs/modules/cluster-performance/pages/best-practices.adoc
+++ b/docs/modules/cluster-performance/pages/best-practices.adoc
@@ -121,7 +121,11 @@ ICache, IAtomicLong, etc. It cannot be used as a transaction mechanism though. S
 none of the requests are executed. If you want to use an atomic behavior, see  xref:transactions:providing-xa-transactions.adoc[Transactions] for more details.
 The pipelining is just a performance optimization, not a mechanism for atomic behavior.
 
-NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+[CAUTION]
+.Deprecation Notice for Transactions
+====
+Hazelcast will deprecate transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+====
 
 The pipelines are cheap and should frequently be replaced because they accumulate results. It is fine to have a few hundred or
 even a few thousand calls being processed with the pipelining. However, all the responses to all requests are stored in the pipeline

--- a/docs/modules/cluster-performance/pages/best-practices.adoc
+++ b/docs/modules/cluster-performance/pages/best-practices.adoc
@@ -122,7 +122,7 @@ none of the requests are executed. If you want to use an atomic behavior, see  x
 The pipelining is just a performance optimization, not a mechanism for atomic behavior.
 
 [NOTE]
-.Transactions Support 5.3 onwards 
+.Transactions Support 5.3 Onwards 
 ====
 An improved version of transactions is in development, and will be available in an upcoming release (5.5).
 

--- a/docs/modules/cluster-performance/pages/best-practices.adoc
+++ b/docs/modules/cluster-performance/pages/best-practices.adoc
@@ -118,8 +118,17 @@ You can use the pipelining both on the clients and members. You do not need a sp
 
 The pipelining can be used for any asynchronous call. You can use it for IMap asynchronous get/put methods as well as for
 ICache, IAtomicLong, etc. It cannot be used as a transaction mechanism though. So you cannot do some calls and throw away the pipeline and expect that
-none of the requests are executed. If you want to use an atomic behavior, see the xref:transactions:providing-xa-transactions.adoc[Transactions chapter].
+none of the requests are executed. If you want to use an atomic behavior, see  xref:transactions:providing-xa-transactions.adoc[Transactions] for more details.
 The pipelining is just a performance optimization, not a mechanism for atomic behavior.
+
+[NOTE]
+.Transactions Support 5.3 onwards 
+====
+An improved version of transactions is in development, and will be available in an upcoming release (5.5).
+
+* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
+* For existing implementations, support will continue until the release of 5.5.
+====
 
 The pipelines are cheap and should frequently be replaced because they accumulate results. It is fine to have a few hundred or
 even a few thousand calls being processed with the pipelining. However, all the responses to all requests are stored in the pipeline

--- a/docs/modules/cluster-performance/pages/best-practices.adoc
+++ b/docs/modules/cluster-performance/pages/best-practices.adoc
@@ -121,14 +121,7 @@ ICache, IAtomicLong, etc. It cannot be used as a transaction mechanism though. S
 none of the requests are executed. If you want to use an atomic behavior, see  xref:transactions:providing-xa-transactions.adoc[Transactions] for more details.
 The pipelining is just a performance optimization, not a mechanism for atomic behavior.
 
-[NOTE]
-.Transactions Support 5.3 Onwards 
-====
-An improved version of transactions is in development, and will be available in an upcoming release (5.5).
-
-* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
-* For existing implementations, support will continue until the release of 5.5.
-====
+NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
 
 The pipelines are cheap and should frequently be replaced because they accumulate results. It is fine to have a few hundred or
 even a few thousand calls being processed with the pipelining. However, all the responses to all requests are stored in the pipeline

--- a/docs/modules/integrate/pages/jdbc-connector.adoc
+++ b/docs/modules/integrate/pages/jdbc-connector.adoc
@@ -145,7 +145,7 @@ to get more information. This only applies to the JDBC sink, the source
 doesn't use XA transactions.
 
 [NOTE]
-.Transactions Support 5.3 onwards 
+.Transactions Support 5.3 Onwards 
 ====
 An improved version of transactions is in development, and will be available in an upcoming release (5.5).
 

--- a/docs/modules/integrate/pages/jdbc-connector.adoc
+++ b/docs/modules/integrate/pages/jdbc-connector.adoc
@@ -143,3 +143,12 @@ some records will be missing from the target database. To test your
 broker we provide a tool, please go to link:https://github.com/hazelcast/hazelcast-jet-contrib/tree/master/xa-test[XA tests]
 to get more information. This only applies to the JDBC sink, the source
 doesn't use XA transactions.
+
+[NOTE]
+.Transactions Support 5.3 onwards 
+====
+An improved version of transactions is in development, and will be available in an upcoming release (5.5).
+
+* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
+* For existing implementations, support will continue until the release of 5.5.
+====

--- a/docs/modules/integrate/pages/jdbc-connector.adoc
+++ b/docs/modules/integrate/pages/jdbc-connector.adoc
@@ -144,4 +144,8 @@ broker we provide a tool, please go to link:https://github.com/hazelcast/hazelca
 to get more information. This only applies to the JDBC sink, the source
 doesn't use XA transactions.
 
-NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+[CAUTION]
+.Deprecation Notice for Transactions
+====
+Hazelcast will deprecate transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+====

--- a/docs/modules/integrate/pages/jdbc-connector.adoc
+++ b/docs/modules/integrate/pages/jdbc-connector.adoc
@@ -144,11 +144,4 @@ broker we provide a tool, please go to link:https://github.com/hazelcast/hazelca
 to get more information. This only applies to the JDBC sink, the source
 doesn't use XA transactions.
 
-[NOTE]
-.Transactions Support 5.3 Onwards 
-====
-An improved version of transactions is in development, and will be available in an upcoming release (5.5).
-
-* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
-* For existing implementations, support will continue until the release of 5.5.
-====
+NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.

--- a/docs/modules/integrate/pages/jms-connector.adoc
+++ b/docs/modules/integrate/pages/jms-connector.adoc
@@ -177,11 +177,4 @@ tool, please go to link:https://github.com/hazelcast/hazelcast-jet-contrib/tree/
 to get more information. This only applies to JMS sink, the source
 doesn't use XA transactions.
 
-[NOTE]
-.Transactions Support 5.3 Onwards 
-====
-An improved version of transactions is in development, and will be available in an upcoming release (5.5).
-
-* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
-* For existing implementations, support will continue until the release of 5.5.
-====
+NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.

--- a/docs/modules/integrate/pages/jms-connector.adoc
+++ b/docs/modules/integrate/pages/jms-connector.adoc
@@ -176,3 +176,12 @@ messages will be missing from the sink. To test your broker we provide a
 tool, please go to link:https://github.com/hazelcast/hazelcast-jet-contrib/tree/master/xa-test[XA tests]
 to get more information. This only applies to JMS sink, the source
 doesn't use XA transactions.
+
+[NOTE]
+.Transactions Support 5.3 onwards 
+====
+An improved version of transactions is in development, and will be available in an upcoming release (5.5).
+
+* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
+* For existing implementations, support will continue until the release of 5.5.
+====

--- a/docs/modules/integrate/pages/jms-connector.adoc
+++ b/docs/modules/integrate/pages/jms-connector.adoc
@@ -177,4 +177,8 @@ tool, please go to link:https://github.com/hazelcast/hazelcast-jet-contrib/tree/
 to get more information. This only applies to JMS sink, the source
 doesn't use XA transactions.
 
-NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+[CAUTION]
+.Deprecation Notice for Transactions
+====
+Hazelcast will deprecate transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+====

--- a/docs/modules/integrate/pages/jms-connector.adoc
+++ b/docs/modules/integrate/pages/jms-connector.adoc
@@ -178,7 +178,7 @@ to get more information. This only applies to JMS sink, the source
 doesn't use XA transactions.
 
 [NOTE]
-.Transactions Support 5.3 onwards 
+.Transactions Support 5.3 Onwards 
 ====
 An improved version of transactions is in development, and will be available in an upcoming release (5.5).
 

--- a/docs/modules/performance/pages/pipelining.adoc
+++ b/docs/modules/performance/pages/pipelining.adoc
@@ -41,7 +41,7 @@ none of the requests are executed. If you want to use an atomic behavior, see xr
 The pipelining is just a performance optimization, not a mechanism for atomic behavior.
 
 [NOTE]
-.Transactions Support 5.3 onwards 
+.Transactions Support 5.3 Onwards 
 ====
 An improved version of transactions is in development, and will be available in an upcoming release (5.5).
 

--- a/docs/modules/performance/pages/pipelining.adoc
+++ b/docs/modules/performance/pages/pipelining.adoc
@@ -40,14 +40,7 @@ ICache, IAtomicLong, etc. It cannot be used as a transaction mechanism though. S
 none of the requests are executed. If you want to use an atomic behavior, see xref:transactions:providing-xa-transactions.adoc[Transactions] for more details.
 The pipelining is just a performance optimization, not a mechanism for atomic behavior.
 
-[NOTE]
-.Transactions Support 5.3 Onwards 
-====
-An improved version of transactions is in development, and will be available in an upcoming release (5.5).
-
-* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
-* For existing implementations, support will continue until the release of 5.5.
-====
+NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
 
 The pipelines are cheap and should frequently be replaced because they accumulate results. It is fine to have a few hundred or
 even a few thousand calls being processed with the pipelining. However, all the responses to all requests are stored in the pipeline

--- a/docs/modules/performance/pages/pipelining.adoc
+++ b/docs/modules/performance/pages/pipelining.adoc
@@ -40,7 +40,11 @@ ICache, IAtomicLong, etc. It cannot be used as a transaction mechanism though. S
 none of the requests are executed. If you want to use an atomic behavior, see xref:transactions:providing-xa-transactions.adoc[Transactions] for more details.
 The pipelining is just a performance optimization, not a mechanism for atomic behavior.
 
-NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+[CAUTION]
+.Deprecation Notice for Transactions
+====
+Hazelcast will deprecate transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+====
 
 The pipelines are cheap and should frequently be replaced because they accumulate results. It is fine to have a few hundred or
 even a few thousand calls being processed with the pipelining. However, all the responses to all requests are stored in the pipeline

--- a/docs/modules/performance/pages/pipelining.adoc
+++ b/docs/modules/performance/pages/pipelining.adoc
@@ -37,8 +37,17 @@ You can use the pipelining both on the clients and members. You do not need a sp
 
 The pipelining can be used for any asynchronous call. You can use it for IMap asynchronous get/put methods as well as for
 ICache, IAtomicLong, etc. It cannot be used as a transaction mechanism though. So you cannot do some calls and throw away the pipeline and expect that
-none of the requests are executed. If you want to use an atomic behavior, see the xref:transactions:providing-xa-transactions.adoc[Transactions chapter].
+none of the requests are executed. If you want to use an atomic behavior, see xref:transactions:providing-xa-transactions.adoc[Transactions] for more details.
 The pipelining is just a performance optimization, not a mechanism for atomic behavior.
+
+[NOTE]
+.Transactions Support 5.3 onwards 
+====
+An improved version of transactions is in development, and will be available in an upcoming release (5.5).
+
+* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
+* For existing implementations, support will continue until the release of 5.5.
+====
 
 The pipelines are cheap and should frequently be replaced because they accumulate results. It is fine to have a few hundred or
 even a few thousand calls being processed with the pipelining. However, all the responses to all requests are stored in the pipeline

--- a/docs/modules/release-notes/pages/5-3-0.adoc
+++ b/docs/modules/release-notes/pages/5-3-0.adoc
@@ -216,7 +216,7 @@ https://github.com/hazelcast/hazelcast/issues/22256[#22256]
 
 == Upcoming Deprecations
 
-Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+Hazelcast will deprecate transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
 
 == Contributors
 

--- a/docs/modules/release-notes/pages/5-3-0.adoc
+++ b/docs/modules/release-notes/pages/5-3-0.adoc
@@ -216,7 +216,7 @@ https://github.com/hazelcast/hazelcast/issues/22256[#22256]
 
 == Upcoming Deprecations
 
-An improved version of transactions is in development, and will be available in an upcoming release (5.5). Support for existing transaction implementations will continue until the release of 5.5. 
+Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
 
 == Contributors
 

--- a/docs/modules/release-notes/pages/5-3-0.adoc
+++ b/docs/modules/release-notes/pages/5-3-0.adoc
@@ -214,6 +214,10 @@ https://github.com/hazelcast/hazelcast/pull/22279[#22279]
 in Kubernetes cluster with Istio Envoy Proxy enabled.
 https://github.com/hazelcast/hazelcast/issues/22256[#22256]
 
+== Upcoming Deprecations
+
+An improved version of transactions is in development, and will be available in an upcoming release (5.5). Support for existing transaction implementations will continue until the release of 5.5. 
+
 == Contributors
 
 We would like to thank the contributors from our open source community

--- a/docs/modules/transactions/pages/creating-a-transaction-interface.adoc
+++ b/docs/modules/transactions/pages/creating-a-transaction-interface.adoc
@@ -1,13 +1,6 @@
 = Creating a Transaction Interface
 
-[NOTE]
-.Transactions Support 5.3 Onwards 
-====
-An improved version of transactions is in development, and will be available in an upcoming release (5.5).
-
-* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
-* For existing implementations, support will continue until the release of 5.5.
-====
+NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
 
 You create a `TransactionContext` object to begin, commit and rollback
 a transaction. You can obtain transaction-aware instances of queues,

--- a/docs/modules/transactions/pages/creating-a-transaction-interface.adoc
+++ b/docs/modules/transactions/pages/creating-a-transaction-interface.adoc
@@ -1,7 +1,7 @@
 = Creating a Transaction Interface
 
 [NOTE]
-.Transactions Support 5.3 onwards 
+.Transactions Support 5.3 Onwards 
 ====
 An improved version of transactions is in development, and will be available in an upcoming release (5.5).
 

--- a/docs/modules/transactions/pages/creating-a-transaction-interface.adoc
+++ b/docs/modules/transactions/pages/creating-a-transaction-interface.adoc
@@ -1,5 +1,14 @@
 = Creating a Transaction Interface
 
+[NOTE]
+.Transactions Support 5.3 onwards 
+====
+An improved version of transactions is in development, and will be available in an upcoming release (5.5).
+
+* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
+* For existing implementations, support will continue until the release of 5.5.
+====
+
 You create a `TransactionContext` object to begin, commit and rollback
 a transaction. You can obtain transaction-aware instances of queues,
 maps, sets, lists and multimaps via `TransactionContext`, work with

--- a/docs/modules/transactions/pages/creating-a-transaction-interface.adoc
+++ b/docs/modules/transactions/pages/creating-a-transaction-interface.adoc
@@ -1,6 +1,10 @@
 = Creating a Transaction Interface
 
-NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+[CAUTION]
+.Deprecation Notice for Transactions
+====
+Hazelcast will deprecate transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+====
 
 You create a `TransactionContext` object to begin, commit and rollback
 a transaction. You can obtain transaction-aware instances of queues,

--- a/docs/modules/transactions/pages/providing-xa-transactions.adoc
+++ b/docs/modules/transactions/pages/providing-xa-transactions.adoc
@@ -1,7 +1,7 @@
 = Providing XA Transactions
 
 [NOTE]
-.Transactions Support 5.3 onwards 
+.Transactions Support 5.3 Onwards 
 ====
 An improved version of transactions is in development, and will be available in an upcoming release (5.5).
 

--- a/docs/modules/transactions/pages/providing-xa-transactions.adoc
+++ b/docs/modules/transactions/pages/providing-xa-transactions.adoc
@@ -1,6 +1,10 @@
 = Providing XA Transactions
 
-NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+[CAUTION]
+.Deprecation Notice for Transactions
+====
+Hazelcast will deprecate transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
+====
 
 XA describes the interface between the global transaction manager and the
 local resource manager. XA allows multiple resources (such as databases,

--- a/docs/modules/transactions/pages/providing-xa-transactions.adoc
+++ b/docs/modules/transactions/pages/providing-xa-transactions.adoc
@@ -1,5 +1,14 @@
 = Providing XA Transactions
 
+[NOTE]
+.Transactions Support 5.3 onwards 
+====
+An improved version of transactions is in development, and will be available in an upcoming release (5.5).
+
+* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
+* For existing implementations, support will continue until the release of 5.5.
+====
+
 XA describes the interface between the global transaction manager and the
 local resource manager. XA allows multiple resources (such as databases,
 application servers, message queues and transactional caches) to be accessed

--- a/docs/modules/transactions/pages/providing-xa-transactions.adoc
+++ b/docs/modules/transactions/pages/providing-xa-transactions.adoc
@@ -1,13 +1,6 @@
 = Providing XA Transactions
 
-[NOTE]
-.Transactions Support 5.3 Onwards 
-====
-An improved version of transactions is in development, and will be available in an upcoming release (5.5).
-
-* For new transaction implementations, Hazelcast recommends waiting for the 5.5 release.
-* For existing implementations, support will continue until the release of 5.5.
-====
+NOTE: Hazelcast will no longer support transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
 
 XA describes the interface between the global transaction manager and the
 local resource manager. XA allows multiple resources (such as databases,


### PR DESCRIPTION
Added the following note to transaction sections and added a equivalent line of text to the release notes. Future 5.4 release notes will also need to be updated.

**Deprecation Notice for Transactions**
Hazelcast will deprecate transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.

Closes [DOCS-551](https://hazelcast.atlassian.net/browse/DOCS-551)

[DOCS-551]: https://hazelcast.atlassian.net/browse/DOCS-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ