### PR TITLE
Update documentation support links

### DIFF
--- a/docs/modules/getting-started/pages/get-started-cli.adoc
+++ b/docs/modules/getting-started/pages/get-started-cli.adoc
@@ -132,4 +132,4 @@ write data to it and visualize that data in Management Center. To continue your 
 
 - Go straight into deploying a production-ready cluster with our xref:ROOT:production-checklist.adoc[production checklist].
 
-If you need some help, reach out to us on https://slack.hazelcast.com/[Slack^].
+If you need some help, reach out via xref:getting-started:support.adoc[support].

--- a/docs/modules/getting-started/pages/get-started-cli.adoc
+++ b/docs/modules/getting-started/pages/get-started-cli.adoc
@@ -132,5 +132,4 @@ write data to it and visualize that data in Management Center. To continue your 
 
 - Go straight into deploying a production-ready cluster with our xref:ROOT:production-checklist.adoc[production checklist].
 
-If you need some help, reach out to us on https://slack.hazelcast.com/[Slack^],
-https://groups.google.com/forum/#!forum/hazelcast[Mail Group^] or http://www.stackoverflow.com[StackOverflow^].
+If you need some help, reach out to us on https://slack.hazelcast.com/[Slack^].

--- a/docs/modules/getting-started/pages/resources.adoc
+++ b/docs/modules/getting-started/pages/resources.adoc
@@ -6,5 +6,4 @@ This is also where you can contribute and report issues.
 * Hazelcast API can be found at https://docs.hazelcast.org/docs/latest/javadoc/[hazelcast.org/docs/Javadoc^].
 * Code samples can be downloaded from https://hazelcast.org/imdg/download/[hazelcast.org/download^].
 * More use cases and resources can be found at http://www.hazelcast.com[hazelcast.com^].
-* You can join to the https://slack.hazelcast.com/[Hazelcast Community^] group on Slack to post questions, follow the announcements, participate in the discussions and more.
-* You can also use the https://groups.google.com/forum/#!forum/hazelcast[Hazelcast mail group^] to post questions and start/follow discussions.
+* xref:getting-started:support.adoc[Support information].

--- a/docs/modules/getting-started/pages/support.adoc
+++ b/docs/modules/getting-started/pages/support.adoc
@@ -8,9 +8,7 @@
 Community support is for every Hazelcast user. You can use the following channels to get community support:
 
 * https://github.com/hazelcast/hazelcast[Hazelcast GitHub] (for reporting issues through our GitHub repository)
-* https://slack.hazelcast.com/[Hazelcast Community Slack^]
-* https://groups.google.com/forum/#!forum/hazelcast[Mail Group^]
-* http://www.stackoverflow.com/[StackOverflow^].
+* https://slack.hazelcast.com/[Hazelcast Community Slack^].
 
 == Customer Support
 


### PR DESCRIPTION
Update support channels in documentation:
- Google Group link removed
   - > The Hazelcast Google User Group is read-only. Please post your questions on the Hazelcast Community Slack)
- Replace Slack link with support information
   - so that information on enterprise support is also available

Raised via [Slack](https://hazelcast.slack.com/archives/C035HQET5/p1712850038375199).