### PR TITLE
Add missing column types for Oracle to documentation

### DIFF
--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -315,11 +315,15 @@ For Oracle data types see the https://docs.oracle.com/en/database/oracle/oracle-
 |`NUMBER(p,s) where "s" is 0 and "p" is bigger than 18 or "s+p" is bigger than 15`
 |`DECIMAL`
 
-|`NUMBER(p,s) where "s+p" is smaller than 8`
+|`BINARY_FLOAT`
 |`REAL`
 
 |`NUMBER(p,s) where "s+p" is smaller than 16`
 |`DOUBLE`
+
+|`BINARY_DOUBLE`
+|`DOUBLE`
+
 
 |`DATE`
 |`DATE`


### PR DESCRIPTION
I have added these rows:

BINARY_FLOAT -> REAL
BINARY_DOUBLe -> DOUBLE


Jira : https://hazelcast.atlassian.net/browse/HZ-4375
Fiex By : https://github.com/hazelcast/hazelcast-mono/pull/727