### PR TITLE
Update capacity-planning.adoc

### DIFF
--- a/docs/modules/tiered-storage/pages/capacity-planning.adoc
+++ b/docs/modules/tiered-storage/pages/capacity-planning.adoc
@@ -26,7 +26,7 @@ NOTE: There is a HybridLog instance for every configured index on every partitio
 
 This means that if you have Tiered Storage enabled for a single IMap, with no index configured, and the default partition count and page size, the minimum required memory is `(1 + 0) * 271 * 4MB = 1084MB`.
 
-The Hazelcast cluster members validate, on startup, if the native memory configured for the member is greater than or equal to the minimum required memory as calculated above.
+The Hazelcast cluster members validate, on startup, if the native memory configured for the member is greater than or equal to the minimum required memory. This includes the above calculation along with the amount of memory allocated for each data structure using Tiered Storage. 
 If not, the cluster fails to start.
 
 In addition, around 20 MB of RAM is required for every one million entries stored on a member, including backups. To calculate the required RAM for members, divide the total expected number of entries (including backups) stored in the cluster by the member count.


### PR DESCRIPTION
Added a few words to clarify the point that this calculation is only for the HybridLog requirement, and that the startup sanity check also includes the amount allocated at the data structure configuration level. It also clarifies the point that memory capacity planning includes hybridlog and the data itself - which should be obvious but isn't explicitly stated.