### PR TITLE
Fix jetty plugin documentation link

### DIFF
--- a/docs/modules/plugins/pages/web-session-replication.adoc
+++ b/docs/modules/plugins/pages/web-session-replication.adoc
@@ -31,5 +31,4 @@ Jetty based web session replication is offered through Hazelcastty Session Manag
 It is a container specific module that enables session replication for
 JEE Web Applications without requiring changes to the application.
 
-For further information, refer to https://jetty.org/docs/jetty/12/operations-guide/session/index.html#hazelcast[Persistent Sessions with Hazelcast^] in the Jetty documentation.
-for more details.
+For further information, refer to the HTTP Session Management topic in the relevant version of the jetty documentation. The related documentation for Jetty 12 can be found https://jetty.org/docs/jetty/12/operations-guide/session/index.html#hazelcast[here].

--- a/docs/modules/plugins/pages/web-session-replication.adoc
+++ b/docs/modules/plugins/pages/web-session-replication.adoc
@@ -31,5 +31,5 @@ Jetty based web session replication is offered through Hazelcastty Session Manag
 It is a container specific module that enables session replication for
 JEE Web Applications without requiring changes to the application.
 
-See the https://jetty.org/docs/jetty/12/operations-guide/session/index.html#hazelcast[Jetty: Persistent Sessions with Hazelcast^]
+For further information, refer to https://jetty.org/docs/jetty/12/operations-guide/session/index.html#hazelcast[Persistent Sessions with Hazelcast^] in the Jetty documentation.
 for more details.

--- a/docs/modules/plugins/pages/web-session-replication.adoc
+++ b/docs/modules/plugins/pages/web-session-replication.adoc
@@ -31,5 +31,5 @@ Jetty based web session replication is offered through Hazelcastty Session Manag
 It is a container specific module that enables session replication for
 JEE Web Applications without requiring changes to the application.
 
-See the https://www.eclipse.org/jetty/documentation/current/configuring-sessions-hazelcast.html[Jetty: Persistent Sessions with Hazelcast^]
+See the https://jetty.org/docs/jetty/12/operations-guide/session/index.html#hazelcast[Jetty: Persistent Sessions with Hazelcast^]
 for more details.


### PR DESCRIPTION
The old link redirects to https://jetty.org/docs/

Feel free to change the new link, I'm not sure if we should give a link to 12. Using latest in the link does not work

Should be backported and forwardported to all versions imo. 