### PR TITLE
Add CPMap to Spring Resources [HZ-4196]

### DIFF
--- a/docs/modules/spring/pages/configuration.adoc
+++ b/docs/modules/spring/pages/configuration.adoc
@@ -227,6 +227,7 @@ you must enable the permissions for transactions. For further information, see t
 ** `countDownLatch`
 ** `lock`
 ** `externalDataStore`
+** `cpmap`
 +
 [source,xml]
 ----
@@ -265,6 +266,7 @@ you must enable the permissions for transactions. For further information, see t
         <hz:property name="jdbcUrl">jdbc:mysql://dummy:3306</hz:property>
     </hz:properties>
 </hz:external-data-store>
+<hz:cpmap instance-ref="instance" name="cpmap" id="cpMap" />
 ----
 +
 * **Supported Spring Bean Attributes**


### PR DESCRIPTION
Add `CPMap` to the set of configurables in the Spring configuration section with an example.