### PR TITLE
Add warning information for `max-concurrent-invocations` [DOCS-893]

### DIFF
--- a/docs/modules/wan/pages/tuning.adoc
+++ b/docs/modules/wan/pages/tuning.adoc
@@ -616,7 +616,7 @@ this element, it makes sense to set it to a value equal to or greater than 3. Ot
 setting it to less than 2 in which case WAN will use the default replication strategy and adapt to
 the target endpoint count while maintaining causality.
 
-NOTE: Configuring the `max-concurrent-invocations` above 1 will improve WAN replication speed, but this will be a trade-off for higher CPU consumption as more threads are involved in WAN replication. If your replication setup is not saturating WAN queues (so there is no demand for faster WAN replication) then this functionality should not be used as serial replication will be sufficient without additional overhead or out-of-order risks.
+NOTE: Configuring the `max-concurrent-invocations` to a value greater than 1 will improve WAN replication speed, but this will be a trade-off for higher CPU consumption as more threads are involved in WAN replication. If your replication setup is not saturating WAN queues (so there is no demand for faster WAN replication) then this functionality should not be used as serial replication will be sufficient without additional overhead or out-of-order risks.
 
 An example WAN replication configuration using the default values of
 the aforementioned elements is shown below.

--- a/docs/modules/wan/pages/tuning.adoc
+++ b/docs/modules/wan/pages/tuning.adoc
@@ -612,9 +612,11 @@ ordering, when these entries are added, is not necessary.
 Keep in mind that if you set this element to a value which is less than the target endpoint count,
 you will lose performance as not all target endpoints will be used at any point in time to process the WAN event batches.
 So, for instance, if you have a target cluster with 3 members (target endpoints) and you want to use
-this element, it only makes sense to set it to a value higher than 3. Otherwise, you can simply disable it by
+this element, it makes sense to set it to a value equal to or greater than 3. Otherwise, you can simply disable it by
 setting it to less than 2 in which case WAN will use the default replication strategy and adapt to
 the target endpoint count while maintaining causality.
+
+NOTE: Configuring the `max-concurrent-invocations` above 1 will improve WAN replication speed, but this will be a trade-off for higher CPU consumption as more threads are involved in WAN replication. If your replication setup is not saturating WAN queues (so there is no demand for faster WAN replication) then this functionality should not be used as serial replication will be sufficient without additional overhead or out-of-order risks.
 
 An example WAN replication configuration using the default values of
 the aforementioned elements is shown below.


### PR DESCRIPTION
Following on-site visit with a customer today, we identified a need to add more information to the documentation for `max-concurrent-invocations` regarding the negative consequences of using it.

Fixes https://hazelcast.atlassian.net/browse/DOCS-893