### PR TITLE
Fix broken code formatting

### DIFF
--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -88,7 +88,7 @@ For example, you can execute the below command on one member (i.e. listening on 
 
 And you can execute the below command on the other member.
 
-`iperf -c` *`<IP address>`* `-d -p 5701`
+`iperf -c *``<IP address>``* -d -p 5701`
 
 The output should include connection information, such as the IP addresses, transfer speed and bandwidth.
 Otherwise, if the output says `No route to host`, it means a network connection problem exists.

--- a/docs/modules/query/pages/predicate-overview.adoc
+++ b/docs/modules/query/pages/predicate-overview.adoc
@@ -198,7 +198,7 @@ xref:sql-overview.adoc[] for more information.
 
 SQL-like predicates support the following syntax:
 
-**AND/OR:** `<expression> AND <expression> AND <expression>... `
+**AND/OR:** `<expression> AND <expression> AND <expression>...`
 
 * `active AND age>30`
 * `active=false OR age = 45 OR name = 'Joe'`


### PR DESCRIPTION
Ensure that code blocks are properly rendered:
- remove trailing spaces
    - ![image](https://github.com/hazelcast/hz-docs/assets/8626721/d587a825-3875-4c65-8b6e-f9500d3d1280)
- escape backticks
    - ![image](https://github.com/hazelcast/hz-docs/assets/8626721/3d018cfc-45bf-4851-8ac1-09236358c9dd)
