### PR TITLE
Remove references to Java 8/9

### DIFF
--- a/docs/modules/cluster-performance/pages/performance-tuning.adoc
+++ b/docs/modules/cluster-performance/pages/performance-tuning.adoc
@@ -507,8 +507,7 @@ increase the performance.
 
 The first thing that can be done is making sure that AES intrinsics are used.
 Modern CPUs (2010 or newer Westmere) have hardware support for AES encryption/decryption
-and if a Java 8 or newer JVM is
-used, the JIT automatically makes use of these AES intrinsics. They can also be
+and the JIT automatically makes use of these AES intrinsics. They can also be
 explicitly enabled using `-XX:+UseAES -XX:+UseAESIntrinsics`,
 or disabled using `-XX:-UseAES -XX:-UseAESIntrinsics`.
 

--- a/docs/modules/security/pages/integrating-openssl.adoc
+++ b/docs/modules/security/pages/integrating-openssl.adoc
@@ -208,7 +208,7 @@ value is `TLSv1.2`. Available values are:
 ** `SSLv2` _(insecure!)_
 ** `SSLv3` _(insecure!)_
 +
-All the algorithms listed above support Java 8 and higher versions. For the
+For the
 `protocol` property, we recommend you to provide SSL or TLS with its version
 information, e.g., `TLSv1.2`. Note that if you
 provide only `SSL` or `TLS` as a value for the `protocol` property, they are

--- a/docs/modules/security/pages/tls-ssl.adoc
+++ b/docs/modules/security/pages/tls-ssl.adoc
@@ -5,11 +5,9 @@
 NOTE: You cannot use TLS/SSL when xref:encryption.adoc[Symmetric Encryption]
 is enabled. Also note that the symmetric encryption feature has been deprecated.
 
-You can use the SSL (Secure Sockets Layer)
+You can use the TLS (Transport Layer Security)
 protocol to establish an encrypted communication
-across your Hazelcast cluster with key stores and trust stores. Note that, if
-you are developing applications using Java 8, you will be using its
-successor TLS (Transport Layer Security).
+across your Hazelcast cluster with key stores and trust stores.
 
 NOTE: It is NOT recommended to reuse the key stores and trust stores
 for external applications.

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -1127,7 +1127,7 @@ type must be defined as a separate class which stores the array type as a field.
 array of array type can be serialized/deserialized as an array of that separate class.
 
 For Java APIs, a zero-config Compact serializer uses reflection to read and write to fields of
-objects, regardless of whether those fields are public. If you use Java 9 onwards, you must
+objects, regardless of whether those fields are public. You must
 enable reflective access for packages of your module by using the `opens` statement in the
 module declaration:
 


### PR DESCRIPTION
Hazelcast 5.3 requires Java 11+, so documentation on behavior with older Java runtimes is unnecessary.