### PR TITLE
Add default WAN republishing behaviour information

### DIFF
--- a/docs/modules/wan/pages/configuring-for-map-and-cache.adoc
+++ b/docs/modules/wan/pages/configuring-for-map-and-cache.adoc
@@ -74,7 +74,7 @@ will be used as the merge policy.
 * `republishing-enabled`: When enabled, an incoming event to a member is forwarded to target cluster of that member.
 Enabling the event republishing is useful in a scenario where cluster A replicates to cluster B and
 cluster B replicates to cluster C. You do not need to enable republishing when all your clusters
-replicate to each other.
+replicate to each other. If not otherwise specified, the default value for republishing is `true` (enabled).
 
 When using Active-Active Replication, multiple clusters can simultaneously update the same
 entry in a distributed data structure. You can configure a merge policy to resolve these potential


### PR DESCRIPTION
It turns out there is no documentation about the default state of WAN's republishing feature (that I could find). I've also updated the Javadocs in this PR: https://github.com/hazelcast/hazelcast-mono/pull/728