### PR TITLE
Update client versions

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -24,7 +24,7 @@ asciidoc:
     page-latest-supported-mc: '6.0-snapshot'
     page-latest-supported-java-client: '6.0.0-SNAPSHOT'
     # https://github.com/hazelcast/hazelcast-go-client/releases
-    page-latest-supported-go-client: '1.4.1'
+    page-latest-supported-go-client: '1.4.2'
     # https://github.com/hazelcast/hazelcast-cpp-client/releases
     page-latest-supported-cplusplus-client: '5.3.0'
     # https://github.com/hazelcast/hazelcast-csharp-client/releases

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -25,8 +25,8 @@ asciidoc:
     page-latest-supported-java-client: '6.0.0-SNAPSHOT'
     # https://github.com/hazelcast/hazelcast-go-client/releases
     page-latest-supported-go-client: '1.4.1'
-    # https://github.com/hazelcast/hazelcast-python-client/releases
-    page-latest-supported-cplusplus-client: '5.4.0'
+    # https://github.com/hazelcast/hazelcast-cpp-client/releases
+    page-latest-supported-cplusplus-client: '5.3.0'
     # https://github.com/hazelcast/hazelcast-csharp-client/releases
     page-latest-supported-csharp-client: '5.4.0'
     # https://github.com/hazelcast/hazelcast-python-client/releases

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -23,12 +23,18 @@ asciidoc:
     # Must be lowercase because this is how the version appears in the docs
     page-latest-supported-mc: '6.0-snapshot'
     page-latest-supported-java-client: '6.0.0-SNAPSHOT'
-    page-latest-supported-go-client: '1.4.0'
-    page-latest-supported-cplusplus-client: '5.3.0'
-    page-latest-supported-csharp-client: '5.3.0'
-    page-latest-supported-python-client: '5.3.0'
+    # https://github.com/hazelcast/hazelcast-go-client/releases
+    page-latest-supported-go-client: '1.4.1'
+    # https://github.com/hazelcast/hazelcast-python-client/releases
+    page-latest-supported-cplusplus-client: '5.4.0'
+    # https://github.com/hazelcast/hazelcast-csharp-client/releases
+    page-latest-supported-csharp-client: '5.4.0'
+    # https://github.com/hazelcast/hazelcast-python-client/releases
+    page-latest-supported-python-client: '5.4.0'
+    # https://github.com/hazelcast/hazelcast-nodejs-client/releases
     page-latest-supported-nodejs-client: '5.3.0'
-    page-latest-supported-clc: '5.3.1'
+    # https://github.com/hazelcast/clc/releases
+    page-latest-supported-clc: '5.4.1'
     open-source-product-name: 'Community Edition'
     enterprise-product-name: 'Enterprise Edition'
 nav:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -30,7 +30,7 @@ asciidoc:
     # https://github.com/hazelcast/hazelcast-csharp-client/releases
     page-latest-supported-csharp-client: '5.4.0'
     # https://github.com/hazelcast/hazelcast-python-client/releases
-    page-latest-supported-python-client: '5.4.0'
+    page-latest-supported-python-client: '5.5.0'
     # https://github.com/hazelcast/hazelcast-nodejs-client/releases
     page-latest-supported-nodejs-client: '5.3.0'
     # https://github.com/hazelcast/clc/releases


### PR DESCRIPTION
[It was highlighted](https://hazelcast.slack.com/archives/C035HQET5/p1722523025052379) that the documentation refers to out-of-date Hazelcast client versions.

This PR updates all to the latest versions, and I've updated the internal documentation to add this step for each next release ([example](https://hazelcast.atlassian.net/wiki/spaces/HZC/pages/115376462/Python+Client+Release+Procedure)).