### PR TITLE
Remove `$` from Docker getting started IP address

### DIFF
--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -72,7 +72,7 @@ Replace the `<host_ip>` placeholder with the IP address of your Docker host.
 +
 [source,shell,subs="attributes+"]
 ----
-docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{full-version} hz-cli --targets hello-world@$<host_ip> sql
+docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{full-version} hz-cli --targets hello-world@<host_ip> sql
 ----
 +
 The `--targets` parameter tells the SQL shell to connect to the member at the given IP address in a cluster called `hello-world`.


### PR DESCRIPTION
This is the only reference to `$<host_ip>`, everywhere else uses `<host_ip>`. The `$` shouldn't be included in the command, otherwise it'll break.