### PR TITLE
DOCS-547 End of support for Elasticsearch 6

### DIFF
--- a/docs/modules/integrate/pages/elasticsearch-connector.adoc
+++ b/docs/modules/integrate/pages/elasticsearch-connector.adoc
@@ -14,6 +14,8 @@ To use this connector in the slim distribution, you must have one of the followi
 
 Each module includes an Elasticsearch client that's compatible with the given major version of Elasticsearch. The connector API is the same between different versions, apart from a few minor differences where we surface the API of Elasticsearch client. See the link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/jet/elastic/ElasticSources.html[Javadoc] for any such differences.
 
+CAUTION: Elastic discontinued support for Elasticsearch 6 in 2022. As a result, Hazelcast will also end support for this version in the upcoming release (5.4), when the version 6 module and documentation will be removed.
+
 == Permissions
 [.enterprise]*Enterprise*
 

--- a/docs/modules/release-notes/pages/5-3-0.adoc
+++ b/docs/modules/release-notes/pages/5-3-0.adoc
@@ -216,7 +216,7 @@ https://github.com/hazelcast/hazelcast/issues/22256[#22256]
 
 == Upcoming Deprecations
 
-Hazelcast will end support for Elasticsearch 6 in the upcoming release (5.4). This will affect customers using the xref:integrate:elasticsearch-connector.adoc#installing-the-connector[version 6 module of the Elasticsearch connector].
+Hazelcast will end support for Elasticsearch 6 in the upcoming release (5.4). This will affect you if you are using the xref:integrate:elasticsearch-connector.adoc#installing-the-connector[version 6 module of the Elasticsearch connector].
 
 == Contributors
 

--- a/docs/modules/release-notes/pages/5-3-0.adoc
+++ b/docs/modules/release-notes/pages/5-3-0.adoc
@@ -214,6 +214,10 @@ https://github.com/hazelcast/hazelcast/pull/22279[#22279]
 in Kubernetes cluster with Istio Envoy Proxy enabled.
 https://github.com/hazelcast/hazelcast/issues/22256[#22256]
 
+== Upcoming Deprecations
+
+Hazelcast will end support for Elasticsearch 6 in the upcoming release (5.4). This will affect customers using the xref:integrate:elasticsearch-connector.adoc#installing-the-connector[version 6 module of the Elasticsearch connector].
+
 == Contributors
 
 We would like to thank the contributors from our open source community


### PR DESCRIPTION
Note and line in release notes for end of elasticsearch 6 support.

Closes ticket [DOCS-547](https://hazelcast.atlassian.net/jira/software/projects/DOCS/boards/60?selectedIssue=DOCS-547)

[DOCS-547]: https://hazelcast.atlassian.net/browse/DOCS-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ