### PR TITLE
Fix WAN static discovery properties description

### DIFF
--- a/docs/modules/wan/pages/tuning.adoc
+++ b/docs/modules/wan/pages/tuning.adoc
@@ -860,7 +860,7 @@ hazelcast:
 Health checks attempt connections, and each connection attempt can take up to ten seconds to timeout.
 For this reason, ensure that tasks are sufficiently spaced to reduce the system resource usage. Default is `10000`.
 <2> Defines the maximum duration to wait when checking connection health, in milliseconds. Default is `3000`.
-<3> When an unhealthy connection is not found during target discovery, it is
+<3> When an unhealthy connection is found during target discovery, it is
 marked as a failed probe attempt. This property defines the maximum number of times a connection probe can be marked as failed in a row,
 after which it is removed from subsequent health checks. Set to `-1` if you do not want to remove these connections from health checks. Default is `10`.
 <4> Defines whether all connections are treated as potentially unhealthy


### PR DESCRIPTION
Fixes typo in the `HEALTH_CHECK_MAX_FAILED_PROBES` property description. This must be present for 5.4 onwards.