### PR TITLE
Update Persistence metrics documentation

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -1061,7 +1061,7 @@ with the master member.
 
 |`persistence.liveTombstones`
 |count
-|Number of live tombstones in the xref:storage:persistence.adoc[persistent store]; this and the below Persistence metrics have the following format when output: `hz_persistence_<INSTANCE_NAME>_<CHUNK_MANAGER_ID>_<metric>`
+|Number of live tombstones in the xref:storage:persistence.adoc[persistent store]
 
 |`persistence.liveValues`
 |count


### PR DESCRIPTION
The metric naming convention for `persistence` metrics has changed such that the "store name" (`<INSTANCE_NAME>_<CHUNK_MANAGER_ID>`) is declared as a discriminator now, not part of the static metric name.

Refer to https://github.com/hazelcast/hazelcast-enterprise/pull/6160 for more details.