### PR TITLE
Add Enterprise Tag to CPMap Documentation [HZ-4063]

### DIFF
--- a/docs/modules/data-structures/pages/cpmap.adoc
+++ b/docs/modules/data-structures/pages/cpmap.adoc
@@ -4,8 +4,8 @@
 
 
 Hazelcast `CPMap` is a distributed implementation of a minimal key-value interface. It supports 
-atomic `compareAndSet`, `delete`, `get`, `put`, `remove` and `set` operations. As `CPMap` is a 
-distributed key-value implementation, these operations involve remote calls and their 
+atomic `compareAndSet`, `delete`, `get`, `put`, `putIfAbsent`, `remove` and `set` operations. As 
+`CPMap` is a distributed key-value implementation, these operations involve remote calls and their 
 performance differs from non-distributed key-value data structures; for example, `java.util.HashMap`. 
 `CPMap` is only available in the Enterprise Edition.
 

--- a/docs/modules/data-structures/pages/cpmap.adoc
+++ b/docs/modules/data-structures/pages/cpmap.adoc
@@ -1,6 +1,8 @@
 = CPMap
 [[cpmap]]
 
+:page-enterprise: true
+
 Hazelcast `CPMap` is a distributed implementation of a minimal key-value interface. It supports 
 atomic `compareAndSet`, `delete`, `get`, `put`, `remove` and `set` operations. As `CPMap` is a 
 distributed key-value implementation, these operations involve remote calls and their 

--- a/docs/modules/data-structures/pages/cpmap.adoc
+++ b/docs/modules/data-structures/pages/cpmap.adoc
@@ -1,7 +1,7 @@
 = CPMap
+:page-enterprise: true
 [[cpmap]]
 
-:page-enterprise: true
 
 Hazelcast `CPMap` is a distributed implementation of a minimal key-value interface. It supports 
 atomic `compareAndSet`, `delete`, `get`, `put`, `remove` and `set` operations. As `CPMap` is a 


### PR DESCRIPTION
Adds the 'Enterprise' tag to the `CPMap` page. Previously it's not there but Enterprise is mentioned as a requirement.