### PR TITLE
Update java.adoc around client routing

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -87,7 +87,7 @@ The client is updated whenever the cluster version, partition groups, or CP grou
 
 From {enterprise-product-name} 5.5, you can use any of the following cluster routing modes:
 
-* **ALL_MEMBERS** 
+* **Client ALL_MEMBERS Routing** 
 +
 The default mode, and is the equivalent of the legacy **Smart** client operation mode. 
 +
@@ -101,7 +101,7 @@ If <<configuring-direct-to-leader-routing, CP direct-to-leader routing>> is enab
 license is present on your Enterprise cluster, then clients in this routing mode can use this to send CP operations
 directly to group leaders wherever possible, even after leadership changes.
 
-* **SINGLE_MEMBER** 
+* **Client SINGLE_MEMBER Routing** 
 +
 In `SINGLE_MEMBER` cluster routing mode, clients only connect to one of the configured addresses. This is the equivalent of the legacy **Unisocket** client operation mode.
 +
@@ -113,7 +113,7 @@ The single connected member behaves as a gateway to the other members.
 When the client makes a request, the connected member redirects the request to the relevant member and
 returns the response from that member to the client.
 
-* **MULTI_MEMBER** 
+* **Client MULTI_MEMBER Routing** 
 +
 This mode provides most of the functionality of `ALL_MEMBERS` mode over a single paritition group, falling back to the more restricted behavior
 of `SINGLE_MEMBER` mode for members outside that partition group as follows:


### PR DESCRIPTION
Updated the headings to include "Client" as a prefix and "Routing" so that customers can read the announcement and find it in the documentation