### PR TITLE
New UCN YAML format updates

### DIFF
--- a/docs/modules/clusters/pages/ucn-member-side.adoc
+++ b/docs/modules/clusters/pages/ucn-member-side.adoc
@@ -60,7 +60,8 @@ user-code-namespaces:
       blacklist:
         class:
           - com.acme.app.BeanComparator
-   myNameSpace: []
+   name-spaces:
+      myNameSpace: []
 ----
 ====  
 
@@ -101,16 +102,17 @@ YAML::
 user-code-namespaces:
    enabled: true
    ...
-   myNameSpace:
-    - id: jarID
-      resource-type: JAR
-      url: "file:///yoursrc/class/usercodedeployment/MyJarFile.jar"
-    - id: MyJARsInZIPFileID
-      resource-type: JARS_IN_ZIP
-      url: "file:///yoursrc/class/usercodedeployment/MyJarZIP.zip"
-    - id: classId
-      resource-type: CLASS
-      url: "file:///yoursrc/class/usercodedeployment/MyClass.class"
+   name-spaces:
+      myNameSpace:
+       - id: jarID
+         resource-type: JAR
+         url: "file:///yoursrc/class/usercodedeployment/MyJarFile.jar"
+       - id: MyJARsInZIPFileID
+         resource-type: JARS_IN_ZIP
+         url: "file:///yoursrc/class/usercodedeployment/MyJarZIP.zip"
+       - id: classId
+         resource-type: CLASS
+         url: "file:///yoursrc/class/usercodedeployment/MyClass.class"
 ----
 ====  
 

--- a/docs/modules/clusters/pages/ucn-non-associated.adoc
+++ b/docs/modules/clusters/pages/ucn-non-associated.adoc
@@ -53,7 +53,8 @@ YAML::
 user-code-namespaces:
    enabled: true
    ...
-   default:
+   name-spaces:
+      default:
 ----
 ====  
 
@@ -92,14 +93,15 @@ YAML::
 user-code-namespaces:
    enabled: true
    ...
-   default:
-    - id: jarID
-      url: "file:///yoursrc/class/ucnDefaults/MyJarFile.jar"
-    - id: MyJARsInZIPFileID
-      url: "file:///yoursrc/class/ucnDefaults/MyJarZIP.zip"
-    - id: classId
-      resource-type: class
-      url: "file:///yoursrc/class/ucnDefaults/MyClass.class"
+   name-spaces:
+      default:
+       - id: jarID
+         url: "file:///yoursrc/class/ucnDefaults/MyJarFile.jar"
+       - id: MyJARsInZIPFileID
+         url: "file:///yoursrc/class/ucnDefaults/MyJarZIP.zip"
+       - id: classId
+         resource-type: class
+         url: "file:///yoursrc/class/ucnDefaults/MyClass.class"
 ----
 ====  
 


### PR DESCRIPTION
Following changes in https://github.com/hazelcast/hazelcast-mono/pull/2446 these config examples need to be updated.

I believe this will need to be backported to `5.4` docs as well, but @Fly-Style can confirm.