### PR TITLE
WAN additions & Advanced Features tweaks [HZ-3386]

### DIFF
--- a/docs/modules/wan/pages/advanced-features.adoc
+++ b/docs/modules/wan/pages/advanced-features.adoc
@@ -9,7 +9,7 @@ This section provides information on how to do the following:
 * xref:advanced-features.adoc#event-filtering-api[Use the Event Filtering API for WAN replication events]
 * xref:advanced-features.adoc#implementing-a-custom-wan-publisher[Implement your own Custom WAN Publisher]
 * xref:advanced-features.adoc#customizing-wan-event-processing-on-passivetarget-cluster[Customize WAN event processing on target clusters]
-* xref:advanced-features.adoc#securing-wan-connections[Secure connections used for WAN replication]
+* xref:advanced-features.adoc#securing-the-connections-for-wan-replication[Secure connections used for WAN replication]
 
 == Synchronizing WAN Clusters
 

--- a/docs/modules/wan/pages/advanced-features.adoc
+++ b/docs/modules/wan/pages/advanced-features.adoc
@@ -13,8 +13,8 @@ This section provides information on how to do the following:
 
 == Synchronizing WAN Clusters
 
-WAN Replication replicates data structure mutation events that happen on the source
-cluster as they occur. The events are queued up, collected in a batch
+WAN Replication creates a replica of data structure mutation events as they occur on 
+the source cluster. The events are queued up, collected in a batch
 and sent to the target cluster to be applied, without any user interaction.
 
 However, Hazelcast clusters connected over WAN may become out-of-sync for various reasons,

--- a/docs/modules/wan/pages/advanced-features.adoc
+++ b/docs/modules/wan/pages/advanced-features.adoc
@@ -18,31 +18,31 @@ cluster as they occur. The events are queued up, collected in a batch
 and sent to the target cluster to be applied, without any user interaction.
 
 However, Hazelcast clusters connected over WAN may become out-of-sync for various reasons,
-including but not limited to the following:
+including but not limited to:
 
 * Member failures
 * Concurrent updates
-* Target cluster starts up with no data
-* Target cluster experiences issues and some operations fail
+* Target cluster starts with no data
+* Target cluster experiences issues that result in the failure of one or more operations
 * Two sides disconnect and the in-memory buffer of the source
 cluster becomes full (the behavior in this case is xref:tuning.adoc#queue-full-behavior[configurable])
-* The WAN link can't keep up with a burst that the source cluster experiences
+* The WAN linkcannot keep up with a burst experienced by the source cluster
 and its in-memory buffer gets full (the behavior in this case is xref:tuning.adoc#queue-full-behavior[configurable])
-* Split-brain scenario in source clusters where both brains are 
-still able to communicate with WAN target clusters
+* Split-brain scenario in source clusters where both brains can 
+still communicate with WAN target clusters
 
 As well as failures such as the examples above, data can become out-of-sync
 after manual interventions such as cluster restarts or failover of one cluster
-to another (i.e. disaster recovery). **It is recommended to synchronize all
-WAN replicated data after any situations such as these**.
+to another (for example disaster recovery). **After any such situation, you are
+advised to synchronize all WAN replicated data.**.
 
-Hazelcast offers the following options to overcome this out-of-sync issue and
-synchronize your WAN replicated clusters:
+To overcome this out-of-sync issue, you can use either of the following approaches
+to synchronize your WAN replicated clusters:
 
 * Full synchronization
 * Delta synchronization
 
-The following sections describe each in detail. 
+These approaches are described in the following sections.
 
 [[synchronizing-wan-target-cluster]]
 == Full WAN Synchronization

--- a/docs/modules/wan/pages/advanced-features.adoc
+++ b/docs/modules/wan/pages/advanced-features.adoc
@@ -2,35 +2,47 @@
 [[wr-advanced]]
 :page-enterprise: true
 
-This section describes how you can synchronize your WAN replicated clusters,
-change their configurations dynamically and intercept WAN replication events using
-the event filtering API.
+This section provides information on how to do the following:
+
+* xref:advanced-features.adoc#synchronizing-wan-clusters[Synchronize WAN Clusters]
+* xref:advanced-features.adoc#dynamically-adding-wan-publishers[Dynamically add WAN Publishers at runtime]
+* xref:advanced-features.adoc#event-filtering-api[Use the Event Filtering API for WAN replication events]
+* xref:advanced-features.adoc#implementing-a-custom-wan-publisher[Implement your own Custom WAN Publisher]
+* xref:advanced-features.adoc#customizing-wan-event-processing-on-passivetarget-cluster[Customize WAN event processing on target clusters]
+* xref:advanced-features.adoc#securing-wan-connections[Secure connections used for WAN replication]
 
 == Synchronizing WAN Clusters
 
-WAN Replication replicates mutation events that happen on the source
-cluster as they happen. The events are queued up, collected in a batch
+WAN Replication replicates data structure mutation events that happen on the source
+cluster as they occur. The events are queued up, collected in a batch
 and sent to the target cluster to be applied, without any user interaction.
 
-However, Hazelcast clusters connected over WAN may become out-of-sync because of various reasons
+However, Hazelcast clusters connected over WAN may become out-of-sync for various reasons,
 including but not limited to the following:
 
 * Member failures
 * Concurrent updates
-* Target cluster freshly starts with no data
-* Target cluster experiences problems and some operations fail
+* Target cluster starts up with no data
+* Target cluster experiences issues and some operations fail
 * Two sides disconnect and the in-memory buffer of the source
-cluster gets full (the behavior in this case is xref:tuning.adoc#queue-full-behavior[configurable])
-* The WAN link can't keep up with the burst that the source cluster experiences
+cluster becomes full (the behavior in this case is xref:tuning.adoc#queue-full-behavior[configurable])
+* The WAN link can't keep up with a burst that the source cluster experiences
 and its in-memory buffer gets full (the behavior in this case is xref:tuning.adoc#queue-full-behavior[configurable])
+* Split-brain scenario in source clusters where both brains are 
+still able to communicate with WAN target clusters
 
-To overcome this out-of-sync issue, you have the
-following options to synchronize your WAN replicated clusters:
+As well as failures such as the examples above, data can become out-of-sync
+after manual interventions such as cluster restarts or failover of one cluster
+to another (i.e. disaster recovery). **It is recommended to synchronize all
+WAN replicated data after any situations such as these**.
+
+Hazelcast offers the following options to overcome this out-of-sync issue and
+synchronize your WAN replicated clusters:
 
 * Full synchronization
 * Delta synchronization
 
-The following sections describe each. 
+The following sections describe each in detail. 
 
 [[synchronizing-wan-target-cluster]]
 == Full WAN Synchronization

--- a/docs/modules/wan/pages/advanced-features.adoc
+++ b/docs/modules/wan/pages/advanced-features.adoc
@@ -26,7 +26,7 @@ including but not limited to:
 * Target cluster experiences issues that result in the failure of one or more operations
 * Two sides disconnect and the in-memory buffer of the source
 cluster becomes full (the behavior in this case is xref:tuning.adoc#queue-full-behavior[configurable])
-* The WAN linkcannot keep up with a burst experienced by the source cluster
+* The WAN link cannot keep up with a burst experienced by the source cluster
 and its in-memory buffer gets full (the behavior in this case is xref:tuning.adoc#queue-full-behavior[configurable])
 * Split-brain scenario in source clusters where both brains can 
 still communicate with WAN target clusters

--- a/docs/modules/wan/pages/modes.adoc
+++ b/docs/modules/wan/pages/modes.adoc
@@ -18,6 +18,7 @@ using active-active mode instead.
 * [[active-active]]**Active-Active:** Every cluster is equal, each cluster replicates to all other clusters.
 This is normally used to connect different clients to different clusters for the sake of
 the shortest path between client and server, hence gaining increased performance. An example use case would be geographically
-distributed applications. When using this mode of replication, if the same key is modified on multiple clusters, the data across
-all clusters will eventually match that of the last replicated transcation; this includes metadata such as expiry information
-if relevant.
+distributed applications. If the same key is modified on multiple clusters when using this mode of replication, data -
+including any relevant metadata such as expiry information - across all clusters eventually matches the last replicated transaction,
+assuming a transparent WAN merging policy.
+

--- a/docs/modules/wan/pages/modes.adoc
+++ b/docs/modules/wan/pages/modes.adoc
@@ -18,4 +18,6 @@ using active-active mode instead.
 * [[active-active]]**Active-Active:** Every cluster is equal, each cluster replicates to all other clusters.
 This is normally used to connect different clients to different clusters for the sake of
 the shortest path between client and server, hence gaining increased performance. An example use case would be geographically
-distributed applications.
+distributed applications. When using this mode of replication, if the same key is modified on multiple clusters, the data across
+all clusters will eventually match that of the last replicated transcation; this includes metadata such as expiry information
+if relevant.


### PR DESCRIPTION
This PR makes the following changes:

- Add some extra details on active-active replication results for concurrent key changes
- Rework introduction paragraph for Advanced Features section; it was missing information, and since "Advanced Features" covers a variety of very different topics, it was most useful to have a contents table style hyperlink list imo; allows people to find the information they need quickly
- Made some grammatical changes to the "Synchronizing WAN Clusters" section
- Added split-brain scenario as potential cause of out-of-sync WAN data
- Added specific wording to recommend invocation of synchronizations after out-of-sync scenarios such as examples listed

Although not included in this PR, I think there is an argument to be made for separating the entire "Synchronizing WAN Clusters" section out into its own page, standalone from "Advanced Features" - imo knowledge of synchronization is an essential part of using WAN replication properly (understanding its shortfalls and how to correct when they occur), and it shouldn't be buried under "Advanced Features". What do you think @hazelcast/documentation?

Jira https://hazelcast.atlassian.net/browse/HZ-3386