### PR TITLE
Document that a non-PK column shouldn't be specified as the id-column [HZ-4211]

### DIFF
--- a/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
+++ b/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
@@ -257,7 +257,7 @@ mapConfig.setMapStoreConfig(mapStoreConfig);
 ====
 
 |[[id-column]]`id-column`
-|Name of the column that contains the primary key. Do not specify a column without a primary key constraint as the id-column.
+|Name of the column that contains the primary key. Do not specify a column without a unique key constraint as the id-column.
 
 |id
 |

--- a/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
+++ b/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
@@ -257,7 +257,7 @@ mapConfig.setMapStoreConfig(mapStoreConfig);
 ====
 
 |[[id-column]]`id-column`
-|Name of the column that contains the primary key.
+|Name of the column that contains the primary key. A column without a primary key constraint should not be specified as the id-column.
 
 |id
 |
@@ -381,7 +381,7 @@ You can use any database as the MapStore backend as long as you have its Hazelca
 
 Officially supported backend databases:
 
-- MySQL, PostgreSQL (it uses JDBC SQL Connector).
+- MySQL, PostgreSQL, Microsoft SQL Server, Oracle (it uses JDBC SQL Connector).
 - MongoDB (make sure you have `hazelcast-jet-mongodb` artifact included on the classpath).
 
 == Related Resources

--- a/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
+++ b/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
@@ -257,7 +257,7 @@ mapConfig.setMapStoreConfig(mapStoreConfig);
 ====
 
 |[[id-column]]`id-column`
-|Name of the column that contains the primary key. A column without a primary key constraint should not be specified as the id-column.
+|Name of the column that contains the primary key. Do not specify a column without a primary key constraint as the id-column.
 
 |id
 |


### PR DESCRIPTION
Added Microsoft SQL Server and Oracle to the supported databases and added a warning for declaring non-pk columns as the id-column. 