### PR TITLE
Fix code samples link

### DIFF
--- a/docs/modules/getting-started/pages/resources.adoc
+++ b/docs/modules/getting-started/pages/resources.adoc
@@ -4,7 +4,7 @@
 * Hazelcast source code can be found at https://github.com/hazelcast/hazelcast[GitHub/Hazelcast^].
 This is also where you can contribute and report issues.
 * Hazelcast API can be found at https://docs.hazelcast.org/docs/latest/javadoc/[hazelcast.org/docs/Javadoc^].
-* Code samples can be downloaded from https://hazelcast.org/imdg/download/[hazelcast.org/download^].
+* Code samples can be downloaded from https://github.com/hazelcast/hazelcast-code-samples[GitHub/hazelcast-code-samples^].
 * More use cases and resources can be found at http://www.hazelcast.com[hazelcast.com^].
 * You can join to the https://slack.hazelcast.com/[Hazelcast Community^] group on Slack to post questions, follow the announcements, participate in the discussions and more.
 * You can also use the https://groups.google.com/forum/#!forum/hazelcast[Hazelcast mail group^] to post questions and start/follow discussions.


### PR DESCRIPTION
The link to code samples refers to IMDG (suggests outdated) and no longer works, redirecting to the hazelcast homepage - updated with a link to the active `code-samples` repo.