### PR TITLE
Add WAN eviction cluster properties [HZ-2619]

### DIFF
--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -1164,6 +1164,16 @@ master starts forming the cluster.
 |Defines the pending invocation threshold for the WAN replication implementation. Exceeding this threshold on a WAN consumer member makes the member to delay the WAN acknowledgment,
 thus slowing down the WAN publishers on the source side that send WAN events to the given WAN consumer. Setting this value to negative disables the acknowledgement delaying feature.
 
+|`hazelcast.wan.replicate.imap.evictions`
+|false
+|bool
+|Specifies whether `IMap` objects should replicate entry evictions over WAN to target clusters. When enabled, ALL evictions (size- or expiration-driven as well as manual invocation) are replicated to targets, so this should be used with caution. Setting this property to true does not guarantee data consistency between two clusters.
+
+|`hazelcast.wan.replicate.icache.evictions`
+|false
+|bool
+|Specifies whether `ICache` objects should replicate entry evictions over WAN to target clusters. When enabled, ALL evictions (size- or expiration-driven as well as manual invocation) are replicated to targets, so this should be used with caution. Setting this property to true does not guarantee data consistency between two clusters.
+
 |`tcp.channels.per.connection`
 | 1
 | int

--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -1167,12 +1167,12 @@ thus slowing down the WAN publishers on the source side that send WAN events to 
 |`hazelcast.wan.replicate.imap.evictions`
 |false
 |bool
-|Specifies whether `IMap` objects should replicate entry evictions over WAN to target clusters. When enabled, ALL evictions (size- or expiration-driven as well as manual invocation) are replicated to targets, so this should be used with caution. Setting this property to true does not guarantee data consistency between two clusters.
+|Specifies whether `IMap` objects replicate entry evictions over WAN to target clusters. Use this property with caution. When enabled, _ALL_ evictions, including size or expiration-driven evictions and manual invocations are replicated to target clusters. Setting this property to `true` does not guarantee data consistency between clusters.
 
 |`hazelcast.wan.replicate.icache.evictions`
 |false
 |bool
-|Specifies whether `ICache` objects should replicate entry evictions over WAN to target clusters. When enabled, ALL evictions (size- or expiration-driven as well as manual invocation) are replicated to targets, so this should be used with caution. Setting this property to true does not guarantee data consistency between two clusters.
+|Specifies whether `ICache` objects replicate entry evictions over WAN to target clusters. Use this property with caution. When enabled, _ALL_ evictions, including size or expiration-driven evictions and manual invocations are replicated to target clusters. Setting this property to `true` does not guarantee data consistency between clusters.
 
 |`tcp.channels.per.connection`
 | 1

--- a/docs/modules/wan/pages/tuning.adoc
+++ b/docs/modules/wan/pages/tuning.adoc
@@ -757,16 +757,17 @@ hazelcast:
 
 == Replicating `IMap`/`ICache` Evictions
 
-The replication of `IMap` and `ICache` evictions to other clusters can be enabled by setting the relevant xref:ROOT:system-properties.adoc[Hazelcast
-system property] to `true`. The replication of eviction events can be useful for maintaining stronger data consistency
-between clusters, however it should be used with caution: source clusters with eviction enabled should replicate to
-target clusters which **do not** have eviction enabled. If both source and target clusters have eviction enabled, due
-to eviction being a largely local operation, it is possible for a target cluster to evict data that has not been
-evicted on the source cluster. When replication is used for data consistency on a failover deployment, it is important
-that eviction is re-enabled on the standby cluster when it becomes active.
+The replication of eviction events can be useful for maintaining stronger data consistency between clusters. However,
+you should use it with caution; source clusters with eviction enabled should replicate to target clusters which **do
+not** have eviction enabled. If both source and target clusters have eviction enabled, due to eviction being a largely
+local operation, it is possible for a target cluster to evict data that has not been evicted on the source cluster.
+When replication is used for data consistency on a failover deployment, it is important that eviction is re-enabled on
+the standby cluster when it becomes active.
 
 While enabling this functionality can help to maintain stronger data consistency over WAN between clusters, it is
-important to note that this **does not guarantee full data consistency**.
+important to note that this **does not guarantee full data consistency**. You can enable the replication of `IMap` and 
+`ICache` evictions to the other clusters by setting the `hazelcast.wan.replicate.imap/icache.evictions` property to
+`true`, as shown below.
 
 [tabs] 
 ==== 
@@ -797,4 +798,5 @@ hazelcast:
       hazelcast.wan.replicate.icache.evictions: true
     ...
 ----
+You can find the specifications of these properties in xref:ROOT:system-properties.adoc[System Properties].
 ====

--- a/docs/modules/wan/pages/tuning.adoc
+++ b/docs/modules/wan/pages/tuning.adoc
@@ -754,3 +754,47 @@ hazelcast:
         use-endpoint-private-address: true
 ----
 ====
+
+== Replicating `IMap`/`ICache` Evictions
+
+The replication of `IMap` and `ICache` evictions to other clusters can be enabled by setting the relevant xref:ROOT:system-properties.adoc[Hazelcast
+system property] to `true`. The replication of eviction events can be useful for maintaining stronger data consistency
+between clusters, however it should be used with caution: source clusters with eviction enabled should replicate to
+target clusters which **do not** have eviction enabled. If both source and target clusters have eviction enabled, due
+to eviction being a largely local operation, it is possible for a target cluster to evict data that has not been
+evicted on the source cluster. When replication is used for data consistency on a failover deployment, it is important
+that eviction is re-enabled on the standby cluster when it becomes active.
+
+While enabling this functionality can help to maintain stronger data consistency over WAN between clusters, it is
+important to note that this **does not guarantee full data consistency**.
+
+[tabs] 
+==== 
+XML:: 
++ 
+-- 
+[source,xml]
+----
+<hazelcast>
+    ...
+    <properties>
+        <property name="hazelcast.wan.replicate.imap.evictions">true</property>
+        <property name="hazelcast.wan.replicate.icache.evictions">true</property>
+    </properties>
+    ...
+</hazelcast>
+----
+--
+
+YAML::
++
+[source,yaml]
+----
+hazelcast:
+    ...
+    properties:
+      hazelcast.wan.replicate.imap.evictions: true
+      hazelcast.wan.replicate.icache.evictions: true
+    ...
+----
+====


### PR DESCRIPTION
We recently added 2 new `ClusterProperty` entries for 5.4 related to the replication of eviction events with `IMap` and `ICache`.

Relevant PR: https://github.com/hazelcast/hazelcast/pull/24941