### PR TITLE
Added character data mapping for Postgres.

### DIFF
--- a/docs/modules/sql/pages/mapping-to-jdbc.adoc
+++ b/docs/modules/sql/pages/mapping-to-jdbc.adoc
@@ -185,6 +185,9 @@ For PostgreSQL data types, see the https://www.postgresql.org/docs/current/datat
 |`char`
 |`VARCHAR`
 
+|`character`
+|`VARCHAR`
+
 |`bpchar`
 |`VARCHAR`
 


### PR DESCRIPTION
Adding Character data mapping to docs as it is part of [DefaultTypeResolver](https://github.com/hazelcast/hazelcast-mono/blob/058ffb99800213830be896282a38b891a66b2b64/hazelcast/hazelcast-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/jdbc/DefaultTypeResolver.java#L47C1-L47C13).