### PR TITLE
Ensure backports to all maintenance versions includes 5.4

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ jobs:
   backport:
     strategy:
       matrix:
-        branch: ['v/5.0', 'v/5.1', 'v/5.2', 'v/5.3']
+        branch: ['v/5.0', 'v/5.1', 'v/5.2', 'v/5.3', 'v/5.4']
     runs-on: ubuntu-latest
     steps:
     


### PR DESCRIPTION
https://github.com/hazelcast/hz-docs/pull/1082 was not backported to 5.4 as it’s not listed as a maintenance version for the purposes of the action.