### PR TITLE
Remove redundant `docker pull` from installation instructions

### DIFF
--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -23,7 +23,6 @@ docker version
 ----
 
 . If you do not see a version number, see the link:https://docs.docker.com/config/daemon/[Docker docs^] for troubleshooting information.
-
 // end::docker[]
 . xref:get-started-docker.adoc[Start the cluster].
 

--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -24,12 +24,6 @@ docker version
 
 . If you do not see a version number, see the link:https://docs.docker.com/config/daemon/[Docker docs^] for troubleshooting information.
 
-. Pull the Hazelcast Docker image from Docker Hub.
-+
-[source,bash,subs="attributes+"]
-----
-docker pull hazelcast/hazelcast-enterprise:{full-version}
-----
 // end::docker[]
 . xref:get-started-docker.adoc[Start the cluster].
 

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -142,12 +142,6 @@ docker version
 
 . If you do not see a version number, see the link:https://docs.docker.com/config/daemon/[Docker docs^] for troubleshooting information.
 // end::docker[]
-. Pull the Hazelcast Docker image from Docker Hub.
-+
-[source,bash,subs="attributes+"]
-----
-docker pull hazelcast/hazelcast:{full-version}
-----
 . xref:get-started-docker.adoc[Start the cluster].
 
 == Using the Binary

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -141,14 +141,13 @@ docker version
 ----
 
 . If you do not see a version number, see the link:https://docs.docker.com/config/daemon/[Docker docs^] for troubleshooting information.
-
+// end::docker[]
 . Pull the Hazelcast Docker image from Docker Hub.
 +
 [source,bash,subs="attributes+"]
 ----
 docker pull hazelcast/hazelcast:{full-version}
 ----
-// end::docker[]
 . xref:get-started-docker.adoc[Start the cluster].
 
 == Using the Binary


### PR DESCRIPTION
The [Docker introduction](https://docs.hazelcast.com/hazelcast/latest/getting-started/get-started-docker#step-1-pull-the-hazelcast-docker-image) tells you to:
1. Install Docker
2. Pull the image
3. Run the image

But (2) is redundant as `docker run hazelcast/hazelcast:5.3.7` will download if required anyway:
```
Unable to find image 'hazelcast/hazelcast:5.3.7' locally
5.3.7: Pulling from hazelcast/hazelcast
8a49fdb3b6a5: Pull complete
acb6c723f025: Pull complete
dfe629926fe6: Pull complete
610b8e3f6d86: Pull complete
4f4fb700ef54: Pull complete
933e63ec690a: Pull complete
Digest: sha256:b3d2d47e6387f15b28b92a393a2366514ef7160bca00d8617b4306a1b83027c1
Status: Downloaded newer image for hazelcast/hazelcast:5.3.7
```