### PR TITLE
Quick Typo Correction

### DIFF
--- a/docs/modules/deploy/pages/enterprise-licenses.adoc
+++ b/docs/modules/deploy/pages/enterprise-licenses.adoc
@@ -5,7 +5,7 @@
 
 {description}
 
-== Getting an Enterpr{enterprise-product-name}ise License Key
+== Getting an {enterprise-product-name} License Key
 
 // tag::get-license[]
 Hazelcast {enterprise-product-name} requires a license key. You can get a


### PR DESCRIPTION
Textual Enterprise was split by the new variable instead of being replaced by it.