### PR TITLE
Add notice about memory leak in vector collections in beta version [AI-133]

### DIFF
--- a/docs/modules/data-structures/pages/vector-collections.adoc
+++ b/docs/modules/data-structures/pages/vector-collections.adoc
@@ -695,3 +695,10 @@ As this is a beta version, Vector Collection has some limitations; the most sign
 3. The lack of fault tolerance, as backups cannot yet be configured. However, data in collections is migrated to other cluster members on graceful shutdown and a new member joining the cluster, which means that normal cluster maintenance (such as a rolling restart) is possible without data loss.
 4. Only on-heap storage of vector collections is available
 
+There is a known memory leak in Vector collection in some scenarios:
+
+1. Using `destroy` or `clear` on a non-empty Vector Collection
+2. Making Vector collection partition empty by removing the last entry using `deleteAsync` or `removeAsync` or overwriting it using one of the `put`/`set` methods
+3. Repeated migrations back and forth when a member is not restarted. This should not significantly affect rolling restart, provided sufficient heap margin. The leak may manifest itself when a subset of members is not restarted and the rest of them is repeatedly shutdown or restarted gracefully.
+
+The workaround in the first scenarios is to avoid those situations or restart affected cluster. For the last scenario workaround is to restart affected member or cluster. The restart can be graceful in which case no data should be lost. 


### PR DESCRIPTION
Info and workaround for memory leaks described in https://github.com/hazelcast/hazelcast-mono/pull/2767