### PR TITLE
Clarification about client use public ip property

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -104,9 +104,9 @@ The initial connection of a client is established using one of the addresses you
 The client gets the addresses of other members in the cluster from the initially connected member.
 If your client is <<java-client-operation-modes, smart>>, the client tries to connect to them.
 If any of the other members have both private and public addresses, the client must decide
-which one to use when connecting to those members. You can override the property `hazelcast.discovery.public.ip.enabled` property 
+which one to use when connecting to those members. You can override the `hazelcast.discovery.public.ip.enabled` property 
 to suit your setup. For further information on the `hazelcast.discovery.public.ip.enabled` property,
-see <<client-system-properties, Client System Properties section>>.
+see <<client-system-properties, Client System Properties>>.
 
 If you use a <<client-network,discovery mechanism>> to find the initial member for the connection instead of an address list,
 you can use the same property to configure whether the initial member connection uses the private or public address.

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -108,7 +108,7 @@ which one to use when connecting to those members. You can override the property
 to suit your setup. For further information on the `hazelcast.discovery.public.ip.enabled` property,
 see <<client-system-properties, Client System Properties section>>.
 
-If you use a <<client-network,discovery mechanism>> instead of an address list to find an initial member to connect to,
+If you use a <<client-network,discovery mechanism>> to find the initial member for the connection instead of an address list,
 above property also applies to the private vs public address selection decision of initial member connection.
 
 For an example of this scenario, you can have a look at the 

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -112,7 +112,7 @@ If you use a <<client-network,discovery mechanism>> instead of an address list t
 above property also applies to the private vs public address selection decision of initial member connection.
 
 For an example of this scenario, you can have a look at the 
-xref:ROOT:hazelcast-platform-operator-expose-externally.adoc[Connect to Hazelcast from Outside Kubernetes] guide.
+link:https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-expose-externally[Connect to Hazelcast from Outside Kubernetes] guide.
 
 **Handling Retry-able Operation Failure:**
 

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -112,7 +112,7 @@ but using a <<client-network, discovery mechanism>> to find the initial member t
 above property also applies to the private vs public address selection decision of initial member connection.
 
 For an example of this scenario, you can have a look at the 
-xref:hazelcast-platform-operator-expose-externally.adoc[Connect to Hazelcast from Outside Kubernetes] guide.
+xref:ROOT:hazelcast-platform-operator-expose-externally.adoc[Connect to Hazelcast from Outside Kubernetes] guide.
 
 **Handling Retry-able Operation Failure:**
 

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -108,7 +108,7 @@ which one to use when connecting to those members. You can override the property
 to suit your setup. For further information on the `hazelcast.discovery.public.ip.enabled` property,
 see <<client-system-properties, Client System Properties section>>.
 
-If you use a <<client-network,discovery mechanism>> to find the initial member for the connection instead of an address list,
+If you use a <<client-network,discovery mechanism>> instead of an address list to find an initial member to connect to,
 above property also applies to the private vs public address selection decision of initial member connection.
 
 For an example of this scenario, you can have a look at the 

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -111,8 +111,8 @@ see <<client-system-properties, Client System Properties section>>.
 If you use a <<client-network,discovery mechanism>> to find the initial member for the connection instead of an address list,
 you can use the same property to configure whether the initial member connection uses the private or public address.
 
-For an example of this scenario, you can have a look at the 
-link:https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-expose-externally[Connect to Hazelcast from Outside Kubernetes] guide.
+For an example of this scenario, refer to
+link:https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-expose-externally[Connect to Hazelcast from Outside Kubernetes, window=_blank] in the Operator documentation.
 
 **Handling Retry-able Operation Failure:**
 

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -100,15 +100,15 @@ the client retries to connect as configured which is described in the
 The client executes each operation through the already established connection to the cluster.
 If this connection(s) disconnects or drops, the client tries to reconnect as configured.
 
-The initial connection of a client will be established using one of the addresses you provide in the <<configuring-address-list, address list>>. 
-In case your client is <<java-client-operation-modes, smart>>, the client will then get the addresses of other members in the cluster and try to connect to them.
-If any of those members has private & public addresses at the same time, the client needs to decide
-which one it should use to connect to those members. You may want to override the property `hazelcast.discovery.public.ip.enabled`
-depending on your setup. See the <<client-system-properties, Client System Properties section>> for the description of 
-the `hazelcast.discovery.public.ip.enabled` property. 
+The initial connection of a client is established using one of the addresses you provide in the <<configuring-address-list, address list>>. 
+The client gets the addresses of other members in the cluster from the initially connected member.
+If your client is <<java-client-operation-modes, smart>>, the client tries to connect to them.
+If any of the other members have both private and public addresses, the client must decide
+which one to use when connecting to those members. You can override the property `hazelcast.discovery.public.ip.enabled` property 
+to suit your setup. For further information on the `hazelcast.discovery.public.ip.enabled` property,
+see <<client-system-properties, Client System Properties section>>.
 
-In case you are not providing an address list,
-but using a <<client-network, discovery mechanism>> to find the initial member to connect to,
+If you use a <<client-network,discovery mechanism>> to find the initial member for the connection instead of an address list,
 above property also applies to the private vs public address selection decision of initial member connection.
 
 For an example of this scenario, you can have a look at the 
@@ -2230,12 +2230,12 @@ See xref:extending-hazelcast:discovery-spi.adoc[Discovery SPI] for more informat
 |`hazelcast.discovery.public.ip.enabled`
 |null
 |bool
-|Overrides client behaviour when choosing between using public or private addresses of members.
+|Overrides client behavior when the member has both public and private addresses available.
 When set to `true`, the client assumes that it needs to use public IP addresses reported by the members.
 When set to `false`, the client always uses private addresses reported by the members. If it is `null`,
 the client will try to infer how the discovery mechanism should be based on the reachability of the members.
-This inference is not %100 reliable and may result in false-negatives. Thus, it's advised to override this 
-to `true` if it's known that the client will not be able to connect to members via their public addresses.
+As the client's inference is not 100% reliable and can result in false-negatives, we recommend that it is overridden by
+setting to `true` when the client cannot connect to members using their public addresses.
 
 |`hazelcast.client.event.queue.capacity`
 |1000000

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -109,7 +109,7 @@ the `hazelcast.discovery.public.ip.enabled` property.
 
 In case you are not providing an address list,
 but using a <<client-network, discovery mechanism>> to find the initial member to connect to,
-above property also applies to the initial member connection private vs public address selection decision.
+above property also applies to the private vs public address selection decision of initial member connection.
 
 For an example of this scenario, you can have a look at 
 xref:hazelcast-platform-operator-expose-externally.adoc[Connect to Hazelcast from Outside Kubernetes] guide.

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -111,7 +111,7 @@ In case you are not providing an address list,
 but using a <<client-network, discovery mechanism>> to find the initial member to connect to,
 above property also applies to the private vs public address selection decision of initial member connection.
 
-For an example of this scenario, you can have a look at 
+For an example of this scenario, you can have a look at the 
 xref:hazelcast-platform-operator-expose-externally.adoc[Connect to Hazelcast from Outside Kubernetes] guide.
 
 **Handling Retry-able Operation Failure:**

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -100,6 +100,20 @@ the client retries to connect as configured which is described in the
 The client executes each operation through the already established connection to the cluster.
 If this connection(s) disconnects or drops, the client tries to reconnect as configured.
 
+The initial connection of a client will be established using one of the addresses you provide in the <<configuring-address-list, address list>>. 
+In case your client is <<java-client-operation-modes, smart>>, the client will then get the addresses of other members in the cluster and try to connect to them.
+If any of those members has private & public addresses at the same time, the client needs to decide
+which one it should use to connect to those members. You may want to override the property `hazelcast.discovery.public.ip.enabled`
+depending on your setup. See the <<client-system-properties, Client System Properties section>> for the description of 
+the `hazelcast.discovery.public.ip.enabled` property. 
+
+In case you are not providing an address list,
+but using a <<client-network, discovery mechanism>> to find the initial member to connect to,
+above property also applies to the initial member connection private vs public address selection decision.
+
+For an example of this scenario, you can have a look at 
+xref:hazelcast-platform-operator-expose-externally.adoc[Connect to Hazelcast from Outside Kubernetes] guide.
+
 **Handling Retry-able Operation Failure:**
 
 While sending the requests to related members, operations can fail due to various reasons.
@@ -2214,14 +2228,14 @@ will try write through and other optimizations even though the system is concurr
 See xref:extending-hazelcast:discovery-spi.adoc[Discovery SPI] for more information.
 
 |`hazelcast.discovery.public.ip.enabled`
-|false
+|null
 |bool
-|Enables the discovery joiner to use public IPs from `DiscoveredNode`.
-See xref:extending-hazelcast:discovery-spi.adoc[Discovery SPI] for more information.
+|Overrides client behaviour when choosing between using public or private addresses of members.
 When set to `true`, the client assumes that it needs to use public IP addresses reported by the members.
 When set to `false`, the client always uses private addresses reported by the members. If it is `null`,
 the client will try to infer how the discovery mechanism should be based on the reachability of the members.
-This inference is not %100 reliable and may result in false-negatives.
+This inference is not %100 reliable and may result in false-negatives. Thus, it's advised to override this 
+to `true` if it's known that the client will not be able to connect to members via their public addresses.
 
 |`hazelcast.client.event.queue.capacity`
 |1000000

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -109,7 +109,7 @@ to suit your setup. For further information on the `hazelcast.discovery.public.i
 see <<client-system-properties, Client System Properties section>>.
 
 If you use a <<client-network,discovery mechanism>> to find the initial member for the connection instead of an address list,
-above property also applies to the private vs public address selection decision of initial member connection.
+you can use the same property to configure whether the initial member connection uses the private or public address.
 
 For an example of this scenario, you can have a look at the 
 link:https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-expose-externally[Connect to Hazelcast from Outside Kubernetes] guide.


### PR DESCRIPTION
See https://hazelcast.slack.com/archives/C01JU7ZJYGP/p1715012564100079

the property is not described well enough. in this pr I am fixing this. 

note: this is kinda tricky information to add.
it's in the conjunction of smart/unisocket, discovery and network/address list topics, each have their own sections. So pls advise if I can improve this pr.