### PR TITLE
Fixed typo in XML tag for CP group-size

### DIFF
--- a/docs/modules/cp-subsystem/pages/configuration.adoc
+++ b/docs/modules/cp-subsystem/pages/configuration.adoc
@@ -247,7 +247,7 @@ XML::
 ----
 <hazelcast>
   <cp-subsystem>
-    <group-size>7</grou-size>
+    <group-size>7</group-size>
   </cp-subsystem>
 </hazelcast>
 ----


### PR DESCRIPTION
Fixed a typo in the XML closing tag for CP `group-size`