### PR TITLE
Use correct capitalization of datastructure names

### DIFF
--- a/docs/modules/configuration/pages/dynamic-config.adoc
+++ b/docs/modules/configuration/pages/dynamic-config.adoc
@@ -69,7 +69,7 @@ Dynamic configuration is supported for the following data structures:
 - Set
 - MultiMap
 - ReplicatedMap
-- RingBuffer
+- Ringbuffer
 - Topic
 - ReliableTopic
 - Executor

--- a/docs/modules/data-structures/pages/distributed-data-structures.adoc
+++ b/docs/modules/data-structures/pages/distributed-data-structures.adoc
@@ -53,7 +53,7 @@ duplicate elements and preserves their order.
 |<<partitioned,Non-partitioned>>
 |<<ap-data,Availability and partition tolerance>>
 
-|xref:multimap.adoc[Multimap]
+|xref:multimap.adoc[MultiMap]
 |A specialized Hazelcast map. It is a distributed data
 structure where you can store multiple values for a single key.
 |<<partitioned,Partitioned>>

--- a/docs/modules/fault-tolerance/pages/backups.adoc
+++ b/docs/modules/fault-tolerance/pages/backups.adoc
@@ -31,7 +31,7 @@ for the data structures:
 
 * xref:data-structures:backing-up-maps.adoc[Maps]
 * xref:jcache:icache.adoc#icache-configuration[Caches]
-* xref:data-structures:multimap.adoc#configuring-multimap[Multimaps]
+* xref:data-structures:multimap.adoc#configuring-multimap[MultiMaps]
 * xref:data-structures:queue.adoc#configuring-queue[Queues], xref:data-structures:priority-queue.adoc[Priority Queues]
 * xref:data-structures:set.adoc#configuring-set[Sets], xref:data-structures:list.adoc#configuring-list[Lists]
 * xref:data-structures:ringbuffer.adoc#backing-up-ringbuffer[Ringbuffers]

--- a/docs/modules/maintain-cluster/pages/monitoring.adoc
+++ b/docs/modules/maintain-cluster/pages/monitoring.adoc
@@ -827,7 +827,7 @@ the `NearCacheStats` object (applies to both client and member Near Caches):
 
 See the https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/nearcache/NearCacheStats.html[`NearCacheStats` Javadoc^] to see all the metrics.
 
-=== Multimap Statistics
+=== MultiMap Statistics
 
 To get MultiMap statistics, use the `getLocalMultiMapStats()` method from the `MultiMap` interface.
 This method returns a `LocalMultiMapStats` object that holds local MultiMap statistics.

--- a/docs/modules/network-partitioning/pages/split-brain-protection.adoc
+++ b/docs/modules/network-partitioning/pages/split-brain-protection.adoc
@@ -35,7 +35,7 @@ Split-brain protection is supported for the following Hazelcast data structures:
 * IQueue (for Hazelcast 3.8 and higher versions)
 * IExecutorService, DurableExecutorService, IScheduledExecutorService,
 MultiMap, ISet, IList, Ringbuffer, Replicated Map, Cardinality Estimator,
-IAtomicLong, IAtomicReference, ISemaphore, ICountdownLatch
+IAtomicLong, IAtomicReference, ISemaphore, ICountDownLatch
 (for Hazelcast 3.10 and higher versions)
 
 Each data structure to be protected should have the configuration added to

--- a/docs/modules/network-partitioning/pages/split-brain-recovery.adoc
+++ b/docs/modules/network-partitioning/pages/split-brain-recovery.adoc
@@ -73,7 +73,7 @@ The following data structures support split-brain recovery:
 * `IQueue`
 * `IList`
 * `ISet`
-* `RingBuffer`
+* `Ringbuffer`
 * `CardinalityEstimator`
 * `ScheduledExecutorService`
 
@@ -91,7 +91,7 @@ See also the <<merge-types, Merge Types section>> for a complete overview of
 supported merge types of each data structure. There is a config validation which
 checks these constraints to provide fail-fast behavior for invalid configurations.
 
-NOTE: For the other data structures, e.g., `ISemaphore`, `ICountdownLatch` and `ILock`,
+NOTE: For the other data structures, e.g., `ISemaphore`, `ICountDownLatch` and `ILock`,
 the instance from the smaller cluster is discarded during the split-brain recovery.
 
 == Configuring Merge Policies

--- a/docs/modules/security/pages/native-client-security.adoc
+++ b/docs/modules/security/pages/native-client-security.adoc
@@ -423,7 +423,7 @@ queue:
 ----
 ====
 
-=== Multimap Permission
+=== MultiMap Permission
 
 Actions: all, create, destroy, listen, lock, put, read, remove
 

--- a/docs/modules/transactions/pages/creating-a-transaction-interface.adoc
+++ b/docs/modules/transactions/pages/creating-a-transaction-interface.adoc
@@ -56,7 +56,7 @@ NOTE: The isolation levels might be broken if the objects involved
 in the transaction span multiple partitions. A reader which is not
 in a transaction can then temporarily observe partially committed data.
 
-== Queue/Set/List vs. Map/Multimap
+== Queue/Set/List vs. Map/MultiMap
 
 Hazelcast implements queue/set/list operations differently than
 map/multimap operations. For queue operations (offer, poll), offered


### PR DESCRIPTION
Incorrect capitalization of datastructure names is found for the following, the correct capitalization is defined by the name of the class.
- `MultiMap`
- `RingBuffer`
- `ICountDownLatch`