### PR TITLE
Use released Hazelcast `5.4.0` instead of `SNAPSHOT`

### DIFF
--- a/docs/modules/events/pages/object-events.adoc
+++ b/docs/modules/events/pages/object-events.adoc
@@ -510,7 +510,7 @@ The `ReliableMessageListener` also copes with exceptions using the `isTerminal(T
 
 **Global Order**
 
-The `ReliableMessageListener` always gets all events in order (global order). It does not get duplicates, and gaps (loss of messages) only occur when it is too slow. For more information on dealing with message loss, refer to the `isLossTolerant()` method in the https://docs.hazelcast.org/docs/5.4.0-SNAPSHOT/javadoc/com/hazelcast/topic/ReliableMessageListener.html#isLossTolerant()[Java API documentation^].
+The `ReliableMessageListener` always gets all events in order (global order). It does not get duplicates, and gaps (loss of messages) only occur when it is too slow. For more information on dealing with message loss, refer to the `isLossTolerant()` method in the https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/topic/ReliableMessageListener.html#isLossTolerant()[Java API documentation^].
 
 **Delivery Guarantees**
 


### PR DESCRIPTION
Now `5.4.0` is released, the released version should be used in preferences to a pre-release `SNAPSHOT`.