### PR TITLE
Move "Improving Query Performance" just after Predicates API

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -16,17 +16,17 @@ include::mapstore:partial$nav.adoc[]
 --
 include::pipelines:partial$nav.adoc[]
 include::query:partial$nav.adoc[]
-* SQL
-+
---
-include::sql:partial$nav.adoc[]
---
 * Improving Query Performance
 ** xref:query:indexing-maps.adoc[]
 ** xref:performance:data-affinity.adoc[]
 ** xref:performance:caching-deserialized-values.adoc[]
 ** xref:performance:near-cache.adoc[]
 ** xref:data-structures:preventing-out-of-memory.adoc[]
+* SQL
++
+--
+include::sql:partial$nav.adoc[]
+--
 include::integrate:partial$nav.adoc[]
 include::spring:partial$nav.adoc[]
 include::computing:partial$nav.adoc[]


### PR DESCRIPTION
"Improving Query Performance" describes mostly optimizations specific to raw IMap usage or Predicate API. Some of them make sense also for SQL, but many are not used in SQL. SQL has its own section about performance.