### PR TITLE
Add missing column types for MySQL to documentation

### DIFF
--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -105,20 +105,50 @@ Hazelcast supports a subset of SQL data types. For MySQL data types, see the htt
 |`CHAR`
 |`VARCHAR`
 
+|`TINYTEXT`
+|`VARCHAR`
+
+|`MEDIUMTEXT`
+|`VARCHAR`
+
+|`LONGTEXT`
+|`VARCHAR`
+
 |`TEXT`
 |`VARCHAR`
 
 |`BOOLEAN`
 |`BOOLEAN`
 
+|`TINYINT`
+|`TINYINT`
+
+|`TINYINT UNSIGNED`
+|`SMALLINT`
+
 |`SMALLINT`
 |`SMALLINT`
+
+|`SMALLINT UNSIGNED`
+|`INT`
+
+|`MEDIUMINT`
+|`INT`
+
+|`MEDIUMINT UNSIGNED`
+|`INT`
 
 |`INT`
 |`INTEGER`
 
+|`INT UNSIGNED`
+|`BIGINT`
+
 |`BIGINT`
 |`BIGINT`
+
+|`BIGINT UNSIGNED`
+|`DECIMAL`
 
 |`DECIMAL`
 |`DECIMAL`


### PR DESCRIPTION
Some MySQL columns types were missing for JDBC mapping. 
This PR adds these to documentation

Jira : https://hazelcast.atlassian.net/browse/HZ-4285
Fixed by : https://github.com/hazelcast/hazelcast-mono/pull/592