### PR TITLE
Correct UCN Namespace definition key

### DIFF
--- a/docs/modules/clusters/pages/ucn-enable.adoc
+++ b/docs/modules/clusters/pages/ucn-enable.adoc
@@ -47,8 +47,7 @@ XML::
 +
 [source,xml]
 ----
-<user-code-namespaces>
-    <user-code-namespaces enabled="true">
+<user-code-namespaces enabled="true">
 </user-code-namespaces>
 ----
 

--- a/docs/modules/clusters/pages/ucn-member-side.adoc
+++ b/docs/modules/clusters/pages/ucn-member-side.adoc
@@ -34,8 +34,8 @@ XML::
         <class>com.acme.app.BeanComparator</class>
       </blacklist>
     </java-serialization-filter>
-    <user-code-namespace name="myNameSpace">
-    </user-code-namespace>
+    <namespace name="myNameSpace">
+    </namespace>
 </user-code-namespaces>
 ----
 
@@ -80,7 +80,7 @@ XML::
 ----
 <user-code-namespaces enabled="true">
     ...
-    <user-code-namespace name="myNameSpace">
+    <namespace name="myNameSpace">
         <jar id="jarID">
             <url>file:///hazelcast/src/class/usercodedeployment/MyJarFile.jar</url>
         </jar>
@@ -90,7 +90,7 @@ XML::
         <class id="classId">
           <url>file:///hazelcast/src/class/usercodedeployment/MyClass.class</url>
         </class>
-    </user-code-namespace>
+    </namespace>
 </user-code-namespaces>
 ----
 

--- a/docs/modules/clusters/pages/ucn-non-associated.adoc
+++ b/docs/modules/clusters/pages/ucn-non-associated.adoc
@@ -41,8 +41,8 @@ XML::
 ----
 <user-code-namespaces enabled="true">
     ...
-    <user-code-namespace name="default">
-    </user-code-namespace>
+    <namespace name="default">
+    </namespace>
 </user-code-namespaces>
 ----
 
@@ -71,7 +71,7 @@ XML::
 ----
 <user-code-namespaces enabled="true">
     ...
-    <user-code-namespace name="default">
+    <namespace name="default">
         <jar id="jarID">
             <url>file:///yoursrc/class/ucnDefaults/MyJarFile.jar</url>
         </jar>
@@ -81,7 +81,7 @@ XML::
         <class id="classId">
           <url>file:///yoursrc/class/ucnDefaults/MyClass.class</url>
         </class>
-    </user-code-namespace>
+    </namespace>
 </user-code-namespaces>
 ----
 


### PR DESCRIPTION
The `user-code-namespace` key was changed to `namespace` before release as the `user-code-` prefix is redundant when part of the parent `user-code-namespaces` property anyway.