### PR TITLE
Fix the IPv6 note in Network Configuration page

### DIFF
--- a/docs/modules/clusters/pages/network-configuration.adoc
+++ b/docs/modules/clusters/pages/network-configuration.adoc
@@ -588,9 +588,9 @@ system property.
 See also additional http://docs.oracle.com/javase/1.5.0/docs/guide/net/ipv6_guide/[details on IPv6 support in Java^].
 
 NOTE: IPv6 support has been switched off by default, since some platforms have issues
-using the IPv6 stack. Some other platforms such as Amazon AWS have no support at all.
-To enable IPv6 support, just set configuration property `hazelcast.prefer.ipv4.stack`
-to *false*. See the xref:ROOT:system-properties.adoc[System Properties appendix] for details.
+using the IPv6 stack. Some other platforms have no support at all. To enable IPv6 support,
+just set configuration property `hazelcast.prefer.ipv4.stack` to *false*.
+See the xref:ROOT:system-properties.adoc[System Properties appendix] for details.
 
 [[member-address-provides-spi]]
 == Member Address Provider SPI

--- a/docs/modules/clusters/pages/network-configuration.adoc
+++ b/docs/modules/clusters/pages/network-configuration.adoc
@@ -587,9 +587,9 @@ system property.
 
 See also additional http://docs.oracle.com/javase/1.5.0/docs/guide/net/ipv6_guide/[details on IPv6 support in Java^].
 
-NOTE: IPv6 support has been switched off by default, since some platforms have issues
-using the IPv6 stack. Some other platforms have no support at all. To enable IPv6 support,
-just set configuration property `hazelcast.prefer.ipv4.stack` to *false*.
+NOTE: By default, IPv6 support has been switched off. Some platforms have issues
+using the IPv6 stack. Other platforms have no IPv6 support at all. To enable IPv6 support,
+just set the configuration property `hazelcast.prefer.ipv4.stack` to `false`.
 See the xref:ROOT:system-properties.adoc[System Properties appendix] for details.
 
 [[member-address-provides-spi]]


### PR DESCRIPTION
AWS supports IPv6-only networking as of 2021
https://aws.amazon.com/vpc/ipv6/