### PR TITLE
Add CPMap.putIfAbsent Example [HZ-4215]

### DIFF
--- a/docs/modules/ROOT/examples/dds/cpmap/ExampleCPMap.java
+++ b/docs/modules/ROOT/examples/dds/cpmap/ExampleCPMap.java
@@ -19,6 +19,9 @@ public class ExampleCPMap {
         capitalCities.set("Germany", "Munich");
         assert capitalCities.compareAndSet("Germany", "Munich", "Berlin");
         assert "Berlin".equals(capitalCities.get("Germany"));
+        assert null == capitalCities.putIfAbsent("Ireland", "Dublin");
+        assert "Dublin".equals(capitalCities.putIfAbsent("Ireland", "Cork"));
+        assert "Dublin".equals(capitalCities.get("Ireland"));
         capitalCities.destroy();
         //end::cpm[]
     }


### PR DESCRIPTION
Adds an example usage of `CPMap.putIfAbsent`.