### PR TITLE
Clarify partition migration timing metric includes unsuccessful migrations

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -997,7 +997,7 @@ with the master member.
 
 |`partitions.elapsedMigrationTime`
 |ns
-|Total elapsed time from start of migration tasks to their completion on the latest repartitioning round
+|Total elapsed time from the start of migration tasks to their completion (successful or otherwise) on the latest repartitioning round
 
 |`partitions.lastRepartitionTime`
 |ms
@@ -1057,7 +1057,7 @@ with the master member.
 
 |`partitions.totalElapsedMigrationTime`
 |ns
-|Total elapsed time from start of migration tasks to their completion since the beginning
+|Total elapsed time from the start of migration tasks to their completion (successful or otherwise) since the beginning
 
 |`persistence.liveTombstones`
 |count


### PR DESCRIPTION
Following on from the discussion [this issue](https://github.com/hazelcast/hazelcast/pull/25292#issuecomment-1705374524), completed != successful.

Fixes [#25164](https://github.com/hazelcast/hazelcast/issues/25164) / [HZ-2939](https://hazelcast.atlassian.net/browse/HZ-2939)

[HZ-2939]: https://hazelcast.atlassian.net/browse/HZ-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ