### PR TITLE
DOCS-601 Caution message for SQL catalog persistence

### DIFF
--- a/docs/modules/storage/pages/configuring-persistence.adoc
+++ b/docs/modules/storage/pages/configuring-persistence.adoc
@@ -1266,6 +1266,8 @@ config.addMapConfig(mapConfig);
 
 Use the following configuration to enable the cluster-wide persistence of SQL metadata to disk. With persistence enabled, SQL mappings, data connections, and views are retained after cluster restarts.
 
+CAUTION: Once persistence of SQL metadata is enabled on a cluster, you cannot disable it.
+
 [tabs] 
 ==== 
 XML:: 


### PR DESCRIPTION
Added Caution admonition to warn users that SQL catalog persistence is permanently enabled.