### PR TITLE
DOCS-568 Product Renaming

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -30,7 +30,7 @@ asciidoc:
     idseparator: '-'
     # Variables used in the docs
     page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9
-    hazelcast-cloud: Viridian
+    hazelcast-cloud: Viridian Cloud
   extensions:
     - ./docs-tabs-library/tabs-block.js
     - asciidoctor-kroki

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -27,7 +27,7 @@ asciidoc:
     idseparator: '-'
     # Variables used in the docs
     page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9
-    hazelcast-cloud: Viridian
+    hazelcast-cloud: Viridian Cloud
   extensions:
     - ./docs-tabs-library/tabs-block.js
     - asciidoctor-kroki

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -1041,8 +1041,8 @@ know which clients they can trust: see the xref:security:tls-ssl.adoc#mutual-aut
 
 ==== Configuring Hazelcast {hazelcast-cloud}
 
-You can connect your Java client to a {hazelcast-cloud} Serverless cluster which is hosted on link:{url-cloud-signup}[Hazelcast {hazelcast-cloud} Managed Services].
-For this, you simply enable Hazelcast {hazelcast-cloud} and specify the cluster's discovery token provided while creating the cluster; this allows the cluster to discover your clients.
+You can connect your Java client to a {hazelcast-cloud} Standard cluster which is hosted on link:{url-cloud-signup}[{hazelcast-cloud}].
+For this, you simply enable {hazelcast-cloud} and specify the cluster's discovery token provided while creating the cluster; this allows the cluster to discover your clients.
 See the following example configurations.
 
 Declarative Configuration:
@@ -1092,10 +1092,9 @@ networkConfig.setSSLConfig(new SSLConfig().setEnabled(true));
 HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
 ----
 
-Hazelcast {hazelcast-cloud} is disabled for the Java client, by default (`enabled` attribute is `false`).
+{hazelcast-cloud} is disabled for the Java client, by default (`enabled` attribute is `false`).
 
-See xref:cloud:ROOT:overview.adoc[]
-for more information about Hazelcast {hazelcast-cloud} Managed Services.
+See xref:cloud:ROOT:overview.adoc[Hazelcast {hazelcast-cloud}] for more information about {hazelcast-cloud}.
 
 NOTE: Since this is a REST based discovery, you need to enable the REST listener service.
 See the xref:clients:rest.adoc#using-the-rest-endpoint-groups[REST Endpoint Groups section] on how to enable REST endpoints.
@@ -2194,7 +2193,7 @@ The table below lists the client configuration properties with their description
 |`hazelcast.client.cloud.discovery.token`
 |
 |long
-|Token to use when discovering the cluster via Hazelcast {hazelcast-cloud}.
+|Token to use when discovering the cluster via {hazelcast-cloud}.
 
 |`hazelcast.client.concurrent.window.ms`
 |100

--- a/docs/modules/deploy/pages/choosing-a-deployment-option.adoc
+++ b/docs/modules/deploy/pages/choosing-a-deployment-option.adoc
@@ -8,7 +8,7 @@ You can deploy Hazelcast in two topologies, depending on where you want the Haze
 - *Embedded mode:* Hazelcast members run in the same Java process as your application.
 - *Client/server mode:* Hazelcast members run remotely outside your application, allowing you to scale them independently and connect to them through any of the supported clients.
 
-TIP: If you don't want to deploy your own self-managed cluster, try link:{url-cloud-signup}[Hazelcast {hazelcast-cloud} Managed Services] for free.
+TIP: If you don't want to deploy your own self-managed cluster, try link:{url-cloud-signup}[Hazelcast {hazelcast-cloud}].
 
 == Comparing Topologies
 

--- a/docs/modules/deploy/pages/deploying-in-cloud.adoc
+++ b/docs/modules/deploy/pages/deploying-in-cloud.adoc
@@ -1,5 +1,5 @@
 = Public Clouds
-:description: Deploy a Hazelcast cluster in cloud environments including Hazelcast {hazelcast-cloud} Managed Services, Amazon AWS, Google Cloud Platform, and Azure.
+:description: Deploy a Hazelcast cluster in cloud environments including Hazelcast {hazelcast-cloud}, Amazon AWS, Google Cloud Platform, and Azure.
 
 {description}
 
@@ -8,11 +8,11 @@ All these environments support the following features:
 - Allow members to discover each other automatically without static IP configuration.
 - Prevent data loss by creating partition backups in other Availability Zones (AZ).
 
-== Hazelcast {hazelcast-cloud} Managed Services
+== Hazelcast {hazelcast-cloud}
 
-Deploy a Hazelcast application on xref:cloud:ROOT:overview.adoc[Hazelcast {hazelcast-cloud} Managed Services].
+Deploy a Hazelcast application on xref:cloud:ROOT:overview.adoc[Hazelcast {hazelcast-cloud}].
 
-Learn more about xref:cloud:ROOT:developer-guide.adoc[developing applications for Hazelcast {hazelcast-cloud}]. 
+Learn more about xref:cloud:ROOT:developer-guide.adoc[developing applications for {hazelcast-cloud}]. 
 
 
 [[hazelcast-cloud-discovery-plugins-aws]]

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -201,7 +201,7 @@ To install Hazelcast with Java, you can use one of the following:
 // tag::maven[]
 Hazelcast runs on Java, which means you can add it as a dependency in your Java project.
 
-The Java package includes both a member API and a Java client API. The member API is for xref:deploy:choosing-a-deployment-option.adoc[embedded topologies] where you want to deploy and manage a cluster in the same Java Virtual Machine (JVM) as your applications. The Java client is for connecting to an existing member in a client/server topology, such as xref:cloud:ROOT:overview.adoc[Hazelcast {hazelcast-cloud} Managed Services].
+The Java package includes both a member API and a Java client API. The member API is for xref:deploy:choosing-a-deployment-option.adoc[embedded topologies] where you want to deploy and manage a cluster in the same Java Virtual Machine (JVM) as your applications. The Java client is for connecting to an existing member in a client/server topology, such as xref:cloud:ROOT:overview.adoc[Hazelcast {hazelcast-cloud}].
 
 . Download and install a xref:deploy:supported-jvms.adoc[supported JDK].
 +

--- a/docs/modules/release-notes/pages/5-3-0.adoc
+++ b/docs/modules/release-notes/pages/5-3-0.adoc
@@ -14,7 +14,7 @@ without the need of a Kafka cluster.
 * Renamed the `DataLinkFactory` interface as `DataConnection`.
 https://github.com/hazelcast/hazelcast/pull/24224[#24224]
 * Changed the default cloud coordinator URL from `coordinator.hazelcast.cloud` to `api.viridian.hazelcast.com`.
-The default configuration now connects to https://viridian.hazelcast.com/sign-in?next=/[Hazelcast Viridian^] instead of Hazelcast Cloud.
+The default configuration now connects to https://viridian.hazelcast.com/sign-in?next=/[Hazelcast Viridian Cloud^] instead of Hazelcast Cloud.
 If you want to continue accessing your Hazelcast Cloud clusters, you need to set the `hazelcast.client.cloud.url` property to `https://coordinator.hazelcast.cloud` in your configuration.
 https://github.com/hazelcast/hazelcast/pull/23290[#23290]
 


### PR DESCRIPTION
Renaming from 

Hazelcast Viridian to Viridian Cloud.

First mention on a page or to product set uses the full product name Hazelcast Viridian Cloud.

Viridian Cloud Standard replaces Serverless.

I will raise another PR for v/5.0 as the content is slightly different.