### PR TITLE
DOC-646 Broken Heading Fix

### DIFF
--- a/docs/modules/security/pages/native-client-security.adoc
+++ b/docs/modules/security/pages/native-client-security.adoc
@@ -1345,6 +1345,7 @@ connector:
 
 WARNING: To protect external systems from being reached by external connectors (JDBC, Mongo, S3, ...), use other means than Hazelcast client permissions.
 Traditionally, this is done by enabling authentication on the external system and/or setting up firewall rules.
+
 === SQL Permission
 
 You can give clients permission to use the following xref:sql:sql-statements.adoc[SQL statements]:


### PR DESCRIPTION
The SQL Permission heading had a missing blank line before it. This meant that it shows as === SQL Permission as part of the preceding warning.

Added blank line to fix the display of the heading.