### PR TITLE
Document 2 recently added WAN metrics [HZ-4342]

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -1730,7 +1730,7 @@ Based on your latency tolerance in your business use case, you can define a thre
 
 |`partitions.migrationActive`
 |boolean
-|Number of active migration tasks
+|Whether there are any currently active migration tasks
 
 |`partitions.migrationQueueSize`
 |count
@@ -2510,6 +2510,14 @@ Based on your latency tolerance in your business use case, you can define a thre
 |`wan.updateCount`
 |count
 |Number of entry update events
+
+|`wan.connectionHealth`
+|boolean
+|The health of an individual WAN target endpoint, where 1 is healthy and 0 is not
+
+|`wan.failedTransmitCount`
+|count
+|Number of attempted WAN replication transmissions that have failed
 |===
 ====
 


### PR DESCRIPTION
I recently added `wan.connectionHealth` metrics [in this commit](https://github.com/hazelcast/hazelcast-mono/commit/b0033718743cce98287ec6e47cfbd2d48570d34d), and today I am introducing `wan.failedTransmitCount` [in this PR](https://github.com/hazelcast/hazelcast-mono/pull/848).

This commit updates documentation for these 2 metrics, and also corrects the description for `partitions.migrationActive` as I noticed it wasn't accurate.