### PR TITLE
Update cluster routing mode compatibility for TPC [ESC-42]

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -932,6 +932,7 @@ When using the `SINGLE_MEMBER` cluster routing mode, consider the following:
 connections to the xref:cp-subsystem:cp-subsystem.adoc[CP Subsystem] are direct-to-leader, which can result in improved performance.
 If leadership is reassigned while using `SINGLE_MEMBER` cluster routing, then this benefit may be lost.
 * <<configuring-load-balancer,`LoadBalancer`>> configuration is ignored
+* xref:thread-per-core-tpc.adoc[Thread-Per-Core] is not supported for `SINGLE_MEMBER` cluster routing and no benefit will gained by enabling it with this routing mode.
 
 Declarative Configuration:
 
@@ -992,6 +993,8 @@ If <<configuring-direct-to-leader-routing, CP direct-to-leader routing>> is enab
 is present on your Enterprise cluster, then clients in this routing mode can use this to send CP operations directly
 to group leaders wherever possible, even after leadership changes.
 * Best efforts are made to route operations to the required member, but if this cannot be done operations are routed as defined in the <<configuring-load-balancer,`LoadBalancer`>>
+
+* xref:thread-per-core-tpc.adoc[Thread-Per-Core] is not supported for `MULTI_MEMBER` cluster routing and may lead to event inconsistency if used.
 
 Declarative Configuration:
 

--- a/docs/modules/cluster-performance/pages/thread-per-core-tpc.adoc
+++ b/docs/modules/cluster-performance/pages/thread-per-core-tpc.adoc
@@ -15,7 +15,7 @@ A Thread-Per-Core (TPC) design uses one thread for every CPU core and every thre
 
 When TPC is enabled, clients using the `ALL_MEMBERS` cluster routing mode connect to the number of cores specified in the client config. If TPC is enabled on both client and server, clients connect directly to one of the TPC threads instead of using the legacy network threads. TPC-enabled servers continue to use the same ports for discovery, which means there's no difference in how the cluster member list is created and TPC-aware servers are backward compatible with clients that don't use TPC.
 
-NOTE: Clients using the `SINGLE_MEMBER` cluster routing mode ignore TPC and connect to a random member in the cluster. Your clients must use the `ALL_MEMBERS` cluster routing mode with TPC. For further information on the `ClientTpcConfig` class used to specify the number of cores to use for connections, refer to https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/client/config/ClientTpcConfig.html[Class ClientTpcConfig] in the Java API documentation.
+NOTE: Clients using the `SINGLE_MEMBER` or `MULTI_MEMBER` cluster routing modes cannot use TPC. Your clients must use the `ALL_MEMBERS` cluster routing mode with TPC. For further information on the `ClientTpcConfig` class used to specify the number of cores to use for connections, refer to https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/client/config/ClientTpcConfig.html[Class ClientTpcConfig] in the Java API documentation.
 
 [[tpc-config]]
 == Configuration Options


### PR DESCRIPTION
TPC causes inconsistency when used with `MULTI_MEMBER` routing in 5.5.0, and it serves no purpose when used with `SINGLE_MEMBER` routing - to alleviate issues this PR updates documentation to make it clear that TPC should only be used with `ALL_MEMBERS` routing enabled.

Related: https://hazelcast.atlassian.net/browse/ESC-42