### PR TITLE
Update data-migration-tool.adoc

### DIFF
--- a/docs/modules/migrate/pages/data-migration-tool.adoc
+++ b/docs/modules/migrate/pages/data-migration-tool.adoc
@@ -109,8 +109,8 @@ Run the following Docker command to start a one-member target cluster.
 
 [source,shell]
 ----
-docker run -e HZ_NETWORK_PORT_PORT=5901 -p 127.0.0.1:5901:5901 
-           -e HZ_LICENSEKEY="<license>" <1>
+docker run -e HZ_NETWORK_PORT_PORT=5901 -p 127.0.0.1:5901:5901 \
+           -e HZ_LICENSEKEY="<license>" \ <1>
            -e HZ_CLUSTERNAME=target hazelcast/hazelcast-enterprise:{full-version}-slim <2>
 ----
 <1> If you don't have a Hazelcast Enterprise license key, you can either use a Hazelcast Viridian https://docs.hazelcast.com/cloud/free-trial[trial cluster] or request a xref:getting-started:enterprise-overview.adoc#step-2-get-your-enterprise-license[trial license].


### PR DESCRIPTION
Adds backslashes to multi-line target cluster creation command to allow copy-paste and run.