### PR TITLE
Write fields in alphabetical order when using GenericRecord and compact serialization for the same object [API-2215]

### DIFF
--- a/docs/modules/clusters/pages/accessing-domain-objects.adoc
+++ b/docs/modules/clusters/pages/accessing-domain-objects.adoc
@@ -41,6 +41,8 @@ With the introduction of `GenericRecord`, User Code Deployment should be used on
 
 == Creating New Portable Objects
 
+CAUTION: Portable Serialization has been deprecated. We recommend you use Compact Serialization as Portable Serialization will be removed as of version 7.0.
+
 To create a `GenericRecord` object in portable format, use the `GenericRecordBuilder.portable()` method:
 
 [source,java]
@@ -73,6 +75,8 @@ GenericRecord namedRecord = GenericRecordBuilder.compact("employee")
 
 Note that there is no need to create a class definition, or a schema in this case. A schema will be created
 from the fields of the builder automatically.
+
+WARNING: If you want to use the same object using the `GenericRecord` and the compact serializer, then you should write your object fields in the `CompactSerializer.write` method in the alphabetical order. Otherwise, the fields will not be matched correctly.
 
 == Adding and Changing Values in Domain Objects
 

--- a/docs/modules/clusters/pages/accessing-domain-objects.adoc
+++ b/docs/modules/clusters/pages/accessing-domain-objects.adoc
@@ -80,7 +80,7 @@ GenericRecord namedRecord = GenericRecordBuilder.compact("employee")
 Note that there is no need to create a class definition, or a schema in this case. A schema will be created
 from the fields of the builder automatically.
 
-WARNING: If you want to use the same object using the `GenericRecord` and the compact serializer, then you should write your object fields in the `CompactSerializer.write` method in the alphabetical order. Otherwise, the fields will not be matched correctly.
+WARNING: To use the same object when using `GenericRecord` and the compact serializer, write your object fields in alphabetic order in the `CompactSerializer.write` method. If this is not done, the fields are not correctly matched.
 
 == Adding and Changing Values in Domain Objects
 

--- a/docs/modules/clusters/pages/accessing-domain-objects.adoc
+++ b/docs/modules/clusters/pages/accessing-domain-objects.adoc
@@ -80,7 +80,7 @@ GenericRecord namedRecord = GenericRecordBuilder.compact("employee")
 Note that there is no need to create a class definition, or a schema in this case. A schema will be created
 from the fields of the builder automatically.
 
-WARNING: To use the same object when using `GenericRecord` and the compact serializer, write your object fields in alphabetic order in the `CompactSerializer.write` method. If this is not done, the fields are not correctly matched.
+WARNING: Data mismatches can occur if you use both generic and specific Compact serializers. For example, the Compact Generic Record serializer, which is included with Hazelcast, writes variable size fields in alphabetic order based on the field name. To avoid potential mismatches in your data, write explicit variable size fields for Compact serializers in alphabetic order.
 
 == Adding and Changing Values in Domain Objects
 

--- a/docs/modules/clusters/pages/accessing-domain-objects.adoc
+++ b/docs/modules/clusters/pages/accessing-domain-objects.adoc
@@ -41,7 +41,11 @@ With the introduction of `GenericRecord`, User Code Deployment should be used on
 
 == Creating New Portable Objects
 
-CAUTION: Portable Serialization has been deprecated. We recommend you use Compact Serialization as Portable Serialization will be removed as of version 7.0.
+CAUTION: 
+.Deprecation Notice for Portable Serialization
+====
+Portable Serialization has been deprecated. We recommend you use Compact Serialization as Portable Serialization will be removed as of version 7.0.
+====
 
 To create a `GenericRecord` object in portable format, use the `GenericRecordBuilder.portable()` method:
 


### PR DESCRIPTION
Added the warning about the write order of the fields for compact serialization when the genericrecord is also used for the same object.

Also, added the missing deprecation notice to the `Creating New Portable Objects` section.

fixes https://github.com/hazelcast/hazelcast-mono/issues/714