### PR TITLE
Update protocol documentation

### DIFF
--- a/docs/modules/security/pages/integrating-openssl.adoc
+++ b/docs/modules/security/pages/integrating-openssl.adoc
@@ -198,7 +198,7 @@ Available values are:
 require it
 * `ciphersuites`: Comma-separated list of cipher suite names allowed to be used.
 * `protocol`: Name of the algorithm which is used in your TLS/SSL. Its default
-value is `TLSv1.2`. Available values are:
+value is `TLS`. Available values are:
 ** `TLS`
 ** `TLSv1`
 ** `TLSv1.1`
@@ -211,6 +211,6 @@ For the
 `protocol` property, we recommend you to provide SSL or TLS with its version
 information, e.g., `TLSv1.2`. Note that if you
 provide only `SSL` or `TLS` as a value for the `protocol` property, they are
-converted to `SSLv3` and `TLSv1.2`, respectively. We strongly recommend to avoid
+converted to `SSLv3` and `TLS`, respectively. We strongly recommend to avoid
 SSL protocols.
 * `validateIdentity`: Flag which allows enabling endpoint identity validation. It means, during the TLS handshake client verifies if the server's hostname (or IP address) matches the information in X.509 certificate (Subject Alternative Name extension). Possible values are `"true"` and `"false"` (default).

--- a/docs/modules/security/pages/integrating-openssl.adoc
+++ b/docs/modules/security/pages/integrating-openssl.adoc
@@ -204,14 +204,9 @@ values depend on the engine implementation but usually support:
 ** `TLSv1`
 ** `TLSv1.1`
 ** `TLSv1.2`
-** `SSL` _(insecure!)_
-** `SSLv2` _(insecure!)_
-** `SSLv3` _(insecure!)_
 +
 For the
 `protocol` property, we recommend you to provide SSL or TLS with its version
 information, e.g., `TLSv1.3`. It ensures the engine won't allow a fallback to an old, insecure version.
-Note that if you provide only `SSL` or `TLS` as a value for the `protocol` property, they are
-converted to `SSLv3` and `TLS`, respectively. We strongly recommend to avoid
-SSL protocols.
+
 * `validateIdentity`: Flag which allows enabling endpoint identity validation. It means, during the TLS handshake client verifies if the server's hostname (or IP address) matches the information in X.509 certificate (Subject Alternative Name extension). Possible values are `"true"` and `"false"` (default).

--- a/docs/modules/security/pages/integrating-openssl.adoc
+++ b/docs/modules/security/pages/integrating-openssl.adoc
@@ -197,7 +197,7 @@ Available values are:
 ** `OPTIONAL` - server asks for a client certificate, but it doesn't
 require it
 * `ciphersuites`: Comma-separated list of cipher suite names allowed to be used.
-* `protocol`: Name of the algorithm which is used in your TLS/SSL. Its default
+* `protocol`: Name of the algorithm which is used in your TLS. Its default
 value is empty, meaning the protocol version to use is not specified. Available
 values depend on the engine implementation but usually support:
 ** `TLS` (equivalent to the empty value)
@@ -205,7 +205,7 @@ values depend on the engine implementation but usually support:
 ** `TLSv1.3`
 +
 For the
-`protocol` property, we recommend you to provide SSL or TLS with its version
+`protocol` property, we recommend you to provide TLS with its version
 information, e.g., `TLSv1.3`. It ensures the engine won't allow a fallback to an old, insecure version.
 
 * `validateIdentity`: Flag which allows enabling endpoint identity validation. It means, during the TLS handshake client verifies if the server's hostname (or IP address) matches the information in X.509 certificate (Subject Alternative Name extension). Possible values are `"true"` and `"false"` (default).

--- a/docs/modules/security/pages/integrating-openssl.adoc
+++ b/docs/modules/security/pages/integrating-openssl.adoc
@@ -198,8 +198,9 @@ Available values are:
 require it
 * `ciphersuites`: Comma-separated list of cipher suite names allowed to be used.
 * `protocol`: Name of the algorithm which is used in your TLS/SSL. Its default
-value is `TLS`. Available values are:
-** `TLS`
+value is empty, meaning the protocol version to use is not specified. Available
+values depend on the engine implementation but usually support:
+** `TLS` (equivalent to the empty value)
 ** `TLSv1`
 ** `TLSv1.1`
 ** `TLSv1.2`
@@ -209,8 +210,8 @@ value is `TLS`. Available values are:
 +
 For the
 `protocol` property, we recommend you to provide SSL or TLS with its version
-information, e.g., `TLSv1.2`. Note that if you
-provide only `SSL` or `TLS` as a value for the `protocol` property, they are
+information, e.g., `TLSv1.3`. It ensures the engine won't allow a fallback to an old, insecure version.
+Note that if you provide only `SSL` or `TLS` as a value for the `protocol` property, they are
 converted to `SSLv3` and `TLS`, respectively. We strongly recommend to avoid
 SSL protocols.
 * `validateIdentity`: Flag which allows enabling endpoint identity validation. It means, during the TLS handshake client verifies if the server's hostname (or IP address) matches the information in X.509 certificate (Subject Alternative Name extension). Possible values are `"true"` and `"false"` (default).

--- a/docs/modules/security/pages/integrating-openssl.adoc
+++ b/docs/modules/security/pages/integrating-openssl.adoc
@@ -201,9 +201,8 @@ require it
 value is empty, meaning the protocol version to use is not specified. Available
 values depend on the engine implementation but usually support:
 ** `TLS` (equivalent to the empty value)
-** `TLSv1`
-** `TLSv1.1`
 ** `TLSv1.2`
+** `TLSv1.3`
 +
 For the
 `protocol` property, we recommend you to provide SSL or TLS with its version


### PR DESCRIPTION
See  [here](https://github.com/hazelcast/hazelcast-mono/commit/77b1e0eec4691a2e452eb0da5e38d8d60025baf7#diff-37d9504ce60ecdf27711f36de75d440107d6ef841648903f4baf2df8344bac3aL56) where default TLSv1.2 is changed.

And the current master has TLS [here](https://github.com/hazelcast/hazelcast-mono/blob/9102331bb4025eb793f405aeaff05ae96c15edfd/hazelcast-enterprise/src/main/java/com/hazelcast/internal/nio/ssl/SSLEngineFactorySupport.java#L76)

Also SSL and TLSv1 and TLSv1.1 is old according to @kwart so I removed them 