### PR TITLE
Add client connectivity logging property [HZ-4734]

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -2372,6 +2372,14 @@ increased performance and reduced memory usage.
 to the same member when this property is `true`. When it is set to `false`,
 the client tries to connect to the members in the given order.
 
+|`hazelcast.client.connectivity.logging.delay.seconds`
+|10
+|int
+|Delay in seconds that the client logs connectivity stats on member connection changes.
+The delay functions to reduce noise from frequent connection updates that
+may occur in bursts. Note that the latest connectivity view will be
+logged when the task is run.
+
 |`hazelcast.client.statistics.enabled`
 |false
 |bool

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -2375,10 +2375,11 @@ the client tries to connect to the members in the given order.
 |`hazelcast.client.connectivity.logging.delay.seconds`
 |10
 |int
-|Delay in seconds that the client logs connectivity stats on member connection changes.
-The delay functions to reduce noise from frequent connection updates that
-may occur in bursts. Note that the latest connectivity view will be
-logged when the task is run.
+|Delay in seconds after which the client logs connectivity statistics after member connection changes.
+If a member connection state changes before the delay period has elapsed, the delay is reset.
+The delay reduces noise from frequent connection updates that
+can occur in bursts. Note that only the last connectivity view will be
+logged when the task is run after this delay.
 
 |`hazelcast.client.statistics.enabled`
 |false


### PR DESCRIPTION
Adds reference docs for new client property `hazelcast.client.connectivity.logging.delay.seconds`

Mono PR: https://github.com/hazelcast/hazelcast-mono/pull/2151