### PR TITLE
Manually create release 5.3.6 branch from v5.3.5 [HZ-3673][v/5.3]

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,9 +8,9 @@ display_version: '5.3'
 asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
-    full-version: '5.3.5'
+    full-version: '5.3.6'
     # The snapshot version for installing with brew
-    version-brew: '5.3.5'
+    version-brew: '5.3.6'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true
     page-toclevels: 1@


### PR DESCRIPTION
Manually create release branch 5.3.6 from v5.3.5 and update versions in docs/antora.yml 

Fixes: [HZ-3673]

[HZ-3673]: https://hazelcast.atlassian.net/browse/HZ-3673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ