### PR TITLE
[CN-207] Add a note on external connectivity where NodePorts are used as public IPs in Kubernetes plugin 

### DIFF
--- a/docs/modules/kubernetes/pages/kubernetes-auto-discovery.adoc
+++ b/docs/modules/kubernetes/pages/kubernetes-auto-discovery.adoc
@@ -103,6 +103,8 @@ NOTE: If you don't specify `service-name` and fall back to a `namespace` only di
 * `pod-label-name`, `pod-label-value`: pod label and value used to tag Pods, which together form the Hazelcast cluster. These properties can support multiple comma-separated values. For example: "label-1,label-2". You must use the same number of elements in `pod-label-name` as `pod-label-value`. 
 * `resolve-not-ready-addresses`: if set to `true`, it checks also the addresses of Pods which are not ready; `true` by default
 * `expose-externally`: if set to `true`, it fails fast if an external address cannot be found for each member; if set to `false`, it does not check for external member addresses; by default it tries to resolve external addresses but fails silently
++
+NOTE: If your service type is `NodePort`, there might be connectivity problems from outside to the Kubernetes cluster. Therefore, it's crucial to verify that NodePort IPs are externally accessible.
 * `service-per-pod-label-name`, `service-per-pod-label-value`: service label and value used to tag services that expose each Hazelcast member with a separate Kubernetes service (for connecting Hazelcast Smart Client running outside the Kubernetes cluster)
 * `use-node-name-as-external-address`: if set to `true`, uses the node name to connect to a `NodePort` service instead of looking up the external IP using the API; `false` by default
 * `kubernetes-api-retries`: number of retries in case of issues while connecting to Kubernetes API; defaults to `3` 


### PR DESCRIPTION
Add a note on external connectivity where NodePorts are used as public IPs in Kubernetes plugin.