### PR TITLE
`kubernetes-auto-discovery` typo

### DIFF
--- a/docs/modules/kubernetes/pages/kubernetes-auto-discovery.adoc
+++ b/docs/modules/kubernetes/pages/kubernetes-auto-discovery.adoc
@@ -345,7 +345,7 @@ For the complete example, please check link:https://guides.hazelcast.org/kuberne
 
 === Outside Kubernetes Cluster
 
-If your Hazelcast cluster is deployed on Kubernetes, but your Hazelcast client is in a completely different network, then it can connect only through the public Internet. This requires exposing each Hazelast member pod with a dedicated NodePort or LoadBalancer Kubernetes service. For details and a complete example, please check link:https://guides.hazelcast.org/kubernetes-external-client/[Hazelcast Guides: Connect External Hazelcast Client to Kubernetes].
+If your Hazelcast cluster is deployed on Kubernetes, but your Hazelcast client is in a completely different network, then it can connect only through the public Internet. This requires exposing each Hazelcast member pod with a dedicated NodePort or LoadBalancer Kubernetes service. For details and a complete example, please check link:https://guides.hazelcast.org/kubernetes-external-client/[Hazelcast Guides: Connect External Hazelcast Client to Kubernetes].
 
 == Running Hazelcast Enterprise with Persistence under Kubernetes
 [.enterprise]*Enterprise*


### PR DESCRIPTION
`Hazelast` should be `Hazelcast`.