### PR TITLE
Use latest `checkout` action

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@v4
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.ACTION_UPDATER }}

--- a/.github/workflows/adoc-html.yml
+++ b/.github/workflows/adoc-html.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.1.4
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@v4.0.2
       with:
         node-version: 20

--- a/.github/workflows/backport-5-0.yml
+++ b/.github/workflows/backport-5-0.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5-1.yml
+++ b/.github/workflows/backport-5-1.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5-2.yml
+++ b/.github/workflows/backport-5-2.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5-3.yml
+++ b/.github/workflows/backport-5-3.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5-4.yml
+++ b/.github/workflows/backport-5-4.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5-5.yml
+++ b/.github/workflows/backport-5-5.yml
@@ -1,4 +1,4 @@
-name: Backport changes to all maintenance branches
+name: Backport changes to the 5.5.0 branch
 on:
  push:
   branches:
@@ -7,10 +7,10 @@ jobs:
   backport:
     strategy:
       matrix:
-        branch: ['v/5.0', 'v/5.1', 'v/5.2', 'v/5.3', 'v/5.4', 'v/5.5']
+        branch: ['v/5.5']
     runs-on: ubuntu-latest
     steps:
-    
+
       - name: checkout
         uses: actions/checkout@v4
         with:
@@ -20,14 +20,14 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
-          
+
       - name: Check PR for backport label
         id: check_pr_labels
         uses: shioyang/check-pr-labels-on-push-action@v1.0.12
         with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
-         labels: '["backport to all versions"]'
-        
+         labels: '["backport to 5.5"]'
+
       - name: See result
         run: echo "${{ steps.check_pr_labels.outputs.result }}"
 

--- a/.github/workflows/forwardport.yml
+++ b/.github/workflows/forwardport.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/to-plain-html.yml
+++ b/.github/workflows/to-plain-html.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:              
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.TO_HTML }}      
       - name: Asciidoc to html

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.1.4
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@v4.0.2
       with:
         node-version: 20


### PR DESCRIPTION
Rather than hardcoding a specific (now outdated) version of `checkout`, we can specify the latest `4.x` as per everywhere else.