### PR TITLE
Small improvements to v1 DMT docs

### DIFF
--- a/docs/modules/migrate/pages/data-migration-tool.adoc
+++ b/docs/modules/migrate/pages/data-migration-tool.adoc
@@ -20,6 +20,8 @@ The DMT is typically used in the following situations:
 . If you want to avoid downtime, use an in-place rolling upgrade instead of the DMT tool. For further information on upgrading without interrupting the operation of the cluster, see the xref:maintain-cluster:rolling-upgrades.adoc[Rolling Upgrades] topic.
 
 . The DMT does not support migrating data serialized with xref:serialization:compact-serialization.adoc[Compact Serialization]. Support for Compact Serialization is planned for the next release.
+
+. If you want to migrate compact data, you are responsible for migrating any schemas. To avoid issues with missing schemas during migration, ensure that the schemas are available on the target cluster before starting the migration. For example, you could use a client to add data to a target cluster; the client puts schemas first, and then data. This will be addressed in the next release.
 ====
 
 The DMT can be run on Mac, Linux, and Windows Operating Systems.
@@ -105,12 +107,6 @@ NOTE: If you are using the DMT to test a migration, use a Development cluster wh
 The clusters work to migrate your data as illustrated below:
 
 image::ROOT:dmt_diagram.png[DMT Clusters]
-
-==== Limited Migration Cluster License
-
-A 10-node limited license is included for use with your migration cluster. 
-
-This license is valid for 30 days and can be used only for data migration and trial purposes. 
 
 === Start the Source Cluster
 


### PR DESCRIPTION
Removed license section
Added note on compact data migration limitation

These changes apply only to the 5.3 doc set for v1 of the DMT; updates for the 5.4 doc set for DMT v2 are under [PR #936](https://github.com/hazelcast/hz-docs/pull/936)  