### PR TITLE
[CN-1101] Update Adding Custom Jar Page

### DIFF
--- a/docs/modules/kubernetes/pages/helm-adding-custom-jar.adoc
+++ b/docs/modules/kubernetes/pages/helm-adding-custom-jar.adoc
@@ -1,11 +1,11 @@
 = Adding custom JAR files to the Platform/Management Center Classpath
 
-NOTE: We highly recommend you to use Hazelcast Platform Operator's xref:operator:ROOT:user-code-deployment.adoc[User Code Deployment] feature if you need to add custom jar to your Hazelcast members.
+NOTE: We strongly recommend that you use Hazelcast Platform Operator's xref:operator:ROOT:user-code-deployment.adoc[User Code Deployment] feature if you need to add a custom JAR to your Hazelcast members.
 
-If you'd like to add custom JAR files to the Platform/Management Center, you can extend the Hazelcast/Management Center base image and provide your configuration file or/and custom JARs.
-To do that, you need to create a new `Dockerfile` and build it with `docker build` command.
+If you want to add custom JAR files to the Platform and/or Management Center, you can extend the relevant base image and provide your configuration file and/or custom JARs.
+To do this, you must create a new `Dockerfile` and build it using the `docker build` command.
 
-In the `Dockerfile` example below, we are creating a new image based on the Hazelcast image and adding a custom JAR
+In the `Dockerfile` example below, we create a new image based on the Hazelcast image and add a custom JAR
 from our host to the container, which will be used with Hazelcast when the container runs.
 
 

--- a/docs/modules/kubernetes/pages/helm-adding-custom-jar.adoc
+++ b/docs/modules/kubernetes/pages/helm-adding-custom-jar.adoc
@@ -1,75 +1,35 @@
 = Adding custom JAR files to the Platform/Management Center Classpath
 
-You can mount any volume which contains your JAR files to the pods created by the helm chart using the `customVolume` configuration.
+NOTE: We highly recommend you to use Hazelcast Platform Operator's xref:operator:ROOT:user-code-deployment.adoc[User Code Deployment] feature if you need to add custom jar to your Hazelcast members.
 
-Setting the `customVolume` mounts the provided volume to the pod on the `/data/custom` path. This path is also appended to the classpath of running Java process.
+If you'd like to add custom JAR files to the Platform/Management Center, you can extend the Hazelcast/Management Center base image and provide your configuration file or/and custom JARs.
+To do that, you need to create a new `Dockerfile` and build it with `docker build` command.
 
-For example, if you have existing link:https://kubernetes.io/blog/2019/04/04/kubernetes-1.14-local-persistent-volumes-ga/[Local Persistent Volumes] and Persistent Volume Claims like below;
+In the `Dockerfile` example below, we are creating a new image based on the Hazelcast image and adding a custom JAR
+from our host to the container, which will be used with Hazelcast when the container runs.
+
+
+[source,dockerfile]
+----
+FROM hazelcast/hazelcast:$HAZELCAST_VERSION
+
+# Adding custom JARs to the classpath
+ADD custom-library.jar ${HZ_HOME}
+----
+
+Build and push the image to your own Docker registry.
+
+[source,bash]
+----
+docker build -t example/hazelcast .
+docker push example/hazelcast
+----
+
+You can configure your Helm chart to use the custom image you have built in your `values.yaml`.
 
 [source,yaml]
 ----
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-name: local-storage
-provisioner: kubernetes.io/no-provisioner
-volumeBindingMode: WaitForFirstConsumer
-
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-name: <hz-custom-local-pv / mc-custom-local-pv>
-spec:
-storageClassName: local-storage
-capacity:
-  storage: 1Gi
-accessModes:
-  - ReadWriteOnce
-local:
-  path: </path/to/your/jars>
-nodeAffinity:
-  required:
-  nodeSelectorTerms:
-  - matchExpressions:
-    - key: kubernetes.io/hostname
-      operator: In
-      values:
-      - <YOUR_NODE_1>
-      - <YOUR_NODE_2>
----
-
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-name: < hz-custom-local-pv-claim / mc-custom-local-pv-claim>
-spec:
-storageClassName: local-storage
-accessModes:
-  - ReadWriteOnce
-resources:
-  requests:
-    storage: 1Gi
-----
-
-You can configure your Helm chart to use it like below in your `values.yaml` file.
-
-For IMDG:
-
-[source,yaml]
-----
-customVolume:
-  persistentVolumeClaim:
-    claimName: hz-custom-local-pv-claim
-----
-
-For Management Center:
-
-[source,yaml]
-----
-mancenter:
-  ...
-  customVolume:
-    persistentVolumeClaim:
-      claimName: mc-custom-local-pv-claim
+image:
+  # repository is the Hazelcast image name
+  repository: example/hazelcast
 ----


### PR DESCRIPTION
Since the old suggested way for adding custom jar is not the best practice and it's complicated, we wanted to promote Hazelcast Platform Operator User Code Deployment(UCD) feature. And suggest the basic solution which is custom docker image to our users. Here is the updated version of the page:
 
<img width="1104" alt="Screen Shot 2024-02-01 at 5 07 38 PM" src="https://github.com/hazelcast/hz-docs/assets/44342412/d916b00a-3a07-4046-91bf-9e239cdb6159">
