### PR TITLE
Update CP direct-to-leader docs

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -1566,6 +1566,11 @@ instead of using a faster internal cluster link and routing through another memb
 direct to leader routing can put uneven pressure on the cluster if CP group leaders receive substantially more load than
 other members of the cluster - this is particularly problematic when only one CP group leader is present.
 
+NOTE: If a client does not have an active connection to a known CP group leader then the client will be unable to leverage
+direct-to-leader CP operations and will fall back to default round-robin behaviour, sending the request to any available
+cluster member instead. This feature provides no benefit when `SINGLE_MEMBER` routing is used as the client only has 1
+available connection to use for all operation sending.
+
 CP direct to leader routing can be enabled on clients with a single configuration option. Here is an example programmatic
 configuration snippet:
 


### PR DESCRIPTION
Adds a note regarding the behaviour of this feature when an active connection is not available, and also notes that it provides no benefit in `SINGLE_MEMBER` routing mode.