### PR TITLE
Remove AdoptOpenJDK references

### DIFF
--- a/docs/modules/getting-started/pages/get-started-binary.adoc
+++ b/docs/modules/getting-started/pages/get-started-binary.adoc
@@ -13,11 +13,9 @@ To complete this tutorial, you need the following:
 
 |JDK 11+
 |
-xref:deploy:supported-jvms.adoc[Supported Java Virtual Machines]
+xref:deploy:supported-jvms.adoc#supported-java-virtual-machines[Supported Java Virtual Machines]
 
 xref:deploy:running-in-modular-java.adoc[Using JDK 11+ with Modular Java]
-
-link:https://adoptopenjdk.net[AdoptOpenJDK^]
 
 |A full Hazelcast distribution
 |xref:getting-started:install-hazelcast.adoc#using-the-binary[Install Hazelcast]

--- a/docs/modules/getting-started/pages/get-started-java.adoc
+++ b/docs/modules/getting-started/pages/get-started-java.adoc
@@ -13,7 +13,7 @@ To complete this tutorial, you need the following:
 
 |JDK 11+
 |
-xref:deploy:supported-jvms.adoc[Supported Java Virtual Machines]
+xref:deploy:supported-jvms.adoc#supported-java-virtual-machines[Supported Java Virtual Machines]
 
 |Maven
 |link:https://maven.apache.org/download.cgi[Download Maven]

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -213,9 +213,7 @@ Hazelcast runs on Java, which means you can add it as a dependency in your Java 
 
 The Java package includes both a member API and a Java client API. The member API is for xref:deploy:choosing-a-deployment-option.adoc[embedded topologies] where you want to deploy and manage a cluster in the same Java Virtual Machine (JVM) as your applications. The Java client is for connecting to an existing member in a client/server topology, such as xref:cloud:ROOT:overview.adoc[Hazelcast {hazelcast-cloud}].
 
-. Download and install a xref:deploy:supported-jvms.adoc[supported JDK].
-+
-TIP: We recommend installing the link:https://adoptopenjdk.net[AdoptOpenJDK^].
+. Download and install a xref:deploy:supported-jvms.adoc#supported-java-virtual-machines[supported JDK].
 
 . Add the following to your `pom.xml` file.
 // end::maven[]

--- a/docs/modules/pipelines/pages/stream-processing-client.adoc
+++ b/docs/modules/pipelines/pages/stream-processing-client.adoc
@@ -16,7 +16,7 @@ To complete this tutorial, you need the following:
 
 |JDK 11+
 |
-xref:deploy:supported-jvms.adoc[Supported Java Virtual Machines]
+xref:deploy:supported-jvms.adoc#supported-java-virtual-machines[Supported Java Virtual Machines]
 
 xref:deploy:running-in-modular-java.adoc[Using JDK 11 with Modular Java]
 

--- a/docs/modules/storage/pages/backing-up-persistence.adoc
+++ b/docs/modules/storage/pages/backing-up-persistence.adoc
@@ -27,7 +27,7 @@ NOTE: Backups are transactional and cluster-wide, so either
 all or none of the members start the same backup sequence. 
 
 NOTE: For members to use hard links,
-your xref:deploy:supported-jvms.adoc[JDK] must satisfy all requirements of the
+your xref:deploy:supported-jvms.adoc#supported-java-virtual-machines[JDK] must satisfy all requirements of the
 link:https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#createLink-java.nio.file.Path-java.nio.file.Path-[Files.createLink() method^].
 
 == Triggering a Backup


### PR DESCRIPTION
[AdoptOpenJDK is not a supported JDK](https://docs.hazelcast.com/hazelcast/latest/deploy/versioning-compatibility#supported-java-virtual-machines), so it's usage should not be recommended - the link to the list of supported JDKs is sufficient.

Also ensure that any links to the list of supported JDKs, links directly to the table.

[Slack discussion](https://hazelcast.slack.com/archives/C035HQET5/p1705670136840399)