### PR TITLE
Update outdated infor about client versions

### DIFF
--- a/docs/modules/maintain-cluster/pages/rolling-upgrades.adoc
+++ b/docs/modules/maintain-cluster/pages/rolling-upgrades.adoc
@@ -197,7 +197,7 @@ assuming a `5.1` cluster version.
 **Do I have to upgrade clients to work with rolling upgrades?**
 
 Clients which implement the Open Binary Client Protocol
-are compatible with Hazelcast version 3.6 and newer minor versions.
+are compatible with Hazelcast version 4.0 and newer minor versions.
 Thus, older client versions are compatible with next minor versions. Newer clients
 connected to a cluster operate at the lower version of capabilities until
 all members are upgraded and the cluster version upgrade occurs.


### PR DESCRIPTION
The correct state is
- 3.6+ clients can connect to 3.6+ members, but not to 4.x or 5.x
- 4.x and 5.x clients can connect to 4.x and 5.x members

I am not sure we want to talk about 3.x at all here so simple update should be fine.