### PR TITLE
Remove `5.5-snapshot` reference

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -27,7 +27,7 @@ antora:
       trace: true
       componentversions:
         - name: hazelcast
-          version: '5.5-snapshot'
+          version: '6.0-snapshot'
           mappings:
             - module: integrate
               family: attachment


### PR DESCRIPTION
Already removed from `antora-playbook`, but leftover here.