### PR TITLE
Fix System Properties reference position under Eviction in WAN Tuning

### DIFF
--- a/docs/modules/wan/pages/tuning.adoc
+++ b/docs/modules/wan/pages/tuning.adoc
@@ -798,5 +798,5 @@ hazelcast:
       hazelcast.wan.replicate.icache.evictions: true
     ...
 ----
-You can find the specifications of these properties in xref:ROOT:system-properties.adoc[System Properties].
 ====
+You can find the specifications of these properties in xref:ROOT:system-properties.adoc[System Properties].


### PR DESCRIPTION
The reference is currently embedded within the XML config example when it should be separate.