### PR TITLE
Add missing date column types for Sql Server to documentation

### DIFF
--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -271,6 +271,12 @@ For MSSQL data types, see the https://learn.microsoft.com/en-us/sql/t-sql/data-t
 |`datetime`
 |`TIMESTAMP`
 
+|`datetime2`
+|`TIMESTAMP`
+
+|`smalldatetime`
+|`TIMESTAMP`
+
 |`datetimeoffset`
 |`TIMESTAMP WITH TIME ZONE`
 


### PR DESCRIPTION
Fixed by : https://github.com/hazelcast/hazelcast-mono/pull/675
Jira : https://hazelcast.atlassian.net/browse/HZ-4332

The missing column type related to **date** handling is merged to master

This PR updates the documentation