### PR TITLE
Removing irrelevant deprecation notice for JMS connector.

### DIFF
--- a/docs/modules/integrate/pages/jms-connector.adoc
+++ b/docs/modules/integrate/pages/jms-connector.adoc
@@ -176,9 +176,3 @@ messages will be missing from the sink. To test your broker we provide a
 tool, please go to link:https://github.com/hazelcast/hazelcast-jet-contrib/tree/master/xa-test[XA tests]
 to get more information. This only applies to JMS sink, the source
 doesn't use XA transactions.
-
-[CAUTION]
-.Deprecation Notice for Transactions
-====
-Hazelcast will deprecate transactions in the upcoming release (5.4). An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
-====


### PR DESCRIPTION
As per https://hazelcast.slack.com/archives/C035HQET5/p1705934770078339