### PR TITLE
DOCS-597 Update Predicate Deprecation Statement

### DIFF
--- a/docs/modules/query/pages/overview.adoc
+++ b/docs/modules/query/pages/overview.adoc
@@ -21,7 +21,7 @@ Hazelcast offers the following tools for running distributed queries, depending 
 
 - xref:predicate-overview.adoc[Predicates API]: Use a client API to query your cluster for data in map entries.
 +
-NOTE: The Predicates API will be deprecated in an upcoming release. The recommended way to query data in Hazelcast is xref:sql:sql-overview.adoc[SQL].
+NOTE: In addition to the Java-based Predicates API, Hazelcast also supports xref:sql:sql-overview.adoc[SQL] statements and functions, and streaming SQL queries.
 
 [cols="h,a,a"]
 .Comparison of SQL and the Predicates API

--- a/docs/modules/query/pages/predicate-overview.adoc
+++ b/docs/modules/query/pages/predicate-overview.adoc
@@ -1,6 +1,6 @@
 = Predicates API
 :description: The Predicates API is a programming interface for querying data in Hazelcast, which is similar to the Java Persistence Query Language (JPQL).
-:page-deprecation-message: The Predicates API will be deprecated in an upcoming release. The recommended way to query data in Hazelcast is xref:sql:sql-overview.adoc[SQL].
+:page-deprecation-message: In addition to the Java-based Predicates API, Hazelcast also supports xref:sql:sql-overview.adoc[SQL] statements and functions, and streaming SQL queries.
 :page-aliases: querying-maps-predicates.adoc, custom-attributes.adoc, querying-collections-and-arrays.adoc, aggregations.adoc, projections.adoc, continuous-query-cache.adoc
 
 {description}


### PR DESCRIPTION
Updated predicate deprecation statement to the following:

_In addition to the Java-based Predicates API, Hazelcast also supports [SQL](https://deploy-preview-809--hardcore-allen-f5257d.netlify.app/hazelcast/5.4-snapshot/sql/sql-overview.html) statements and functions, and streaming SQL queries._

https://deploy-preview-809--hardcore-allen-f5257d.netlify.app/hazelcast/5.4-snapshot/query/predicate-overview
https://deploy-preview-809--hardcore-allen-f5257d.netlify.app/hazelcast/5.4-snapshot/query/overview