### PR TITLE
Add bpchar column type for postgres to documentation

### DIFF
--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -153,6 +153,9 @@ For PostgreSQL data types, see the https://www.postgresql.org/docs/current/datat
 |`char`
 |`VARCHAR`
 
+|`bpchar`
+|`VARCHAR`
+
 |`text`
 |`VARCHAR`
 


### PR DESCRIPTION
The bpchar column type for postgres was missing in the documentation. It is mapped to HZ varchar type
The issue was reported here
https://github.com/hazelcast/hazelcast/issues/26218

Fixed by
https://github.com/hazelcast/hazelcast-mono/pull/498