### PR TITLE
Revert the #844

### DIFF
--- a/docs/modules/security/pages/tls-ssl.adoc
+++ b/docs/modules/security/pages/tls-ssl.adoc
@@ -267,17 +267,17 @@ Hazelcast members can be on both sides of TLS connection - TLS servers
 and TLS clients.
 Hazelcast clients are always on the client side of a TLS connection.
 
-By default, Hazelcast members have keyStore used to identify themselves
+By default, Hazelcast members have keystore used to identify themselves
 to the clients and other members.
-Both Hazelcast members and Hazelcast clients have trustStore used to define
+Both Hazelcast members and Hazelcast clients have truststore used to define
 which members they can trust.
 
 When the mutual authentication feature is enabled, Hazelcast clients
-need to provide keyStore.
+need to provide keystore.
 A client proves its identity by providing its certificate to the Hazelcast
 member it's connecting to.
 The member only accepts the connection if the client's certificate is
-present in the member's trustStore.
+present in the member's truststore.
 
 To enable the mutual authentication, set the `mutualAuthentication` property
 value to `REQUIRED` on the member side, as shown below:

--- a/docs/modules/security/pages/tls-ssl.adoc
+++ b/docs/modules/security/pages/tls-ssl.adoc
@@ -103,12 +103,12 @@ XML::
             <properties>
                 <property name="protocol">TLSv1.2</property>
                 <property name="mutualAuthentication">REQUIRED</property>
-                <property name="keystore">/opt/hazelcast-keystore.p12</property>
-                <property name="keystorePassword">secret.123</property>
-                <property name="keystoreType">PKCS12</property>
-                <property name="truststore">/opt/hazelcast-truststore.p12</property>
-                <property name="truststorePassword">changeit</property>
-                <property name="truststoreType">PKCS12</property>
+                <property name="keyStore">/opt/hazelcast-keystore.p12</property>
+                <property name="keyStorePassword">secret.123</property>
+                <property name="keyStoreType">PKCS12</property>
+                <property name="trustStore">/opt/hazelcast-truststore.p12</property>
+                <property name="trustStorePassword">changeit</property>
+                <property name="trustStoreType">PKCS12</property>
                 <property name="keyMaterialDuration">PT10M</property>
             </properties>
         </ssl>
@@ -130,33 +130,33 @@ hazelcast:
       properties:
         protocol: TLSv1.2
         mutualAuthentication: REQUIRED
-        keystore: /opt/hazelcast-keystore.p12
-        keystorePassword: secret.123
-        keystoreType: PKCS12
-        truststore: /opt/hazelcast-truststore.p12
-        truststorePassword: changeit
-        truststoreType: PKCS12
+        keyStore: /opt/hazelcast-keystore.p12
+        keyStorePassword: secret.123
+        keyStoreType: PKCS12
+        trustStore: /opt/hazelcast-truststore.p12
+        trustStorePassword: changeit
+        trustStoreType: PKCS12
         keyMaterialDuration: PT10M
 ----
 ====
 
 The following are the descriptions of the properties:
 
-* `keystore`: Path of your keystore file.
-* `keystorePassword`: Password to access the key from your
+* `keyStore`: Path of your keystore file.
+* `keyStorePassword`: Password to access the key from your
 keystore file.
 * `keyManagerAlgorithm`: Name of the algorithm based on which
 the authentication keys are provided.
-* `keystoreType`: Type of the keystore. Its default value is `JKS`.
+* `keyStoreType`: Type of the keystore. Its default value is `JKS`.
 Another commonly used type is the `PKCS12`. Available keystore/truststore
 types depend on your Operating system and the Java runtime.
-* `truststore`: Path of your truststore file. The file truststore is a
+* `trustStore`: Path of your truststore file. The file truststore is a
 keystore file that contains a collection of certificates trusted by your
 application.
-* `truststorePassword`: Password to unlock the truststore file.
+* `trustStorePassword`: Password to unlock the truststore file.
 * `trustManagerAlgorithm`: Name of the algorithm based on which the
 trust managers are provided.
-* `truststoreType`: Type of the truststore. Its default value is `JKS`.
+* `trustStoreType`: Type of the truststore. Its default value is `JKS`.
 Another commonly used type is the `PKCS12`. Available keystore/truststore
 types depend on your Operating system and the Java runtime.
 * `mutualAuthentication`: Mutual authentication configuration. It's empty
@@ -210,14 +210,14 @@ XML::
             </factory-class-name>
             <properties>
                 <property name="protocol">TLSv1.2</property>
-                <property name="truststore">/opt/hazelcast-client.truststore</property>
-                <property name="truststorePassword">changeit</property>
-                <property name="truststoreType">JKS</property>
+                <property name="trustStore">/opt/hazelcast-client.truststore</property>
+                <property name="trustStorePassword">changeit</property>
+                <property name="trustStoreType">JKS</property>
 
                 <!-- Following properties are only needed when the mutual authentication is used. -->
-                <property name="keystore">/opt/hazelcast-client.keystore</property>
-                <property name="keystorePassword">clientsSecret</property>
-                <property name="keystoreType">JKS</property>
+                <property name="keyStore">/opt/hazelcast-client.keystore</property>
+                <property name="keyStorePassword">clientsSecret</property>
+                <property name="keyStoreType">JKS</property>
             </properties>
         </ssl>
     </network>
@@ -238,14 +238,14 @@ hazelcast-client:
       properties:
         protocol: TLSv1.2
 
-        truststore: /opt/hazelcast-client.truststore
-        truststorePassword: changeit
-        truststoreType: JKS
+        trustStore: /opt/hazelcast-client.truststore
+        trustStorePassword: changeit
+        trustStoreType: JKS
 
         # Following properties are only needed when the mutual authentication is used.
-        keystore: /opt/hazelcast-client.keystore
-        keystorePassword: clientsSecret
-        keystoreType: JKS
+        keyStore: /opt/hazelcast-client.keystore
+        keyStorePassword: clientsSecret
+        keyStoreType: JKS
 ----
 ====
 
@@ -267,17 +267,17 @@ Hazelcast members can be on both sides of TLS connection - TLS servers
 and TLS clients.
 Hazelcast clients are always on the client side of a TLS connection.
 
-By default, Hazelcast members have keystore used to identify themselves
+By default, Hazelcast members have keyStore used to identify themselves
 to the clients and other members.
-Both Hazelcast members and Hazelcast clients have truststore used to define
+Both Hazelcast members and Hazelcast clients have trustStore used to define
 which members they can trust.
 
 When the mutual authentication feature is enabled, Hazelcast clients
-need to provide keystore.
+need to provide keyStore.
 A client proves its identity by providing its certificate to the Hazelcast
 member it's connecting to.
 The member only accepts the connection if the client's certificate is
-present in the member's truststore.
+present in the member's trustStore.
 
 To enable the mutual authentication, set the `mutualAuthentication` property
 value to `REQUIRED` on the member side, as shown below:
@@ -288,10 +288,10 @@ Config cfg = new Config();
 Properties props = new Properties();
 
 props.setProperty("mutualAuthentication", "REQUIRED");
-props.setProperty("keystore", "/opt/hazelcast.keystore");
-props.setProperty("keystorePassword", "123456");
-props.setProperty("truststore", "/opt/hazelcast.truststore");
-props.setProperty("truststorePassword", "123456");
+props.setProperty("keyStore", "/opt/hazelcast.keystore");
+props.setProperty("keyStorePassword", "123456");
+props.setProperty("trustStore", "/opt/hazelcast.truststore");
+props.setProperty("trustStorePassword", "123456");
 
 cfg.getNetworkConfig().setSSLConfig(new SSLConfig().setEnabled(true).setProperties(props));
 Hazelcast.newHazelcastInstance(cfg);
@@ -302,8 +302,8 @@ by providing the keystore:
 
 [source,java]
 ----
-clientSslProps.setProperty("keystore", "/opt/client.keystore");
-clientSslProps.setProperty("keystorePassword", "123456");
+clientSslProps.setProperty("keyStore", "/opt/client.keystore");
+clientSslProps.setProperty("keyStorePassword", "123456");
 ----
 
 The property `mutualAuthentication` has the following options:
@@ -325,10 +325,10 @@ client side:
 ----
 ClientConfig config = new ClientConfig();
 Properties clientSslProps = new Properties();
-clientSslProps.setProperty("keystore", "/opt/client.keystore");
-clientSslProps.setProperty("keystorePassword", "123456");
-clientSslProps.setProperty("truststore", "/opt/client.truststore");
-clientSslProps.setProperty("truststorePassword", "123456");
+clientSslProps.setProperty("keyStore", "/opt/client.keystore");
+clientSslProps.setProperty("keyStorePassword", "123456");
+clientSslProps.setProperty("trustStore", "/opt/client.truststore");
+clientSslProps.setProperty("trustStorePassword", "123456");
 
 config.getNetworkConfig().setSSLConfig(new SSLConfig().setEnabled(true).setProperties(clientSslProps));
 HazelcastClient.newHazelcastClient(config);


### PR DESCRIPTION
Fixes #1130 

The first commit reverts changes introduced in #844 as it breaks the functionality. The second one re-applies a small subset of the changes again (in a few places where it's not used to refer to configuration property names).