### PR TITLE
Improvements to UCN dynamic client docs

### DIFF
--- a/docs/modules/clusters/pages/ucn-dynamic-client.adoc
+++ b/docs/modules/clusters/pages/ucn-dynamic-client.adoc
@@ -1,13 +1,63 @@
 = Configure Client
-:description: Clients use the dynamic configuration API to update {ucn} on the cluster. 
+:description: Clients use the dynamic configuration API to create new, and update existing, {ucn} on the cluster.
 :page-enterprise: true
 :page-beta: false
 
 {description}
 
-You must create a _Client.java_ file containing the configuration and save it to your configuration folder. 
+== Dynamically creating new {ucn}
 
-NOTE: Ensure that you have configured your data structure with the same {ucn} referenced in your client configuration.
+You must create a _Client.java_ file containing the required code and save it to your configuration folder.
+
+The file will be similar to the following:
+
+[source,java]
+----
+package com.hazelcast.namespaces.dyamicconfig;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.UserCodeNamespaceConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.EntryProcessor;
+
+public class Client {
+
+    public static void main(String[] args) {
+        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+
+        // prepare our user code that we want to execute
+        EntryProcessor entryProcessor = new IncrementingEntryProcessor();
+
+        // prepare a new namespace config
+        UserCodeNamespaceConfig namespaceConfig = new UserCodeNamespaceConfig("namespace_name"); <1>
+        namespaceConfig.addClass(IncrementingEntryProcessor.class); <2>
+
+        // prepare our data structure config
+        MapConfig mapConfig = new MapConfig("map_name"); <3>
+        mapConfig.setUserCodeNamespace("namespace_name"); <4>
+
+        // apply our new configs to the cluster
+        client.getConfig().getNamespacesConfig().addNamespaceConfig(namespaceConfig); <5>
+        client.getConfig().addMapConfig(mapConfig); <6>
+
+        // execute the entry processor on the IMap associated with our new configs
+        client.getMap("map_name").executeOnKey("key", entryProcessor); <7>
+    }
+}
+----
+<1> Creates a new `UserCodeNamespaceConfig` with a name of `namespace_name`
+<2> Adds the defined class from the classpath to the `UserCodeNamespaceConfig`
+<3> Creates a new `MapConfig` for the map named `map_name`
+<4> Associated the User Code Namespace `namespace_name` with this `MapConfig`
+<5> Applies our new `UserCodeNamespaceConfig` to the cluster - this must be done before our data structure configs that reference this Namespace are applied
+<6> Applies our new `MapConfig` to the cluster
+<7> Executes `IncrementingEntryProcessor` from the classpath on the key in our map
+
+== Dynamically updating existing {ucn}
+
+You must create a _Client.java_ file containing the required code and save it to your configuration folder.
+
+NOTE: Ensure that you have configured your data structure (an `IMap` in this example) on the member side with the same {ucn} referenced in your client configuration.
 
 The file will be similar to the following:
 
@@ -29,14 +79,14 @@ public class Client {
         UserCodeNamespaceConfig namespaceConfig = new UserCodeNamespaceConfig("namespace_name"); <1>
         namespaceConfig.addClass(IncrementingEntryProcessor.class); <2>
 
-        // dynamically add the namespace config
+        // dynamically update the namespace config
         client.getConfig().getNamespacesConfig().addNamespaceConfig(namespaceConfig); <3>
-        // execute the entry processor
+        // execute the entry processor - this map should already be configured to use our namespace
         client.getMap("map_name").executeOnKey("key", entryProcessor); <4>
     }
 }
 ----
 <1> Creates a `UserCodeNamespaceConfig` with a name of `namespace_name`
 <2> Adds the defined class from the classpath to the `UserCodeNamespaceConfig`
-<3> Gets the Hazelcast configuration from the client instance and adds the `UserCodeNamespaceConfig` to the `Config`
-<4> Executes `IncrementingEntryProcessor` from the classpath on the key in the Map
+<3> Gets the Hazelcast configuration from the client instance and adds the `UserCodeNamespaceConfig` to the `Config`, overwriting the existing config
+<4> Executes `IncrementingEntryProcessor` from the classpath on the key in an IMap that has been configured to use the correct Namespace


### PR DESCRIPTION
Following discussion on Slack, we identified some improvements that can be made to this page to clarify functionality to users.

More specifically I have split the page into 2 pages, 1 focusing on creating a new UCN from clients, and 1 focusing on updating an existing UCN. I've also adjusted some wording to make this difference clearer.

Relevant slack thread: https://hazelcast.slack.com/archives/C035HQET5/p1713272907972899