### PR TITLE
DOCS-604 Correct examples

### DIFF
--- a/docs/modules/sql/pages/create-data-connection.adoc
+++ b/docs/modules/sql/pages/create-data-connection.adoc
@@ -96,7 +96,7 @@ TYPE JDBC
 SHARED
 OPTIONS (
   'jdbcUrl'='jdbc:mysql://dummy:3306',
-  'username'='xyz',
+  'user'='xyz',
   'password'='xyz');
 ----
 
@@ -126,7 +126,7 @@ TYPE JDBC
 SHARED
 OPTIONS (
   'jdbcUrl'='jdbc:mysql://dummy:3306',
-  'username'='xyz',
+  'user'='xyz',
   'password'='xyz');
 ----
 


### PR DESCRIPTION
Update incorrect examples.

CREATE DATA CONNECTION IF NOT EXISTS myDatabase
TYPE JDBC
SHARED
OPTIONS (
  'jdbcUrl'='jdbc:mysql://dummy:3306',
  **'username'**='xyz',
  'password'='xyz');
  
  to 
  
CREATE DATA CONNECTION IF NOT EXISTS myDatabase
TYPE JDBC
SHARED
OPTIONS (
  'jdbcUrl'='jdbc:mysql://dummy:3306',
  **'user'**='xyz',
  'password'='xyz');