### PR TITLE
Add note about compact serialization not supported

### DIFF
--- a/docs/modules/migrate/pages/data-migration-tool.adoc
+++ b/docs/modules/migrate/pages/data-migration-tool.adoc
@@ -19,7 +19,7 @@ The DMT is typically used in the following situations:
 
 . If you want to avoid downtime, use an in-place rolling upgrade instead of the DMT tool. For further information on upgrading without interrupting the operation of the cluster, see the xref:maintain-cluster:rolling-upgrades.adoc[Rolling Upgrades] topic.
 
-. The DMT does not support migrating data serialized with Compact Serialization. Support for Compact Serialization is planned for the next release.
+. The DMT does not support migrating data serialized with xref:serialization:compact-serialization.adoc[Compact Serialization]. Support for Compact Serialization is planned for the next release.
 ====
 
 The DMT can be run on Mac, Linux, and Windows Operating Systems.

--- a/docs/modules/migrate/pages/data-migration-tool.adoc
+++ b/docs/modules/migrate/pages/data-migration-tool.adoc
@@ -18,6 +18,8 @@ The DMT is typically used in the following situations:
 . You cannot use the DMT to upgrade or migrate from IMDG 3.12.x. If you are upgrading from IMDG 3.12.x, see the xref:upgrading-from-imdg-3.adoc[Upgrading from IMDG 3.12.x] topic. If migrating from IMDG 3.12.x, see the xref:migration-tool-imdg.adoc[Migrating Data from IMDG 3.12.x] topic. 
 
 . If you want to avoid downtime, use an in-place rolling upgrade instead of the DMT tool. For further information on upgrading without interrupting the operation of the cluster, see the xref:maintain-cluster:rolling-upgrades.adoc[Rolling Upgrades] topic.
+
+. The DMT does not support migrating data serialized with Compact Serialization. Support for Compact Serialization is planned for the next release.
 ====
 
 The DMT can be run on Mac, Linux, and Windows Operating Systems.


### PR DESCRIPTION
There is a precondition about compact serialization that should hold all the time in a cluster: before putting any compact data into the cluster, the schema of it has to be replicated in the cluster. Otherwise, some errors like SchemaNotFoundException can happen. In phase 1, (the current version) we don't migrate compact schemas. The user can migrate their compact data but it can lead to errors. 

I mention that compact serialization data migration is not supported due to this in our phase 1 documentation

I think we should backport this to 5.3, help me do that pls. 

