### PR TITLE
Add note on ADVANCED_CP for CPMap

### DIFF
--- a/docs/modules/data-structures/pages/cpmap.adoc
+++ b/docs/modules/data-structures/pages/cpmap.adoc
@@ -7,6 +7,8 @@ distributed key-value implementation, these operations involve remote calls and 
 performance differs from non-distributed key-value data structures; for example, `java.util.HashMap`. 
 `CPMap` is only available in the Enterprise Edition.
 
+NOTE: Your license must include `ADVANCED_CP` to activate this feature.
+
 There is no unsafe variant of `CPMap`, unlike other CP data structures. Therefore, CP must be 
 xref:cp-subsystem:configuration.adoc#quickstart-configuration[enabled,window=_blank] before using `CPMap`.
 


### PR DESCRIPTION
Adds note that you need `ADVANCED_CP` feature in your license to use `CPMap`.