### PR TITLE
Removing Elasticsearch 6 references.

### DIFF
--- a/docs/modules/integrate/pages/connectors.adoc
+++ b/docs/modules/integrate/pages/connectors.adoc
@@ -121,11 +121,6 @@ The Jet API supports more connectors than SQL.
 |at-least-once
 
 |xref:integrate:elasticsearch-connector.adoc[ElasticSources.elastic]
-|hazelcast-jet-elasticsearch-6
-|batch
-|N/A
-
-|xref:integrate:elasticsearch-connector.adoc[ElasticSources.elastic]
 |hazelcast-jet-elasticsearch-7
 |batch
 |N/A
@@ -264,11 +259,6 @@ The Jet API supports more connectors than SQL.
 
 |xref:integrate:cdc-connectors.adoc[CdcSinks.map]
 |hazelcast-jet-cdc-debezium
-|streaming
-|at-least-once
-
-|xref:integrate:elasticsearch-connector.adoc[ElasticSinks.elastic]
-|hazelcast-jet-elasticsearch-6
 |streaming
 |at-least-once
 

--- a/docs/modules/integrate/pages/elasticsearch-connector.adoc
+++ b/docs/modules/integrate/pages/elasticsearch-connector.adoc
@@ -7,14 +7,9 @@ use Elasticsearch as both a source and a sink with the Jet API.
 
 This connector is included in the full distribution of Hazelcast.
 
-To use this connector in the slim distribution, you must have one of the following modules on your members' classpaths:
-
-- `hazelcast-jet-elasticsearch-6`
-- `hazelcast-jet-elasticsearch-7`
+To use this connector in the slim distribution, you must have the `hazelcast-jet-elasticsearch-7` module on your members' classpaths.
 
 Each module includes an Elasticsearch client that's compatible with the given major version of Elasticsearch. The connector API is the same between different versions, apart from a few minor differences where we surface the API of Elasticsearch client. See the link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/jet/elastic/ElasticSources.html[Javadoc] for any such differences.
-
-CAUTION: Elastic discontinued support for Elasticsearch 6 in 2022. As a result, Hazelcast will also end support for this version in the upcoming release (5.4), when the version 6 module and documentation will be removed.
 
 == Permissions
 [.enterprise]*Enterprise*


### PR DESCRIPTION
Removal note in release notes: https://github.com/hazelcast/hz-docs/pull/905/files#diff-8421c98df518b7bbbd6e0729d53cc158cf2c961937a9874efb75baffd0d9eedfR251
