### PR TITLE
Add Enterprise Client Requirement for CPMap Usage [HZ-4179]

### DIFF
--- a/docs/modules/data-structures/pages/cpmap.adoc
+++ b/docs/modules/data-structures/pages/cpmap.adoc
@@ -7,7 +7,8 @@ distributed key-value implementation, these operations involve remote calls and 
 performance differs from non-distributed key-value data structures; for example, `java.util.HashMap`. 
 `CPMap` is only available in the Enterprise Edition.
 
-NOTE: Your license must include `ADVANCED_CP` to activate this feature.
+NOTE: Your license must include `ADVANCED_CP` to activate this feature and you must use the
+Enterprise Edition client.
 
 There is no unsafe variant of `CPMap`, unlike other CP data structures. Therefore, CP must be 
 xref:cp-subsystem:configuration.adoc#quickstart-configuration[enabled,window=_blank] before using `CPMap`.


### PR DESCRIPTION
Missing requirement that the client must be the enterprise variant to use `CPMap`.