### PR TITLE
Document `preferredLocalParallelism` SQL Kafka mapping option

### DIFF
--- a/docs/modules/sql/pages/mapping-to-kafka.adoc
+++ b/docs/modules/sql/pages/mapping-to-kafka.adoc
@@ -30,7 +30,7 @@ To create a mapping to a Kafka topic in SQL, you must use the `CREATE MAPPING` s
 - The address of the Kafka broker
 - Client authentication details
 - How to serialize/deserialize the keys and values in messages
-- The preferred local parallelism for the connector (for source mappings)
+- The preferred number of parallel processors on each member for source mappings
 
 ```sql
 CREATE MAPPING my_topic <1>

--- a/docs/modules/sql/pages/mapping-to-kafka.adoc
+++ b/docs/modules/sql/pages/mapping-to-kafka.adoc
@@ -57,7 +57,7 @@ NOTE: Any key/value pairs in the `OPTIONS()` function that are not recognized by
 Each member of the Hazelcast cluster has a processor running a Kafka connector for the mapping.
 For source mappings, preferred local parallelism is the number of parallel processors you would prefer on each member. 
 For balanced distributed processing, ensure that the local parallelism multiplied by the number of members in the cluster is a divisor of the total number of partitions in the Kafka topic.
-Otherwise, some processors will be assigned more topic partitions than others.
+If this is not done, some processors will be assigned more topic partitions than others.
 If there are more processors in the Hazelcast cluster than partitions in the Kafka topic, they will simply idle and waste resources.
 For sink mappings, the preferred local parallelism is always `1`.
 

--- a/docs/modules/sql/pages/mapping-to-kafka.adoc
+++ b/docs/modules/sql/pages/mapping-to-kafka.adoc
@@ -50,7 +50,7 @@ OPTIONS (
 <2> The name of the connector.
 <3> The address of the Kafka broker.
 <4> The SASL configuration used to authenticate client connections, where the API key provides the username and the API secret key provides the password. Note that the clause must end with a semi-colon, as shown in the example above.
-<5> The preferred local parallelism for the connector (for source mappings). If not specified, the default is `4`. See below for more information.
+<5> The preferred number of parallel processors on each member for source mappings. If not specified, the default is `4`.
 
 NOTE: Any key/value pairs in the `OPTIONS()` function that are not recognized by Hazelcast are passed directly to the Kafka consumer/producer.
 

--- a/docs/modules/sql/pages/mapping-to-kafka.adoc
+++ b/docs/modules/sql/pages/mapping-to-kafka.adoc
@@ -58,7 +58,7 @@ Each member of the Hazelcast cluster has a processor running a Kafka connector f
 For source mappings, preferred local parallelism is the number of parallel processors you would prefer on each member. 
 For balanced distributed processing, ensure that the local parallelism multiplied by the number of members in the cluster is a divisor of the total number of partitions in the Kafka topic.
 If this is not done, some processors will be assigned more topic partitions than others.
-If there are more processors in the Hazelcast cluster than partitions in the Kafka topic, they will simply idle and waste resources.
+Where there are more processors in the Hazelcast cluster than partitions in the Kafka topic, the additional processors will be idle and waste resources.
 For sink mappings, the preferred local parallelism is always `1`.
 
 When creating a Kafka mapping, you must tell the Kafka connector how to serialize/deserialize the keys and values in Kafka messages.

--- a/docs/modules/sql/pages/mapping-to-kafka.adoc
+++ b/docs/modules/sql/pages/mapping-to-kafka.adoc
@@ -55,7 +55,7 @@ OPTIONS (
 NOTE: Any key/value pairs in the `OPTIONS()` function that are not recognized by Hazelcast are passed directly to the Kafka consumer/producer.
 
 Each member of the Hazelcast cluster has a processor running a Kafka connector for the mapping.
-For source mappings, the preferred local parallelism is how many parallel processors there are on each member.
+For source mappings, preferred local parallelism is the number of parallel processors you would prefer on each member. 
 For a balanced distributed processing, the local parallelism multiplied by the number of members in the cluster should be a divisor of the total number of partitions in the Kafka topic.
 Otherwise, some processors will be assigned more topic partitions than others.
 If there are more processors in the Hazelcast cluster than partitions in the Kafka topic, they will simply idle and waste resources.

--- a/docs/modules/sql/pages/mapping-to-kafka.adoc
+++ b/docs/modules/sql/pages/mapping-to-kafka.adoc
@@ -56,7 +56,7 @@ NOTE: Any key/value pairs in the `OPTIONS()` function that are not recognized by
 
 Each member of the Hazelcast cluster has a processor running a Kafka connector for the mapping.
 For source mappings, preferred local parallelism is the number of parallel processors you would prefer on each member. 
-For a balanced distributed processing, the local parallelism multiplied by the number of members in the cluster should be a divisor of the total number of partitions in the Kafka topic.
+For balanced distributed processing, ensure that the local parallelism multiplied by the number of members in the cluster is a divisor of the total number of partitions in the Kafka topic.
 Otherwise, some processors will be assigned more topic partitions than others.
 If there are more processors in the Hazelcast cluster than partitions in the Kafka topic, they will simply idle and waste resources.
 For sink mappings, the preferred local parallelism is always `1`.

--- a/docs/modules/sql/pages/mapping-to-kafka.adoc
+++ b/docs/modules/sql/pages/mapping-to-kafka.adoc
@@ -30,17 +30,19 @@ To create a mapping to a Kafka topic in SQL, you must use the `CREATE MAPPING` s
 - The address of the Kafka broker
 - Client authentication details
 - How to serialize/deserialize the keys and values in messages
+- The preferred local parallelism for the connector (for source mappings)
 
 ```sql
 CREATE MAPPING my_topic <1>
 TYPE Kafka <2>
 OPTIONS (
     'bootstrap.servers' = '127.0.0.1:9092', <3>
-    'security.protocol'='SASL_SSL', 
-    'sasl.jaas.config'='org.apache.kafka.common.security.plain.PlainLoginModule
+    'security.protocol' = 'SASL_SSL',
+    'sasl.jaas.config' = 'org.apache.kafka.common.security.plain.PlainLoginModule
     required username="<my_api_key>"
     password="<my_api_secret>";',
-    'sasl.mechanism'='PLAIN', <4>
+    'sasl.mechanism' = 'PLAIN', <4>
+    'preferredLocalParallelism' = '2' <5>
 );
 ```
 
@@ -48,8 +50,16 @@ OPTIONS (
 <2> The name of the connector.
 <3> The address of the Kafka broker.
 <4> The SASL configuration used to authenticate client connections, where the API key provides the username and the API secret key provides the password. Note that the clause must end with a semi-colon, as shown in the example above.
+<5> The preferred local parallelism for the connector (for source mappings). If not specified, the default is `4`. See below for more information.
 
 NOTE: Any key/value pairs in the `OPTIONS()` function that are not recognized by Hazelcast are passed directly to the Kafka consumer/producer.
+
+Each member of the Hazelcast cluster has a processor running a Kafka connector for the mapping.
+For source mappings, the preferred local parallelism is how many parallel processors there are on each member.
+For a balanced distributed processing, the local parallelism multiplied by the number of members in the cluster should be a divisor of the total number of partitions in the Kafka topic.
+Otherwise, some processors will be assigned more topic partitions than others.
+If there are more processors in the Hazelcast cluster than partitions in the Kafka topic, they will simply idle and waste resources.
+For sink mappings, the preferred local parallelism is always `1`.
 
 When creating a Kafka mapping, you must tell the Kafka connector how to serialize/deserialize the keys and values in Kafka messages.
 To read Kafka messages, the Kafka connector must be able to deserialize them. Similarly, to publish messages to Kafka topics, the Kafka connector must be able to serialize them. You can tell Hazelcast how to serialize/deserialize keys and values by specifying the `keyFormat` and `valueFormat` fields in the `OPTIONS()` function.

--- a/docs/modules/sql/pages/mapping-to-kafka.adoc
+++ b/docs/modules/sql/pages/mapping-to-kafka.adoc
@@ -30,7 +30,7 @@ To create a mapping to a Kafka topic in SQL, you must use the `CREATE MAPPING` s
 - The address of the Kafka broker
 - Client authentication details
 - How to serialize/deserialize the keys and values in messages
-- The preferred number of parallel processors on each member for source mappings
+- The preferred number of parallel consumer processors on each member for input mappings
 
 ```sql
 CREATE MAPPING my_topic <1>
@@ -50,16 +50,15 @@ OPTIONS (
 <2> The name of the connector.
 <3> The address of the Kafka broker.
 <4> The SASL configuration used to authenticate client connections, where the API key provides the username and the API secret key provides the password. Note that the clause must end with a semi-colon, as shown in the example above.
-<5> The preferred number of parallel processors on each member for source mappings. If not specified, the default is `4`.
+<5> The preferred number of parallel consumer processors on each member for input mappings. If not specified, the default is `4`. For output mappings, the parallelism is always `1` and this option is ignored.
 
 NOTE: Any key/value pairs in the `OPTIONS()` function that are not recognized by Hazelcast are passed directly to the Kafka consumer/producer.
 
 Each member of the Hazelcast cluster has a processor running a Kafka connector for the mapping.
-For source mappings, preferred local parallelism is the number of parallel processors you would prefer on each member. 
-For balanced distributed processing, ensure that the local parallelism multiplied by the number of members in the cluster is a divisor of the total number of partitions in the Kafka topic.
-If this is not done, some processors will be assigned more topic partitions than others.
-Where there are more processors in the Hazelcast cluster than partitions in the Kafka topic, the additional processors will be idle and waste resources.
-For sink mappings, the preferred local parallelism is always `1`.
+For input mappings, preferred local parallelism is the number of parallel consumer processors you would prefer on each member.
+For balanced distributed processing, ensure that the local parallelism multiplied by the number of members in the cluster is a divisor of the total number of partitions in the input Kafka topic.
+If this is not done, some processors will be assigned more input Kafka topic partitions than others.
+Where there are more processors in the Hazelcast cluster than partitions in the input Kafka topic, the additional processors will be idle and waste resources.
 
 When creating a Kafka mapping, you must tell the Kafka connector how to serialize/deserialize the keys and values in Kafka messages.
 To read Kafka messages, the Kafka connector must be able to deserialize them. Similarly, to publish messages to Kafka topics, the Kafka connector must be able to serialize them. You can tell Hazelcast how to serialize/deserialize keys and values by specifying the `keyFormat` and `valueFormat` fields in the `OPTIONS()` function.


### PR DESCRIPTION
This PR documents the new `preferredLocalParallelism` SQL Kafka mapping option from <https://github.com/hazelcast/hazelcast/pull/26194>.
I also took the opportunity to align the formatting of other existing options in the example.