### PR TITLE
OS to EE Rolling Restarts Doc Updates

### DIFF
--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -4,7 +4,14 @@
 
 {description}
 
-NOTE: These instructions apply only to the licensed {enterprise-product-name} edition, which provides additional features such as the security suite and blue/green client deployment. If you have the {open-source-product-name} edition, follow the instructions in the xref:install-hazelcast.adoc[] topic.
+[NOTE]
+====
+These instructions apply only to the licensed {enterprise-product-name} edition, which provides additional features such as the security suite and blue/green client deployment. If you have the {open-source-product-name} edition, follow the instructions in the xref:install-hazelcast.adoc[] topic.
+
+If you are moving members from an {open-source-product-name} cluster to an {enterprise-product-name} cluster of the same version, you can use rolling restarts to 
+move each member without downtime. For further information on moving members from an {open-source-product-name} cluster to a target {enterprise-product-name}, see 
+xref:migrate:community-to-enterprise.adoc[].
+====
 
 Both slim and full distributions are available. For further information on the available editions and distributions, see the xref:editions.adoc[] topic.
 

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -6,6 +6,12 @@
 
 NOTE: These instructions apply only to the {open-source-product-name} edition. If you have a license, which allows you to take advantage of the additional features offered by {enterprise-product-name} edition, follow the instructions in the xref:install-enterprise.adoc[] topic.
 
+We recommend that you learn more about the benefits of an {enterprise-product-name} license to ensure that you do not require any of the additional functionality or support before you install {open-source-product-name}. If you continue with the {open-source-product-name} installation, you can move your {open-source-product-name} members to {enterprise-product-name} at any time if you subsequently want to benefit from the {enterprise-product-name} functionality without downtime. 
+
+For further information on the available {enterprise-product-name} features and on moving members from an {open-source-product-name} cluster to a target {enterprise-product-name} cluster, see xref:migrate:community-to-enterprise.adoc[].
+
+== Distributions
+
 Both slim and full distributions are available. For further information on the available editions and distributions, see the xref:editions.adoc[] topic.
 
 You must use one of the following installation methods if you want to install the slim distribution:

--- a/docs/modules/maintain-cluster/pages/rolling-upgrades.adoc
+++ b/docs/modules/maintain-cluster/pages/rolling-upgrades.adoc
@@ -5,6 +5,9 @@
 
 {description}
 
+NOTE: If you are moving members from a 5.5 {open-source-product-name} cluster to an {enterprise-product-name} cluster, use an in-place rolling restart instead of a rolling upgrade.
+For further information on rolling restarts, see xref:migrate:community-to-enterprise.adoc[].
+
 == Best Practices
 
 Before starting a rolling upgrade, consider the following best practices:

--- a/docs/modules/migrate/pages/community-to-enterprise.adoc
+++ b/docs/modules/migrate/pages/community-to-enterprise.adoc
@@ -1,0 +1,52 @@
+= Move to {enterprise-product-name} from {open-source-product-name}
+:description: With Enterprise Edition, you can benefit from additional and extended features, patch releases, Hazelcast Support, and more connectors. If you are using the Open Source Edition and want to upgrade to Enterprise, you can do this with clusters of the same version from 5.5.
+
+{description}
+
+The {open-source-product-name} Edition does not include the following, which are be included with an Enterprise license:
+
+* Long term support (LTS) releases and short term support (STS) releases. For more information on LTS and STS releases, see xref:migrate:lts.adoc[]
+
+* Data Migration Tool. For more information on the Data Migration Tool, see xref:migrate:data-migration-tool.adoc[]
+* Patch releases, including those for security vulnerabilities from March 2024
+* Hazelcast Support with defined SLAs. For more information on the benefits of Hazelcast Support, see xref:getting-started:support.adoc#customer-support[]
+
+NOTE: To use the following {enterprise-product-name} features they might need to be enabled on your {enterprise-product-name} license, and must be configured after all members have been moved to {enterprise-product-name}. 
+For further information on the license requirements and configuration, see the linked documentation for the specific feature.
+
+* Security persistence. For more information on storing sensitive data on disk, see xref:secure-cluster:hardening-recommendations.adoc[]
+* CP Subsystem. For more information on building a strongly consistent layer for a set of distributed data structures that withstands server and client failures, see xref:cp-subsystem:cp-subsystem.adoc[]
+* High-Densisty Memory Store (HD Memory). For more information on Hazelcast's in-memory storage solution, which supports predictable application scaling and improved performance while minimizing pauses caused by garbage collection, see xref:storage:high-density-memory.adoc[]
+* WAN Replication. For more information on synchronizing the state of multiple Hazelcast clusters across a WAN, see xref:wan:wan.adoc[]
+* Rolling upgrades. For more information on upgrading the members of a cluster without downtime, see xref:maintain-cluster:rolling-upgrades.adoc[]
+* Thread-Per-Core (TPC). For more information on improving the system performance by using one thread for networking, storage, and compute on each CPU, see xref:cluster-performance:thread-per-core-tpc.adoc[]
+* User Code Namespaces. For more information on using a container for Java classpath resources, such as user code and accompanying artifacts, see xref:clusters:user-code-namespaces.adoc[]
+* Helm charts, with the exception of link:https://github.com/hazelcast/charts/tree/master/stable/hazelcast[Commmunity-driven Open Source Helm Charts, window=_blank]. For more information on using the Helm package manager for Kubernetes with Hazelcast, see xref:kubernetes:deploying-in-kubernetes.adoc[]
+* Updates to connectors available before version 5.4
+* Any connectors added after version 5.4 
++
+For more information on Connectors, see xref:integrate:connectors.adoc[].
+
+In addition, if you are using our tools, {open-source-product-name} does not include the following:
+
+* Hazelcast Operator to support your Kubernetes deployments. For more information on Operator, refer to the link:https://docs.hazelcast.com/operator/latest/[Hazelcast Operator, window=_blank] documentation
+* Client filtering, Prometheus Exporter, Config Health Check, clustered REST, or JMX support in Hazelcast Management Center
++
+Management Center also disables with clusters of more than three members.
++
+For more information on Management Center, refer to the xref:{page-latest-supported-mc}@management-center::index.adoc[Management Center, window=_blank] documentation.
+
+== High-level Process
+
+To upgrade your {open-source-product-name} cluster to an {enterprise-product-name} cluster of the same version, you can use a rolling restart.
+
+The rolling restart supports the IMap and ReplicatedMap data structures.
+
+For each member in the {open-source-product-name} cluster, the rolling restart process is as follows:
+
+. Shut down the member and wait for all partitions to migrate to the rest of the cluster
+. Upgrade the member's codebase
+. Restart the member
+. Configure the {enterprise-product-name} features that you want to use
+
+For further information on rolling restarts, see xref:migrate:rolling-restart.adoc[].

--- a/docs/modules/migrate/pages/data-migration-tool.adoc
+++ b/docs/modules/migrate/pages/data-migration-tool.adoc
@@ -17,7 +17,10 @@ The DMT is typically used in the following situations:
 ====
 . You cannot use the DMT to upgrade or migrate from IMDG 3.12.x. If you are upgrading from IMDG 3.12.x, see the xref:upgrading-from-imdg-3.adoc[Upgrading from IMDG 3.12.x] topic. If migrating from IMDG 3.12.x, see the xref:migration-tool-imdg.adoc[Migrating Data from IMDG 3.12.x] topic. 
 
-. If you want to avoid downtime, use an in-place rolling upgrade instead of the DMT tool. For further information on upgrading without interrupting the operation of the cluster, see the xref:maintain-cluster:rolling-upgrades.adoc[Rolling Upgrades] topic.
+. If you want to avoid downtime when upgrading members, use an in-place rolling upgrade instead of the DMT tool. For further information on upgrading without interrupting the operation of the cluster, see the xref:maintain-cluster:rolling-upgrades.adoc[Rolling Upgrades] topic.
+
+. If you are moving members from a 5.5 {open-source-product-name} cluster to an {enterprise-product-name} cluster, use an in-place rolling restart instead of the DMT tool.
+For further information on moving members from a 5.5 {open-source-product-name} cluster to an {enterprise-product-name} cluster, see xref:migrate:community-to-enterprise.adoc[]. 
 
 . The DMT does not support migrating data serialized with xref:serialization:compact-serialization.adoc[Compact Serialization]. Support for Compact Serialization is planned for the next release.
 ====

--- a/docs/modules/migrate/pages/rolling-restart.adoc
+++ b/docs/modules/migrate/pages/rolling-restart.adoc
@@ -1,0 +1,45 @@
+= Upgrade Cluster to {enterprise-product-name}
+:description: You can use an in-place rolling restart to move each member on your Open Source cluster to an Enterprise cluster.
+
+{description}
+
+This approach ensures that you can move your cluster without interruption to the service. 
+Similar to the rolling upgrade process, a rolling restart allows you to move one member at a time.
+
+The codebase of your {open-source-product-name} cluster must match the target {enterprise-product-name} release. 
+Currently, rolling restart can only be used to update your 5.5 {open-source-product-name} cluster members.
+
+== Best Practice
+
+Before starting a rolling restart, consider the following best practices:
+
+* Backup your IMap and ReplicatedMap data structures. This is not essential, but it is recommended practice
+* If the {open-source-product-name} member is a different version to the target {enterprise-product-name} member, update the codebase to match the target {enterprise-product-name} release
++
+**[RJL: Do we need to include any additional information to cover moving from - for example - 5.3 with CP Subsystem to Enterprise 5.5?]**
+
+* Ensure that the version of JDK meets the minimum required for the target {enterprise-product-name} release
+* Plan sufficient time for the rolling restart to complete, and remember that the member cannot change during the move
+
+== Perform a Rolling Restart
+
+To move your {open-source-product-name} cluster to {enterprise-product-name}, complete the following steps:
+
+. Gracefully shut down an existing {open-source-product-name} member.
++
+See xref:shutdown.adoc#shutting-down-a-hazelcast-member[Shutting Down a Hazelcast Member].
+
+. Wait for all partitions to migrate to the rest of the cluster.
++
+During migrations, members cannot join or leave the cluster.
+
+. Upgrade the member's codebase to match the {enterprise-product-name} version.
+
+. Start the member and wait until it joins the {enterprise-product-name} cluster.
+
+. Repeat this process for each member in the {open-source-product-name} cluster.
+
+. When all members on the {open-source-product-name} cluster have been moved to the {enterprise-product-name} cluster, enable and configure the 
+{enterprise-product-name} features that you want to use.
++
+For further information on the available features, their license requirements, and configuration, see xref:migrate:community-to-enterprise.adoc[].

--- a/docs/modules/migrate/partials/nav.adoc
+++ b/docs/modules/migrate/partials/nav.adoc
@@ -1,5 +1,7 @@
 ** xref:deploy:versioning-compatibility.adoc[Versioning and Compatibility]
 ** xref:migrate:lts.adoc[]
+** xref:migrate:community-to-enterprise.adoc[]
+*** xref:migrate:rolling-restart.adoc[]
 ** xref:migrate:data-migration-tool.adoc[]
 *** xref:migrate:dmt-command-reference.adoc[]
 ** xref:migrate:migration-tool-imdg.adoc[]


### PR DESCRIPTION
New information and cross-references added to document the OS to EE rolling restart mission-driven cycle.

NOTE: Updates will be required for the Release notes and What's New pages, as with other features; these files will be updated separately when all information is populated.

NOTE: The update made to the data-migration-tool.adoc file has also been made locally to the updated version in https://github.com/hazelcast/hz-docs/pull/936. I will ensure that any further changes are rolled into that file too so it does not affect things when that one is merged.