### PR TITLE
Update WAN Rest API with target scope information [HZ-4594]

### DIFF
--- a/docs/modules/wan/pages/rest-api.adoc
+++ b/docs/modules/wan/pages/rest-api.adoc
@@ -96,7 +96,7 @@ The command according to the above example configuration is as follows:
 curl -X POST -d "tokyo&&london-wan-rep&london" --URL http://127.0.0.1:5701/hazelcast/rest/wan/clearWanQueues
 ```
 
-IMPORTANT: This endpoint will only clear the specified WAN queues of the member it is sent to, it will not clear WAN queues for all members of the cluster.
+IMPORTANT: This endpoint only clears the specified WAN queues of the member it is sent to, it does not clear WAN queues for all members of the cluster.
 
 == Pausing the Publisher
 
@@ -118,7 +118,7 @@ The command according to the above example configuration is as follows:
 curl -X POST -d "tokyo&&london-wan-rep&london" --URL http://127.0.0.1:5701/hazelcast/rest/wan/pausePublisher
 ```
 
-IMPORTANT: This endpoint will only pause the specified WAN publisher on the member it is sent to, it will not pause WAN publishers for any other members of the cluster.
+IMPORTANT: This endpoint only pauses the specified WAN publisher on the member it is sent to, it does not pause WAN publishers for any other members of the cluster.
 
 == Resuming the Publisher
 
@@ -140,7 +140,7 @@ The command according to the above example configuration is as follows:
 curl -X POST -d "tokyo&&london-wan-rep&london" --URL http://127.0.0.1:5701/hazelcast/rest/wan/resumePublisher
 ```
 
-IMPORTANT: This endpoint will only resume the specified WAN publisher on the member it is sent to, it will not resume WAN publishers for any other members of the cluster.
+IMPORTANT: This endpoint only resumes the specified WAN publisher on the member it is sent to, it does not resume WAN publishers for any other members of the cluster.
 
 == Stopping the Publisher
 
@@ -162,7 +162,7 @@ The command according to the above example configuration is as follows:
 curl -X POST -d "tokyo&&london-wan-rep&london" --URL http://127.0.0.1:5701/hazelcast/rest/wan/stopPublisher
 ```
 
-IMPORTANT: This endpoint will only stop the specified WAN publisher on the member it is sent to, it will not stop WAN publishers for any other members of the cluster.
+IMPORTANT: This endpoint only stops the specified WAN publisher on the member it is sent to, it does not stop WAN publishers for any other members of the cluster.
 
 == Synchronizing the Clusters
 
@@ -196,7 +196,7 @@ The following is an example output:
 {"status":"success","message":"Sync initiated","uuid":"22e1e3d6-1c96-4757-baee-4cd77f1d214e"}
 ```
 
-IMPORTANT: This endpoint will initiate WAN synchronization across the entire cluster, with the receiving member designated as the coordinator for the synchronization process.
+IMPORTANT: This endpoint initiates WAN synchronization across the entire cluster, with the receiving member designated as the coordinator for the synchronization process.
 
 === Delta Synchronization
 
@@ -219,7 +219,7 @@ a single map or all the maps.
 
 NOTE: Consistency check can be triggered only for one map.
 
-IMPORTANT: This endpoint will initiate WAN synchronization across the entire cluster, with the receiving member designated as the coordinator for the synchronization process.
+IMPORTANT: This endpoint initiates WAN synchronization across the entire cluster, with the receiving member designated as the coordinator for the synchronization process.
 
 == Tracking the WAN Sync Progress
 
@@ -244,7 +244,7 @@ The following is an example output:
 
 The other stages are `STARTED`, `IN_PROGRESS` and `FAILED`.
 
-IMPORTANT: As WAN synchronization is an operation that occurs across the cluster, this response will represent the WAN sync progress for the entire cluster.
+IMPORTANT: As WAN synchronization is an operation that occurs across the cluster, this response represents the WAN sync progress for the entire cluster.
 
 [[wr-dynamically-adding]]
 == Dynamically Adding WAN Publishers
@@ -265,4 +265,4 @@ curl -X POST -d "{clusterOnSource}&{clusterPassword}&{wanConfig}" --URL http://1
 The `wanConfig` parameter should be the full configuration as a JSON string.
 See xref:advanced-features.adoc#dynamically-adding-wan-publishers[here] for configuration examples.
 
-IMPORTANT: This endpoint will deploy the provided config across all members of the cluster, following the same principles as other dynamic configuration mechanisms.
+IMPORTANT: This endpoint deploys the provided config across all members of the cluster, following the same principles as other dynamic configuration mechanisms.

--- a/docs/modules/wan/pages/rest-api.adoc
+++ b/docs/modules/wan/pages/rest-api.adoc
@@ -78,7 +78,7 @@ hazelcast:
 
 == Clearing the Queues
 
-The URL for cleaning the WAN event queues is as follows:
+The URL for clearing the WAN event queues is as follows:
 
 ```
 http://{member IP address:port}/hazelcast/rest/wan/clearWanQueues
@@ -96,6 +96,7 @@ The command according to the above example configuration is as follows:
 curl -X POST -d "tokyo&&london-wan-rep&london" --URL http://127.0.0.1:5701/hazelcast/rest/wan/clearWanQueues
 ```
 
+IMPORTANT: This endpoint will only clear the specified WAN queues of the member it is sent to, it will not clear WAN queues for all members of the cluster.
 
 == Pausing the Publisher
 
@@ -117,6 +118,8 @@ The command according to the above example configuration is as follows:
 curl -X POST -d "tokyo&&london-wan-rep&london" --URL http://127.0.0.1:5701/hazelcast/rest/wan/pausePublisher
 ```
 
+IMPORTANT: This endpoint will only pause the specified WAN publisher on the member it is sent to, it will not pause WAN publishers for any other members of the cluster.
+
 == Resuming the Publisher
 
 The URL for resuming the WAN publisher is as follows:
@@ -137,6 +140,8 @@ The command according to the above example configuration is as follows:
 curl -X POST -d "tokyo&&london-wan-rep&london" --URL http://127.0.0.1:5701/hazelcast/rest/wan/resumePublisher
 ```
 
+IMPORTANT: This endpoint will only resume the specified WAN publisher on the member it is sent to, it will not resume WAN publishers for any other members of the cluster.
+
 == Stopping the Publisher
 
 The URL for stopping the WAN publisher is as follows:
@@ -156,6 +161,8 @@ The command according to the above example configuration is as follows:
 ```
 curl -X POST -d "tokyo&&london-wan-rep&london" --URL http://127.0.0.1:5701/hazelcast/rest/wan/stopPublisher
 ```
+
+IMPORTANT: This endpoint will only stop the specified WAN publisher on the member it is sent to, it will not stop WAN publishers for any other members of the cluster.
 
 == Synchronizing the Clusters
 
@@ -189,6 +196,8 @@ The following is an example output:
 {"status":"success","message":"Sync initiated","uuid":"22e1e3d6-1c96-4757-baee-4cd77f1d214e"}
 ```
 
+IMPORTANT: This endpoint will initiate WAN synchronization across the entire cluster, with the receiving member designated as the coordinator for the synchronization process.
+
 === Delta Synchronization
 
 For the delta synchronization, you need to first perform a
@@ -209,6 +218,8 @@ used in full synchronization in the same way to synchronize
 a single map or all the maps.
 
 NOTE: Consistency check can be triggered only for one map.
+
+IMPORTANT: This endpoint will initiate WAN synchronization across the entire cluster, with the receiving member designated as the coordinator for the synchronization process.
 
 == Tracking the WAN Sync Progress
 
@@ -233,6 +244,8 @@ The following is an example output:
 
 The other stages are `STARTED`, `IN_PROGRESS` and `FAILED`.
 
+IMPORTANT: As WAN synchronization is an operation that occurs across the cluster, this response will represent the WAN sync progress for the entire cluster.
+
 [[wr-dynamically-adding]]
 == Dynamically Adding WAN Publishers
 
@@ -251,3 +264,5 @@ curl -X POST -d "{clusterOnSource}&{clusterPassword}&{wanConfig}" --URL http://1
 
 The `wanConfig` parameter should be the full configuration as a JSON string.
 See xref:advanced-features.adoc#dynamically-adding-wan-publishers[here] for configuration examples.
+
+IMPORTANT: This endpoint will deploy the provided config across all members of the cluster, following the same principles as other dynamic configuration mechanisms.


### PR DESCRIPTION
Some WAN API endpoints apply to the entire cluster, while some only apply to the receiving member. This commit adds notes to each endpoint specifying what the scope of its impact is.

I'm not sure if the `IMPORTANT:` boxes are the best way to present this, so please feel free to suggest better approaches!

Related to https://hazelcast.atlassian.net/browse/HZ-4594