### PR TITLE
Simplifying Phi Accrual and Deadline Failure Detectors content.

### DIFF
--- a/docs/modules/clusters/pages/deadline-detector.adoc
+++ b/docs/modules/clusters/pages/deadline-detector.adoc
@@ -4,9 +4,9 @@ _Deadline Failure Detector_ uses an absolute timeout for missing/lost
 heartbeats. After timeout, a member is considered as crashed/unavailable
 and marked as suspected.
 
-NOTE: _Deadline Failure Detector_ is the default failure detector in Hazelcast.
+NOTE: By default, Hazelcast uses the _Deadline Failure Detector_ for failure detection.
 
-The following is an example configuration with property descriptions.
+The following example provides a configuration, with callouts that describe the properties:
 
 [tabs] 
 ==== 
@@ -51,7 +51,7 @@ config.setProperty("hazelcast.max.no.heartbeat.seconds", "120"); <3>
 ====
 <1> The value must be `deadline`.
 <2> [[heartbeat-interval]]Interval at which member heartbeat messages are sent to each other.
-<3> [[heartbeat-timeout]]Timeout which defines when a cluster member is suspected because it has not sent any heartbeats.
+<3> [[heartbeat-timeout]]Timeout that defines when a cluster member is suspect because it has not sent any heartbeats.
 
 
 

--- a/docs/modules/clusters/pages/deadline-detector.adoc
+++ b/docs/modules/clusters/pages/deadline-detector.adoc
@@ -4,17 +4,9 @@ _Deadline Failure Detector_ uses an absolute timeout for missing/lost
 heartbeats. After timeout, a member is considered as crashed/unavailable
 and marked as suspected.
 
-_Deadline Failure Detector_ has the following configuration properties:
+NOTE: _Deadline Failure Detector_ is the default failure detector in Hazelcast.
 
-* `hazelcast.heartbeat.interval.seconds`: This is the interval at which
-member heartbeat messages are sent to each other.
-* `hazelcast.max.no.heartbeat.seconds`: This is the timeout which defines
-when a cluster member is suspected because it has not sent any heartbeats.
-
-To use _Deadline Failure Detector_, the configuration property
-`hazelcast.heartbeat.failuredetector.type` should be set to `"deadline"`.
-
-**Declarative Configuration:**
+The following is an example configuration with property descriptions.
 
 [tabs] 
 ==== 
@@ -26,9 +18,9 @@ XML::
 <hazelcast>
     ...
     <properties>
-        <property name="hazelcast.heartbeat.failuredetector.type">deadline</property>
-        <property name="hazelcast.heartbeat.interval.seconds">5</property>
-        <property name="hazelcast.max.no.heartbeat.seconds">120</property>
+        <property name="hazelcast.heartbeat.failuredetector.type">deadline</property> <1>
+        <property name="hazelcast.heartbeat.interval.seconds">5</property> <2>
+        <property name="hazelcast.max.no.heartbeat.seconds">120</property> <3>
     </properties>
     ...
 </hazelcast>
@@ -41,22 +33,25 @@ YAML::
 ----
 hazelcast:
   properties:
-    hazelcast.heartbeat.failuredetector.type: deadline
-    hazelcast.heartbeat.interval.seconds: 5
-    hazelcast.max.no.heartbeat.seconds: 120
+    hazelcast.heartbeat.failuredetector.type: deadline <1>
+    hazelcast.heartbeat.interval.seconds: 5 <2>
+    hazelcast.max.no.heartbeat.seconds: 120 <3>
 ----
-====
 
-**Programmatic Configuration:**
-
+Java Member API:
++
 [source,java]
 ----
 Config config = ...;
-config.setProperty("hazelcast.heartbeat.failuredetector.type", "deadline");
-config.setProperty("hazelcast.heartbeat.interval.seconds", "5");
-config.setProperty("hazelcast.max.no.heartbeat.seconds", "120");
+config.setProperty("hazelcast.heartbeat.failuredetector.type", "deadline"); <1>
+config.setProperty("hazelcast.heartbeat.interval.seconds", "5"); <2>
+config.setProperty("hazelcast.max.no.heartbeat.seconds", "120"); <3>
 [...]
 ----
+====
+<1> The value must be `deadline`.
+<2> [[heartbeat-interval]]Interval at which member heartbeat messages are sent to each other.
+<3> [[heartbeat-timeout]]Timeout which defines when a cluster member is suspected because it has not sent any heartbeats.
 
-NOTE: _Deadline Failure Detector_ is the default failure detector in Hazelcast.
+
 

--- a/docs/modules/clusters/pages/phi-accrual-detector.adoc
+++ b/docs/modules/clusters/pages/phi-accrual-detector.adoc
@@ -61,15 +61,13 @@ config.setProperty("hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.m
 ====
 <1> The value must be `phi-accrual`.
 <2> xref:deadline-detector.adoc#heartbeat-interval[Interval] at which member heartbeat messages are sent to each other.
-<3> Timeout which defines when a cluster member is suspected because it has not sent any heartbeats.
-Since _Phi Accrual Failure Detector_ is adaptive to network conditions, a much lower `hazelcast.max.no.heartbeat.seconds` can be defined than
-_Deadline Failure Detector_'s xref:deadline-detector.adoc#heartbeat-timeout[timeout].
-<4> The phi threshold for suspicion. After calculated phi exceeds this threshold, a member
-is considered as unreachable and marked as suspected. A low threshold allows to
-detect member crashes/failures faster but can generate more mistakes and cause
-wrong member suspicions. A high threshold generates fewer mistakes but is slower
-to detect actual crashes/failures. `phi = 1` means likeliness that we will make a mistake is about `10%`. The likeliness
-is about `1%` with `phi = 2`, `0.1%` with `phi = 3` and so on. Default phi threshold is 10.
-<5> Number of samples to keep for history. Its default value is 200.
-<6> Minimum standard deviation to use for the normal distribution used when calculating phi.
-Too low standard deviation might result in too much sensitivity.
+<3> Timeout that defines when a cluster member is suspect because it has not sent any heartbeats.
+As _Phi Accrual Failure Detector_ is adaptive to network conditions, you can define a lower `hazelcast.max.no.heartbeat.seconds` than defined in the
+_Deadline Failure Detector_ timeout. For further information on the _Deadline Failure Detector_ timeout, see the xref:deadline-detector.adoc#heartbeat-timeout[timeout] topic.
+<4> The phi threshold at which a member is considered unreachable and marked as suspect. After calculated phi exceeds this threshold, a member
+is considered as unreachable and marked as suspected. A low threshold threshold allows you to detect any crashes or failures in a member, but can generate more failures and cause the wrong member to be marked as suspect. A higher threshold generates fewer failures but is slower
+to detect actual crashes/failures. If you set `phi = 1`, the possibility of an incorrectly-identified failure is around 10%. If you set `phi = 2`, this falls to around 1%, and setting `phi = 3` reduces this further to around 0.1%. The likelihood of incorrectly-identified failures continues to reduce in this way as you increase the value. By default, the phi threshold is set to `10`.
+<5> Number of samples to retain for history. By default, this is set to `200`.
+<6> Minimum standard deviation for phi calculations in a normal distribution.
++
+NOTE: If you set the standard deviation too low, this can result in excessive sensitivity.

--- a/docs/modules/clusters/pages/phi-accrual-detector.adoc
+++ b/docs/modules/clusters/pages/phi-accrual-detector.adoc
@@ -1,8 +1,5 @@
 = Phi Accrual Failure Detector
 
-This is the failure detector based on
-https://www.computer.org/csdl/proceedings/srds/2004/2239/00/22390066-abs.html[The Phi Accrual Failure Detector' by Hayashibara et al.^]
-
 Phi Accrual Failure Detector keeps track of the intervals between heartbeats
 in a sliding window of time and measures the mean and variance of these
 samples and calculates a value of suspicion level (Phi). The value of phi
@@ -10,35 +7,7 @@ increases when the period since the last heartbeat gets longer. If the network
 becomes slow or unreliable, the resulting mean and variance increase, there needs
 to be a longer period for which no heartbeat is received before the member is suspected. 
 
-The `hazelcast.heartbeat.interval.seconds` and `hazelcast.max.no.heartbeat.seconds`
-properties still can be used as period of heartbeat messages and deadline of
-heartbeat messages. Since _Phi Accrual Failure Detector_ is adaptive to network
-conditions, a much lower `hazelcast.max.no.heartbeat.seconds` can be defined than
-_Deadline Failure Detector_'s timeout.
-
-In addition to the above two properties, _Phi Accrual Failure Detector_ has the
-following configuration properties:
-
-* `hazelcast.heartbeat.phiaccrual.failuredetector.threshold`: This is the phi
-threshold for suspicion. After calculated phi exceeds this threshold, a member
-is considered as unreachable and marked as suspected. A low threshold allows to
-detect member crashes/failures faster but can generate more mistakes and cause
-wrong member suspicions. A high threshold generates fewer mistakes but is slower
-to detect actual crashes/failures.
-+
-`phi = 1` means likeliness that we will make a mistake is about `10%`. The likeliness
-is about `1%` with `phi = 2`, `0.1%` with `phi = 3` and so on. Default phi threshold is 10.
-+
-* `hazelcast.heartbeat.phiaccrual.failuredetector.sample.size`: Number of samples
-to keep for history. Its default value is 200.
-* `hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis`: Minimum
-standard deviation to use for the normal distribution used when calculating phi.
-Too low standard deviation might result in too much sensitivity.
-
-To use _Phi Accrual Failure Detector_, configuration property
-`hazelcast.heartbeat.failuredetector.type` should be set to `"phi-accrual"`.
-
-**Declarative Configuration:**
+The following is an example configuration with property descriptions.
 
 [tabs] 
 ==== 
@@ -50,12 +19,12 @@ XML::
 <hazelcast>
     ...
     <properties>
-        <property name="hazelcast.heartbeat.failuredetector.type">phi-accrual</property>
-        <property name="hazelcast.heartbeat.interval.seconds">1</property>
-        <property name="hazelcast.max.no.heartbeat.seconds">60</property>
-        <property name="hazelcast.heartbeat.phiaccrual.failuredetector.threshold">10</property>
-        <property name="hazelcast.heartbeat.phiaccrual.failuredetector.sample.size">200</property>
-        <property name="hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis">100</property>
+        <property name="hazelcast.heartbeat.failuredetector.type">phi-accrual</property> <1>
+        <property name="hazelcast.heartbeat.interval.seconds">1</property> <2>
+        <property name="hazelcast.max.no.heartbeat.seconds">60</property> <3>
+        <property name="hazelcast.heartbeat.phiaccrual.failuredetector.threshold">10</property> <4>
+        <property name="hazelcast.heartbeat.phiaccrual.failuredetector.sample.size">200</property> <5>
+        <property name="hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis">100</property> <6>
     </properties>
     ...
 </hazelcast>
@@ -68,24 +37,39 @@ YAML::
 ----
 hazelcast:
   properties:
-    hazelcast.heartbeat.failuredetector.type: phi-accrual
-    hazelcast.heartbeat.interval.seconds: 1
-    hazelcast.max.no.heartbeat.seconds: 60
-    hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200
-    hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100
+    hazelcast.heartbeat.failuredetector.type: phi-accrual <1>
+    hazelcast.heartbeat.interval.seconds: 1 <2>
+    hazelcast.max.no.heartbeat.seconds: 60 <3>
+    hazelcast.heartbeat.phiaccrual.failuredetector.threshold: 10 <4>
+    hazelcast.heartbeat.phiaccrual.failuredetector.sample.size: 200 <5>
+    hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis: 100 <6>
 ----
-====
 
-**Programmatic Configuration:**
-
+Java Member API::
++
 [source,java]
 ----
 Config config = ...;
-config.setProperty("hazelcast.heartbeat.failuredetector.type", "phi-accrual");
-config.setProperty("hazelcast.heartbeat.interval.seconds", "1");
-config.setProperty("hazelcast.max.no.heartbeat.seconds", "60");
-config.setProperty("hazelcast.heartbeat.phiaccrual.failuredetector.threshold", "10");
-config.setProperty("hazelcast.heartbeat.phiaccrual.failuredetector.sample.size", "200");
-config.setProperty("hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis", "100");
+config.setProperty("hazelcast.heartbeat.failuredetector.type", "phi-accrual"); <1>
+config.setProperty("hazelcast.heartbeat.interval.seconds", "1"); <2>
+config.setProperty("hazelcast.max.no.heartbeat.seconds", "60"); <3>
+config.setProperty("hazelcast.heartbeat.phiaccrual.failuredetector.threshold", "10"); <4>
+config.setProperty("hazelcast.heartbeat.phiaccrual.failuredetector.sample.size", "200"); <5>
+config.setProperty("hazelcast.heartbeat.phiaccrual.failuredetector.min.std.dev.millis", "100"); <6>
 [...]
 ----
+====
+<1> The value must be `phi-accrual`.
+<2> xref:deadline-detector.adoc#heartbeat-interval[Interval] at which member heartbeat messages are sent to each other.
+<3> Timeout which defines when a cluster member is suspected because it has not sent any heartbeats.
+Since _Phi Accrual Failure Detector_ is adaptive to network conditions, a much lower `hazelcast.max.no.heartbeat.seconds` can be defined than
+_Deadline Failure Detector_'s xref:deadline-detector.adoc#heartbeat-timeout[timeout].
+<4> The phi threshold for suspicion. After calculated phi exceeds this threshold, a member
+is considered as unreachable and marked as suspected. A low threshold allows to
+detect member crashes/failures faster but can generate more mistakes and cause
+wrong member suspicions. A high threshold generates fewer mistakes but is slower
+to detect actual crashes/failures. `phi = 1` means likeliness that we will make a mistake is about `10%`. The likeliness
+is about `1%` with `phi = 2`, `0.1%` with `phi = 3` and so on. Default phi threshold is 10.
+<5> Number of samples to keep for history. Its default value is 200.
+<6> Minimum standard deviation to use for the normal distribution used when calculating phi.
+Too low standard deviation might result in too much sensitivity.


### PR DESCRIPTION
Also removing the reference to the academic paper, on top of the phi accrual detector content.