### PR TITLE
Updated action versions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.ACTION_UPDATER }}

--- a/.github/workflows/backport-5-0.yml
+++ b/.github/workflows/backport-5-0.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5-1.yml
+++ b/.github/workflows/backport-5-1.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5-2.yml
+++ b/.github/workflows/backport-5-2.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5-3.yml
+++ b/.github/workflows/backport-5-3.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5-4-beta-2.yml
+++ b/.github/workflows/backport-5-4-beta-2.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
          fetch-depth: 0
 

--- a/.github/workflows/forwardport.yml
+++ b/.github/workflows/forwardport.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
          fetch-depth: 0
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4.1.1
+    - uses: actions/setup-node@v4.0.2
       with:
         node-version: 16
     - name: Check for broken internal links

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4.1.1
     - uses: actions/setup-node@v4.0.2
       with:
-        node-version: 16
+        node-version: 20
     - name: Check for broken internal links
       run: |
         npm i


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.2](https://github.com/actions/setup-node/releases/tag/v4.0.2)** on 2024-02-07T04:51:19Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
