### PR TITLE
Embedded Avro Schema for Pipeline API [HZ-2773]

### DIFF
--- a/docs/modules/integrate/pages/kafka-connector.adoc
+++ b/docs/modules/integrate/pages/kafka-connector.adoc
@@ -106,7 +106,7 @@ how to serialize/deserialize the record internally.
 == Avro Schema
 To use an Avro schema for `GenericRecord`, you must provide the following as parameters for the Kafka producer and/or consumer:
 
-* The schema
+* JSON representation of Avro schema
 * A HazelcastKafkaAvroSerializer serialization class
 * A HazelcastKafkaAvroDeserializer deserialization class
 
@@ -114,21 +114,23 @@ The process will utilize the schema from properties, disregarding the schema fro
 
 The parameters can be specified as shown in the following examples.
 
-Example consumer parameters:
+Example source parameters:
 ```java
 properties.put("key.deserializer", HazelcastKafkaAvroDeserializer.class);
 properties.put("value.deserializer", HazelcastKafkaAvroDeserializer.class);
-properties.put("keyAvroSchema", keyAvroSchema);
-properties.put("valueAvroSchema", valueAvroSchema);
+properties.put("keyAvroSchema", "{"type":"record","name":"key","namespace":"schema","fields":[{"name":"key","type":["null","int"],"default":null}]}");
+properties.put("valueAvroSchema", "{"type":"record","name":"value","namespace":"schema","fields":[{"name":"value","type":["null","string"],"default":null}]}");
 ```
 
-Example producer parameters:
+Example sink parameters:
 ```java
 properties.put("key.serializer", HazelcastKafkaAvroSerializer.class);
 properties.put("value.serializer", HazelcastKafkaAvroSerializer.class);
-properties.put("keyAvroSchema", keyAvroSchema);
-properties.put("valueAvroSchema", valueAvroSchema);
+properties.put("keyAvroSchema", "{"type":"record","name":"key","namespace":"schema","fields":[{"name":"key","type":["null","int"],"default":null}]}");
+properties.put("valueAvroSchema", "{"type":"record","name":"value","namespace":"schema","fields":[{"name":"value","type":["null","string"],"default":null}]}");
 ```
+
+Keep in mind that you can use different serializer\deserializer for key and value.
 
 == Version Compatibility
 

--- a/docs/modules/integrate/pages/kafka-connector.adoc
+++ b/docs/modules/integrate/pages/kafka-connector.adoc
@@ -103,7 +103,7 @@ properties.put("schema.registry.url", schemaRegistryUrl);
 Keep in mind that once the record deserialized, Jet still needs to know
 how to serialize/deserialize the record internally.
 
-== Avro Schema
+== Explicit Avro Schema
 To use an Avro schema for `GenericRecord`, you must provide the following as parameters for the Kafka source and/or sink:
 
 * JSON representation of Avro schema
@@ -118,16 +118,16 @@ Example source parameters:
 ```java
 properties.put("key.deserializer", HazelcastKafkaAvroDeserializer.class);
 properties.put("value.deserializer", HazelcastKafkaAvroDeserializer.class);
-properties.put("keyAvroSchema", "{"type":"record","name":"key","namespace":"schema","fields":[{"name":"key","type":["null","int"],"default":null}]}");
-properties.put("valueAvroSchema", "{"type":"record","name":"value","namespace":"schema","fields":[{"name":"value","type":["null","string"],"default":null}]}");
+properties.put("keyAvroSchema", "{\"type\":\"record\",\"name\":\"key\",\"namespace\":\"schema\",\"fields\":[{\"name\":\"key\",\"type\":[\"null\",\"int\"],\"default\":null}]}");
+properties.put("valueAvroSchema", "{\"type\":\"record\",\"name\":\"value\",\"namespace\":\"schema\",\"fields\":[{\"name\":\"value\",\"type\":[\"null\",\"string\"],\"default\":null}]}");
 ```
 
 Example sink parameters:
 ```java
 properties.put("key.serializer", HazelcastKafkaAvroSerializer.class);
 properties.put("value.serializer", HazelcastKafkaAvroSerializer.class);
-properties.put("keyAvroSchema", "{"type":"record","name":"key","namespace":"schema","fields":[{"name":"key","type":["null","int"],"default":null}]}");
-properties.put("valueAvroSchema", "{"type":"record","name":"value","namespace":"schema","fields":[{"name":"value","type":["null","string"],"default":null}]}");
+properties.put("keyAvroSchema", "{\"type\":\"record\",\"name\":\"key\",\"namespace\":\"schema\",\"fields\":[{\"name\":\"key\",\"type\":[\"null\",\"int\"],\"default\":null}]}");
+properties.put("valueAvroSchema", "{\"type\":\"record\",\"name\":\"value\",\"namespace\":\"schema\",\"fields\":[{\"name\":\"value\",\"type\":[\"null\",\"string\"],\"default\":null}]}");
 ```
 
 Keep in mind that you can use different serializer/deserializer for key and value.

--- a/docs/modules/integrate/pages/kafka-connector.adoc
+++ b/docs/modules/integrate/pages/kafka-connector.adoc
@@ -130,7 +130,7 @@ properties.put("keyAvroSchema", "{"type":"record","name":"key","namespace":"sche
 properties.put("valueAvroSchema", "{"type":"record","name":"value","namespace":"schema","fields":[{"name":"value","type":["null","string"],"default":null}]}");
 ```
 
-Keep in mind that you can use different serializer\deserializer for key and value.
+Keep in mind that you can use different serializer/deserializer for key and value.
 
 == Version Compatibility
 

--- a/docs/modules/integrate/pages/kafka-connector.adoc
+++ b/docs/modules/integrate/pages/kafka-connector.adoc
@@ -103,6 +103,25 @@ properties.put("schema.registry.url", schemaRegistryUrl);
 Keep in mind that once the record deserialized, Jet still needs to know
 how to serialize/deserialize the record internally.
 
+== Embedded Avro Schema
+It is possible to employ an embedded Avro schema for GeneralRecord by providing the schema as a parameter for Kafka producer/consumer, along with a HazelcastAvro serialization and deserialization class.
+
+Example of producer parameters:
+```java
+properties.put("key.deserializer", HazelcastKafkaAvroDeserializer.class);
+properties.put("value.deserializer", HazelcastKafkaAvroDeserializer.class);
+properties.put("keyAvroSchema", keyAvroSchema);
+properties.put("valueAvroSchema", valueAvroSchema);
+```
+
+Example of consumer parameters:
+```java
+properties.put("key.serializer", HazelcastKafkaAvroDeserializer.class);
+properties.put("value.serializer", HazelcastKafkaAvroDeserializer.class);
+properties.put("keyAvroSchema", keyAvroSchema);
+properties.put("valueAvroSchema", valueAvroSchema);
+```
+
 == Version Compatibility
 
 The Kafka sink and source are based on version 2.2.0, this means Kafka

--- a/docs/modules/integrate/pages/kafka-connector.adoc
+++ b/docs/modules/integrate/pages/kafka-connector.adoc
@@ -103,12 +103,14 @@ properties.put("schema.registry.url", schemaRegistryUrl);
 Keep in mind that once the record deserialized, Jet still needs to know
 how to serialize/deserialize the record internally.
 
-== Embedded Avro Schema
-To use an embedded Avro schema for `GenericRecord`, you must provide the following as parameters for the Kafka producer and/or consumer:
+== Avro Schema
+To use an Avro schema for `GenericRecord`, you must provide the following as parameters for the Kafka producer and/or consumer:
 
 * The schema
 * A HazelcastKafkaAvroSerializer serialization class
 * A HazelcastKafkaAvroDeserializer deserialization class
+
+The process will utilize the schema from properties, disregarding the schema from the record. An exception will be raised if the types of the record schema and properties schema are different.
 
 The parameters can be specified as shown in the following examples.
 

--- a/docs/modules/integrate/pages/kafka-connector.adoc
+++ b/docs/modules/integrate/pages/kafka-connector.adoc
@@ -104,9 +104,15 @@ Keep in mind that once the record deserialized, Jet still needs to know
 how to serialize/deserialize the record internally.
 
 == Embedded Avro Schema
-It is possible to employ an embedded Avro schema for GeneralRecord by providing the schema as a parameter for Kafka producer/consumer, along with a HazelcastAvro serialization and deserialization class.
+To use an embedded Avro schema for `GenericRecord`, you must provide the following as parameters for the Kafka producer and/or consumer:
 
-Example of producer parameters:
+* The schema
+* A HazelcastKafkaAvroSerializer serialization class
+* A HazelcastKafkaAvroDeserializer deserialization class
+
+The parameters can be specified as shown in the following examples.
+
+Example consumer parameters:
 ```java
 properties.put("key.deserializer", HazelcastKafkaAvroDeserializer.class);
 properties.put("value.deserializer", HazelcastKafkaAvroDeserializer.class);
@@ -114,10 +120,10 @@ properties.put("keyAvroSchema", keyAvroSchema);
 properties.put("valueAvroSchema", valueAvroSchema);
 ```
 
-Example of consumer parameters:
+Example producer parameters:
 ```java
-properties.put("key.serializer", HazelcastKafkaAvroDeserializer.class);
-properties.put("value.serializer", HazelcastKafkaAvroDeserializer.class);
+properties.put("key.serializer", HazelcastKafkaAvroSerializer.class);
+properties.put("value.serializer", HazelcastKafkaAvroSerializer.class);
 properties.put("keyAvroSchema", keyAvroSchema);
 properties.put("valueAvroSchema", valueAvroSchema);
 ```

--- a/docs/modules/integrate/pages/kafka-connector.adoc
+++ b/docs/modules/integrate/pages/kafka-connector.adoc
@@ -104,7 +104,7 @@ Keep in mind that once the record deserialized, Jet still needs to know
 how to serialize/deserialize the record internally.
 
 == Avro Schema
-To use an Avro schema for `GenericRecord`, you must provide the following as parameters for the Kafka producer and/or consumer:
+To use an Avro schema for `GenericRecord`, you must provide the following as parameters for the Kafka source and/or sink:
 
 * JSON representation of Avro schema
 * A `HazelcastKafkaAvroSerializer` as key/value serializer class


### PR DESCRIPTION
Updated the documentation to provide information on utilizing an embedded Avro schema for the GenericRecord within the Pipeline API.