### PR TITLE
CPGroupAvailabilityEvent Publication on Graceful Shutdown [HZ-3118]

### DIFF
--- a/docs/modules/cp-subsystem/pages/management.adoc
+++ b/docs/modules/cp-subsystem/pages/management.adoc
@@ -215,7 +215,7 @@ hazelcast-client:
 or it loses the majority completely.
 
 In general, the availability decreases when a CP member becomes unreachable because of a process crash,
-network partition, or out-of-memory error. Once a member is declared unavailable
+network partition, out-of-memory error or upon a graceful shutdown. Once a member is declared unavailable
 by the failure detector, that member is removed from the cluster.
 If it is also a CP member, a `CPGroupAvailabilityEvent` is fired for each CP group that member belongs to.
 


### PR DESCRIPTION
Adds a note to include the fact that the CPGroupAvailabilityEvent is now also published upon a graceful shutdown.