### PR TITLE
Fix Platform versions in antora.yml to 5.3.5

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,9 +8,9 @@ display_version: '5.3'
 asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
-    full-version: '5.3.2'
+    full-version: '5.3.5'
     # The snapshot version for installing with brew
-    version-brew: '5.3.2'
+    version-brew: '5.3.5'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true
     page-toclevels: 1@


### PR DESCRIPTION
We have to manually update versions as the release pipeline code simply increments from previous version in the file. Manual intervention is required as we are skipping 5.3.3 and 5.3.4 release

Fixes: https://hazelcast.atlassian.net/browse/HZ-3546