### PR TITLE
Document Oracle Double Quotes Behavior

### DIFF
--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -19,6 +19,8 @@ The JDBC connector supports the following database management systems:
 
 NOTE: You can use other database management systems with a JDBC interface. However, Hazelcast offers no guarantees or support for these systems.
 
+NOTE: Oracle converts table and column names to upper case if they are not put inside double quotes, otherwise the exact case is kept. Either put the table and column names in double quotes or refer to them in upper case later (e.g. when used in Hazelcast mapping).
+
 == Supported SQL Statements
 
 The JDBC connector supports only the following statements:
@@ -202,6 +204,9 @@ For MSSQL data types, see the https://learn.microsoft.com/en-us/sql/t-sql/data-t
 
 |`varchar`
 |`VARCHAR`
+
+|`bit`
+|`BOOLEAN`
 
 |`tinyint`
 |`TINYINT`

--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -19,7 +19,7 @@ The JDBC connector supports the following database management systems:
 
 NOTE: You can use other database management systems with a JDBC interface. However, Hazelcast offers no guarantees or support for these systems.
 
-NOTE: Oracle converts table and column names to upper case if they are not put inside double quotes, otherwise the exact case is kept. Either put the table and column names in double quotes or refer to them in upper case later (e.g. when used in Hazelcast mapping).
+NOTE: If your table and column names include lower case characters, you must enclose the names in double quotes to prevent Oracle converting the names to upper case. If you do not enclose the table and column names in double quotes, use upper case when referring to them, for example, in Hazelcast mapping.
 
 == Supported SQL Statements
 


### PR DESCRIPTION
Added a note that explains the effect of double quotes on table and column names in Oracle. Added a column that specifies a mapping from bit to boolean in MSSQL to Hazelcast mapping table.