### PR TITLE
Update: no requirement to enable compact serialization

### DIFF
--- a/docs/modules/serialization/pages/serialization.adoc
+++ b/docs/modules/serialization/pages/serialization.adoc
@@ -144,7 +144,7 @@ If parent class search fails, all interfaces implemented by the class are also c
 . If the above check fails, then Hazelcast checks if it is an instance of `java.io.Serializable` or
 `java.io.Externalizable` and a Global Serializer is not registered with Java Serialization Override feature.
 . If the above check fails, Hazelcast uses the registered Global Serializer if one exists.
-. If the above check fails, and the xref:compact-serialization.adoc[Compact Serialization] is enabled, then Hazelcast tries to extract a schema out of the Object's class xref:compact-serialization.adoc#using-compact-serialization-with-zero-configuration[automatically], if possible.
+. If the above check fails, then Hazelcast tries to extract a schema out of the Object's class xref:compact-serialization.adoc#using-compact-serialization-with-zero-configuration[automatically], if possible.
 
 If all the above checks fail, then serialization fails.
 When a class implements multiple interfaces, the above steps are important


### PR DESCRIPTION
Starting with Hazelcast 5.2, when Compact serialization graduated from beta, there is no longer an `enabled` flag in `CompactSerializationConfig` - it is always enabled. See also https://github.com/hazelcast/hazelcast/pull/21997.

 - [ ] backport to 5.2
 - [ ] forward port to latest 5.4-snapshot docs