### PR TITLE
Support for Oracle and MSSQL documentation [HZ-2988]

### DIFF
--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -8,6 +8,16 @@
 
 The JDBC connector allows you to connect to any database that supports the JDBC interface.
 
+== Supported Databases
+
+The JDBC connector officially supports the following database management systems:
+
+- MySQL
+- PostgreSQL
+- Microsoft SQL Server
+- Oracle
+
+
 == Supported SQL Statements
 
 The JDBC connector supports only the following statements:
@@ -77,3 +87,99 @@ OPTIONS (
 
 <1> The name of the connector.
 <2> The name of the external data store configuration on your members.
+
+== Data Type Mapping Between Hazelcast and MSSQL
+Hazelcast supports a subset of SQL data types. The following MSSQL types are mapped to the respective Hazelcast SQL type.
+
+
+[cols="1,1"]
+|===
+| MSSQL Type| Hazelcast SQL Type
+
+|`varchar`
+|`VARCHAR`
+
+|`tinyint`
+|`TINYINT`
+
+|`smallint`
+|`SMALLINT`
+
+|`int`
+|`INTEGER`
+
+|`bigint`
+|`BIGINT`
+
+|`decimal`
+|`DECIMAL`
+
+|`real`
+|`REAL`
+
+|`float`
+|`DOUBLE`
+
+|`date`
+|`DATE`
+
+|`time`
+|`TIME`
+
+|`datetime`
+|`TIMESTAMP`
+
+|`datetimeoffset`
+|`TIMESTAMP WITH TIME ZONE`
+
+|`numeric`
+|`DECIMAL`
+
+|`char`
+|`VARCHAR`
+
+|`text`
+|`VARCHAR`
+
+|===
+
+== Data Type Mapping Between Hazelcast and Oracle
+The following Oracle types are mapped to the respective Hazelcast SQL type.
+NUMBER(p,s) represents NUMBER type with decimal precision "p" and scale "s" where s>0, whereas NUMBER(p) has scale 0.
+
+
+[cols="1,1"]
+|===
+| Oracle Type| Hazelcast SQL Type
+
+|`VARCHAR2`
+|`VARCHAR`
+
+|`from NUMBER(1) to NUMBER(4) inclusive`
+|`SMALLINT`
+
+|`from NUMBER(5) to NUMBER(9) inclusive`
+|`INTEGER`
+
+|`from NUMBER(10) to NUMBER(18) inclusive`
+|`BIGINT`
+
+|`NUMBER(p,s) where "s" is 0 and "p" is bigger than 18 or "s+p" is bigger than 15`
+|`DECIMAL`
+
+|`NUMBER(p,s) where "s+p" is smaller than 8`
+|`REAL`
+
+|`NUMBER(p,s) where "s+p" is smaller than 16`
+|`DOUBLE`
+
+|`DATE`
+|`DATE`
+
+|`TIMESTAMP`
+|`TIMESTAMP`
+
+|`TIMESTAMP WITH TIME ZONE`
+|`TIMESTAMP WITH TIME ZONE`
+
+|===

--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -17,6 +17,7 @@ The JDBC connector supports the following database management systems:
 - Microsoft SQL Server
 - Oracle
 
+NOTE: You can use other database management systems with a JDBC interface. However, Hazelcast offers no guarantees or support for these systems.
 
 == Supported SQL Statements
 
@@ -88,8 +89,111 @@ OPTIONS (
 <1> The name of the connector.
 <2> The name of the external data store configuration on your members.
 
+== Data Type Mapping Between Hazelcast and MySQL
+Hazelcast supports a subset of SQL data types. For MySQL data types, see the https://dev.mysql.com/doc/refman/8.0/en/data-types.html[official MySQL documentation]. The following MySQL types are mapped to the respective Hazelcast SQL type:
+
+
+[cols="1,1"]
+|===
+| MySQL Type| Hazelcast SQL Type
+
+|`VARCHAR`
+|`VARCHAR`
+
+|`CHAR`
+|`VARCHAR`
+
+|`TEXT`
+|`VARCHAR`
+
+|`BOOLEAN`
+|`BOOLEAN`
+
+|`SMALLINT`
+|`SMALLINT`
+
+|`INT`
+|`INTEGER`
+
+|`BIGINT`
+|`BIGINT`
+
+|`DECIMAL`
+|`DECIMAL`
+
+|`FLOAT`
+|`REAL`
+
+|`DOUBLE/DOUBLE PRECISION`
+|`DOUBLE`
+
+|`DATE`
+|`DATE`
+
+|`TIME`
+|`TIME`
+
+|`TIMESTAMP`
+|`TIMESTAMP`
+
+|===
+
+
+== Data Type Mapping Between Hazelcast and PostgreSQL
+For PostgreSQL data types, see the https://www.postgresql.org/docs/current/datatype.html[official PostgreSQL documentation]. The following PostgreSQL types are mapped to the respective Hazelcast SQL type:
+
+
+[cols="1,1"]
+|===
+| PostgreSQL Type| Hazelcast SQL Type
+
+|`varchar`
+|`VARCHAR`
+
+|`char`
+|`VARCHAR`
+
+|`text`
+|`VARCHAR`
+
+|`character varying`
+|`VARCHAR`
+
+|`boolean`
+|`BOOLEAN`
+
+|`smallint`
+|`SMALLINT`
+
+|`integer`
+|`INTEGER`
+
+|`bigint`
+|`BIGINT`
+
+|`numeric/decimal`
+|`DECIMAL`
+
+|`real`
+|`REAL`
+
+|`double precision`
+|`DOUBLE`
+
+|`date`
+|`DATE`
+
+|`time`
+|`TIME`
+
+|`timestamp`
+|`TIMESTAMP`
+
+|===
+
+
 == Data Type Mapping Between Hazelcast and MSSQL
-Hazelcast supports a subset of SQL data types. The following MSSQL types are mapped to the respective Hazelcast SQL type:
+For MSSQL data types, see the https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16[official MSSQL documentation]. The following MSSQL types are mapped to the respective Hazelcast SQL type:
 
 
 [cols="1,1"]
@@ -144,7 +248,7 @@ Hazelcast supports a subset of SQL data types. The following MSSQL types are map
 |===
 
 == Data Type Mapping Between Hazelcast and Oracle
-The following Oracle types are mapped to the respective Hazelcast SQL type.
+For Oracle data types see the https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/Data-Types.html#GUID-7B72E154-677A-4342-A1EA-C74C1EA928E6[official Oracle documentation]. The following Oracle types are mapped to the respective Hazelcast SQL type.
 `NUMBER(p,s)` represents a NUMBER type with a decimal precision of `p` and a scale of `s` that is greater than 0. `NUMBER(p)` has a scale of 0.
 
 

--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -10,7 +10,7 @@ The JDBC connector allows you to connect to any database that supports the JDBC 
 
 == Supported Databases
 
-The JDBC connector officially supports the following database management systems:
+The JDBC connector supports the following database management systems:
 
 - MySQL
 - PostgreSQL
@@ -89,7 +89,7 @@ OPTIONS (
 <2> The name of the external data store configuration on your members.
 
 == Data Type Mapping Between Hazelcast and MSSQL
-Hazelcast supports a subset of SQL data types. The following MSSQL types are mapped to the respective Hazelcast SQL type.
+Hazelcast supports a subset of SQL data types. The following MSSQL types are mapped to the respective Hazelcast SQL type:
 
 
 [cols="1,1"]
@@ -145,7 +145,7 @@ Hazelcast supports a subset of SQL data types. The following MSSQL types are map
 
 == Data Type Mapping Between Hazelcast and Oracle
 The following Oracle types are mapped to the respective Hazelcast SQL type.
-NUMBER(p,s) represents NUMBER type with decimal precision "p" and scale "s" where s>0, whereas NUMBER(p) has scale 0.
+`NUMBER(p,s)` represents a NUMBER type with a decimal precision of `p` and a scale of `s` that is greater than 0. `NUMBER(p)` has a scale of 0.
 
 
 [cols="1,1"]


### PR DESCRIPTION
Added the list of supported databases and data type mappings for Oracle and MSSQL in the JDBC connector doc.