### PR TITLE
Simplifying supported JDK content.

### DIFF
--- a/docs/modules/deploy/pages/versioning-compatibility.adoc
+++ b/docs/modules/deploy/pages/versioning-compatibility.adoc
@@ -125,9 +125,7 @@ Hazelcast Platform has been tested against the following operating systems.
 
 == Supported Java Virtual Machines
 
-Hazelcast runs on Java, so it needs a Java Virtual Machine (JVM). Hazelcast supports the latest and long-term support (LTS) versions of the Java Runtime Environment (JRE). However, some JVMs may not be compatible with Hazelcast.
-
-Hazelcast Platform has been tested against the following JVMs. It may run on other JVMs which are not listed here.
+Hazelcast Platform runs on Java, and supports the following JDKs. It may run on other JDK distributions which are not listed here.
 
 // tag::supported-jvms[]
 [options="header"]
@@ -179,8 +177,6 @@ Hazelcast Platform has been tested against the following JVMs. It may run on oth
 
 |===
 // end::supported-jvms[]
-
-WARNING: Hazelcast does not support JDK 8 as runtime for Hazelcast 5.3.x and later releases.
 
 == Compatibility Guarantees
 


### PR DESCRIPTION
* No need to mention "latest and LTS" since we are saying "we support the following JDK versions".
* Removed the JDK 8 warning since this version (`main`) of content belongs to 5.4.
* Removed "may not be compatible" information. If there is a clear replacement for "some JVMs", I will we happy to re-add it with specific information.