### PR TITLE
Describe recommendations for destroy method [HZ-4563]

### DIFF
--- a/docs/modules/data-structures/pages/distributed-data-structures.adoc
+++ b/docs/modules/data-structures/pages/distributed-data-structures.adoc
@@ -211,6 +211,10 @@ Hazelcast is designed to create any distributed data structure whenever it is ac
 Therefore, keep in mind that a
 data structure is recreated when you perform an operation on it even after you have destroyed it.
 
+NOTE: If you plan to use the distributed object later, prefer clearing the object using `clear()` method or equivalent instead of destroying it.
+
+WARNING: Do not use distributed object concurrently with `destroy()` invocation. This may make the object not fully usable.
+
 == Configuring Data Structures
 
 As to the configuration of distributed objects, Hazelcast uses the default settings

--- a/docs/modules/data-structures/pages/distributed-data-structures.adoc
+++ b/docs/modules/data-structures/pages/distributed-data-structures.adoc
@@ -216,7 +216,7 @@ NOTE: If you plan to use the distributed object later, clear the object using th
 WARNING: Do not use the distributed object concurrently with the `destroy()` invocation, as this can result in the object not being fully usable.
 
 WARNING: If you want to use the destroyed distributed object again, make sure that you do not hold any old references, but obtain a new, fresh reference from `HazelcastInstance.getXXX` method, 
-otherwise the object may not be fully usable.
+otherwise the object might not be fully usable.
 
 == Configuring Data Structures
 

--- a/docs/modules/data-structures/pages/distributed-data-structures.adoc
+++ b/docs/modules/data-structures/pages/distributed-data-structures.adoc
@@ -215,6 +215,9 @@ NOTE: If you plan to use the distributed object later, clear the object using th
 
 WARNING: Do not use the distributed object concurrently with the `destroy()` invocation, as this can result in the object not being fully usable.
 
+WARNING: If you want to use the destroyed distributed object again, make sure that you do not hold any old references, but obtain a new, fresh reference from `HazelcastInstance.getXXX` method, 
+otherwise the object may not be fully usable.
+
 == Configuring Data Structures
 
 As to the configuration of distributed objects, Hazelcast uses the default settings

--- a/docs/modules/data-structures/pages/distributed-data-structures.adoc
+++ b/docs/modules/data-structures/pages/distributed-data-structures.adoc
@@ -211,7 +211,7 @@ Hazelcast is designed to create any distributed data structure whenever it is ac
 Therefore, keep in mind that a
 data structure is recreated when you perform an operation on it even after you have destroyed it.
 
-NOTE: If you plan to use the distributed object later, prefer clearing the object using `clear()` method or equivalent instead of destroying it.
+NOTE: If you plan to use the distributed object later, clear the object using the `clear()` method or equivalent instead of destroying it.
 
 WARNING: Do not use distributed object concurrently with `destroy()` invocation. This may make the object not fully usable.
 

--- a/docs/modules/data-structures/pages/distributed-data-structures.adoc
+++ b/docs/modules/data-structures/pages/distributed-data-structures.adoc
@@ -213,7 +213,7 @@ data structure is recreated when you perform an operation on it even after you h
 
 NOTE: If you plan to use the distributed object later, clear the object using the `clear()` method or equivalent instead of destroying it.
 
-WARNING: Do not use distributed object concurrently with `destroy()` invocation. This may make the object not fully usable.
+WARNING: Do not use the distributed object concurrently with the `destroy()` invocation, as this can result in the object not being fully usable.
 
 == Configuring Data Structures
 

--- a/docs/modules/data-structures/pages/distributed-data-structures.adoc
+++ b/docs/modules/data-structures/pages/distributed-data-structures.adoc
@@ -215,7 +215,7 @@ NOTE: If you plan to use the distributed object later, clear the object using th
 
 WARNING: Do not use the distributed object concurrently with the `destroy()` invocation, as this can result in the object not being fully usable.
 
-WARNING: If you want to use the destroyed distributed object again, make sure that you do not hold any old references, but obtain a new, fresh reference from `HazelcastInstance.getXXX` method, 
+WARNING: If you want to use the destroyed distributed object again, do not hold any old references; instead, obtain a new reference using the `HazelcastInstance.getXXX` method, 
 otherwise the object might not be fully usable.
 
 == Configuring Data Structures


### PR DESCRIPTION
Invoking `destroy` concurrently with other operations may cause the object being recreated but not fully usable (eg. IMap indexes may not work). See HZ-4563