### PR TITLE
stream-processing-client.adoc: wrong description of TestSources.itemStream

### DIFF
--- a/docs/modules/pipelines/pages/stream-processing-client.adoc
+++ b/docs/modules/pipelines/pages/stream-processing-client.adoc
@@ -172,7 +172,7 @@ public class EvenNumberStream {
 ----
 
 <1> Initialize an empty pipeline.
-<2> Read from the dummy data source. Every 10 seconds, the `itemStream()` method emits `SimpleEvent` objects that contain an increasing sequence number.
+<2> Read from the dummy data source. Every second, the `itemStream()` method emits 10 `SimpleEvent` objects that contain an increasing sequence number.
 <3> Tell Hazelcast that you do not plan on using timestamps to process the data. Timestamps are useful for time-sensitive processes such as aggregating streaming data. In this example, you aren't aggregating data.
 <4> Filter out any even numbers from the stream. The `filter()` method receives the `SimpleEvent` objects from the dummy source. 
 <5> Set the name of this processing stage. Naming a processing stage makes it easier to recognize in the <<step-4-monitor-your-jobs-in-management-center, DAG view>> of Management Center.


### PR DESCRIPTION
In `TestSources.itemStream(n)`, `n` is the number of items per second and not (as stated previously), the number of seconds per item.