### PR TITLE
Java Thin Client documentation page for 5.5.0 added

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -21,6 +21,7 @@ asciidoc:
     # Must be lowercase because this is how the version appears in the docs
     page-latest-supported-mc: '5.5.0'
     page-latest-supported-java-client: '5.5.0'
+    page-latest-supported-java-standard-client: '5.5.0'
     page-latest-supported-go-client: '1.4.1'
     page-latest-supported-cplusplus-client: '5.3.0'
     page-latest-supported-csharp-client: '5.3.0'
@@ -29,5 +30,6 @@ asciidoc:
     page-latest-supported-clc: '5.4.1'
     open-source-product-name: 'Community Edition'
     enterprise-product-name: 'Enterprise Edition'
+    java-standard-client-name: 'Java Client (Standard)'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -20,7 +20,6 @@ asciidoc:
     page-latest-cli: '5.2021.09'
     # Must be lowercase because this is how the version appears in the docs
     page-latest-supported-mc: '5.5.0'
-    page-latest-supported-java-standard-client: '5.5.0'
     page-latest-supported-java-client: '5.5.0'
     # https://github.com/hazelcast/hazelcast-go-client/releases
     page-latest-supported-go-client: '1.4.2'

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -20,9 +20,11 @@ asciidoc:
     page-latest-cli: '5.2021.09'
     # Must be lowercase because this is how the version appears in the docs
     page-latest-supported-mc: '5.5.0'
-    page-latest-supported-java-client: '5.5.0'
     page-latest-supported-java-standard-client: '5.5.0'
-    page-latest-supported-go-client: '1.4.1'
+    page-latest-supported-java-client: '5.5.0'
+    # https://github.com/hazelcast/hazelcast-go-client/releases
+    page-latest-supported-go-client: '1.4.2'
+    # https://github.com/hazelcast/hazelcast-cpp-client/releases
     page-latest-supported-cplusplus-client: '5.3.0'
     page-latest-supported-csharp-client: '5.3.0'
     page-latest-supported-python-client: '5.3.0'

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -228,6 +228,7 @@ include::tiered-storage:partial$nav.adoc[]
 
 .Clients & APIs
 * xref:clients:java.adoc[]
+* xref:clients:java-thin-client.adoc[]
 * xref:clients:dotnet.adoc[]
 * xref:clients:python.adoc[]
 * xref:clients:cplusplus.adoc[]

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -128,12 +128,6 @@ If this connection disconnects or drops, the client tries to reconnect as config
 The initial connection is established using one of the addresses provided in the <<configuring-address-list, address list>>.
 The client gets the addresses of other members in the cluster from the first connected member.
 
-If you use a <<client-network,discovery mechanism>> to find the initial member for the connection instead of an address list,
-you can use the same property to configure whether the initial member connection uses the private or public address.
-
-For an example of this scenario, refer to
-link:https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-expose-externally[Connect to Hazelcast from Outside Kubernetes, window=_blank] in the Operator documentation.
-
 **Handling Retry-able Operation Failure:**
 
 While sending the requests to related members, operations can fail due to various reasons.

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -14,7 +14,7 @@ you are using the Hazelcast API. The differences are discussed below.
 NOTE: If you have a Hazelcast {enterprise-product-name} license, you do not need to set the license key in your clients to use the xref:getting-started:editions.adoc#features-in-hazelcast-enterprise[{enterprise-product-name} features] - setting it on the member side is enough. In this case, you only need to include the `hazelcast-enterprise-java-client-{full-version}.jar` dependency in your classpath.
 
 If using Maven, add the `hazelcast-java-client` dependency
-to your `pom.xml`, or to the `hazelcast-enterprise` dependency if you want the client to use {enterprise-product-name} features, and you have the Hazelcast {enterprise-product-name} license,
+to your `pom.xml`, or to the `hazelcast-enterprise-java-client` dependency if you want the client to use {enterprise-product-name} features, and you have the Hazelcast {enterprise-product-name} license,
 which might have been done when starting using Hazelcast.
 
 The `pom.xml` file is updated as follows:

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -116,23 +116,19 @@ The main areas are around client connections and retry-able operations. Some app
 
 **Handling Client Connection Failure:**
 
-While the client initially tries to connect to one of the members in the
-`ClientNetworkConfig.addressList`, it is possible that not all members are available.
-Instead of giving up, throwing an exception and stopping,
-the client continues to attempt to connect as configured.
-For information on the available configuration, see <<configuring-client-connection-retry, Configuring Client Connection Retry>>.
+While the client is trying to connect initially to one of the members in the
+`ClientNetworkConfig.addressList`, all the members might be not available.
+Instead of giving up, throwing an exception and stopping the client,
+the client retries to connect as configured which is described in the
+<<configuring-client-connection-retry, Configuring Client Connection Retry section>>.
 
-The client executes each operation through the already established connection to the cluster.
-If this connection disconnects or drops, the client tries to reconnect as configured.
+The client executes each operation through the already established connection(s) to the cluster.
+If these connection(s) disconnect or drop, the client tries to reconnect as configured.
 
-The initial connection is established using one of the addresses provided in the <<configuring-address-list, address list>>.
-The client gets the addresses of other members in the cluster from the first connected member.
-
-If you use a <<client-network,discovery mechanism>> to find the initial member for the connection instead of an address list,
-you can use the same property to configure whether the initial member connection uses the private or public address.
-
-For an example of this scenario, refer to
-link:https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-expose-externally[Connect to Hazelcast from Outside Kubernetes, window=_blank] in the Operator documentation.
+If using the `MULTI_MEMBER` cluster routing mode, and the cluster has multiple partition groups defined 
+and the client connection to a partition group fails, connectivity is maintained by failing over to an alternative partition group.
+If the connection is lost, which occurs only if all members of the partition group become unavailable, there is no attempt to retry the connection before failing over to another partition group.
+For further information on client cluster routing modes, see <<client-cluster-routing-modes,Client Cluster Routing Modes>>.
 
 **Handling Retry-able Operation Failure:**
 
@@ -765,6 +761,71 @@ When a failover starts, i.e., the client is disconnected and was configured
 to connect to alternative clusters, the current <<client-network, member list>> is not considered;
 the client cuts all the connections before attempting to connect to a new cluster and tries the clusters as configured.
 See the below configuration related sections.
+
+[[ordering-of-clusters-when-clients-try-to-connect]]
+=== Ordering of Clusters When Clients Try to Connect
+
+The order of the clusters, that the client will try to connect
+in a blue-green or disaster recovery scenario, is decided by
+the order of these cluster declarations as given in the client configuration.
+
+Each time the client is disconnected from a cluster and it cannot connect back to the same one,
+the configured list is iterated over. Count of these iterations before
+the client decides to shut down is provided using the `try-count` configuration element.
+See the following configuration related sections.
+
+We didn't go over the configuration yet (see the following configuration related sections),
+but for the sake of explaining the ordering, assume that you have
+`client-config1`, `client-config2` and `client-config3`
+in the given order as shown below (in your `hazelcast-client-failover` XML or YAML file).
+This means you have three alternative clusters.
+
+[tabs] 
+==== 
+XML:: 
++ 
+-- 
+[source,xml]
+----
+<hazelcast-client-failover>
+    <try-count>4</try-count>
+    <clients>
+        <client>client-config1.xml</client>
+        <client>client-config2.xml</client>
+        <client>client-config3.xml</client>
+    </clients>
+</hazelcast-client-failover>
+----
+--
+
+YAML::
++
+[source,yaml]
+----
+hazelcast-client-failover:
+  try-count: 4
+  clients:
+    - client-config1.yaml
+    - client-config2.yaml
+    - client-config3.yaml
+----
+====
+
+And let's say the client is disconnected from the cluster
+whose configuration is given by `client-config2.xml`.
+Then, the client tries to connect to the next cluster in this list,
+whose configuration is given by `client-config3.xml`. When the end of the list is reached,
+which is so in this example, and the client could not connect to `client-config3`,
+then `try-count` is incremented and the client continues to try to connect starting with `client-config1`.
+
+This iteration continues until the client connects to a cluster or `try-count` is reached to the configured value.
+When the iteration reaches this value and the client still could not connect to a cluster,
+it shuts down. Note that, if `try-count` was set to `1` in the above example,
+and the client could not connect to `client-config3`, it would shut down since
+it already tried once to connect to an alternative cluster.
+
+The following sections describe how you can configure the Java client for
+blue-green and disaster recovery scenarios.
 
 === Configuring Without CNAME
 

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -405,7 +405,7 @@ these.
 [[configuring-java-client]]
 == Configuring {java-standard-client-name}
 
-You can configure {client-name} declaratively (XML), programmatically (API), or
+You can configure {java-standard-client-name} declaratively (XML), programmatically (API), or
 using client system properties.
 
 For declarative configuration, the Hazelcast client looks at
@@ -855,7 +855,7 @@ See the xref:serialization:serialization.adoc[Serialization chapter].
 
 === Defining Client Labels
 
-You can define labels in your {client-name}, similar to the way it can
+You can define labels in your {java-standard-client-name}, similar to the way it can
 be done for the xref:management:cluster-utilities.adoc[members].
 Through the client labels, you can assign special roles for your clients and
 use these roles to perform some actions specific to those client connections.
@@ -897,7 +897,7 @@ all the waiting invocations receive a `HazelcastClientOfflineException`.
 Its default value is `ON`.
 
 The below example of programmatic configuration shows how to configure
-the {client-name}'s starting and reconnecting modes.
+the {java-standard-client-name}'s starting and reconnecting modes.
 
 [source,java]
 ----
@@ -1138,7 +1138,7 @@ The client configurations must be exactly the same except the following configur
 * `NetworkConfig.DiscoveryConfig`
 
 
-== {client-name} Failure Detectors
+== {java-standard-client-name} Failure Detectors
 
 The client failure detectors are responsible to determine if a member in the cluster is unreachable or crashed.
 The most important problem in the failure detection is to distinguish
@@ -1149,7 +1149,7 @@ A workaround to this limitation is to use unreliable failure detectors.
 An unreliable failure detector allows a member to suspect that others have failed,
 usually based on liveness criteria but it can make mistakes to a certain degree.
 
-The {client-name} has two built-in failure detectors: Deadline Failure Detector and
+The {java-standard-client-name} has two built-in failure detectors: Deadline Failure Detector and
 Ping Failure Detector. These client failure detectors work independently from
 the member failure detectors, e.g., you do not need to enable the member failure detectors
 to benefit from the client ones.
@@ -1281,7 +1281,7 @@ regardless of the other detectors.
 [[client-system-properties]]
 == Client System Properties
 
-There are some advanced client configuration properties to tune some aspects of the {client-name}.
+There are some advanced client configuration properties to tune some aspects of the {java-standard-client-name}.
 You can set them as property name and value pairs through declarative configuration,
 programmatic configuration, or JVM system property. See the xref:ROOT:system-properties.adoc[System Properties appendix]
 to learn how to set these properties.

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -29,6 +29,43 @@ The `pom.xml` file is updated as follows:
     <version>{full-version}</version>
 </dependency>
 ----
+== Migrating from Embed client
+To migrate from the Embed client to {client-name}, the only change required is in the `pom.xml` file:
+[source,xml,subs="attributes+"]
+----
+<dependency>
+    <groupId>com.hazelcast</groupId>
+    <artifactId>hazelcast-java-client</artifactId>
+    <version>{full-version}</version>
+</dependency>
+----
+The {client-name} is mostly compatible with the Embed client. However, one notable difference is that methods which threw `UnsupportedOperationException` in the Embed client are not present at all in the {client-name}. For example, the following methods from `ClientMapProxy`:
+[source,java]
+----
+@Override
+public UUID addLocalEntryListener(@Nonnull MapListener listener) {
+    throw new UnsupportedOperationException("Locality is ambiguous for client!");
+}
+
+@Override
+public UUID addLocalEntryListener(@Nonnull MapListener listener,
+                                  @Nonnull Predicate<K, V> predicate,
+                                  boolean includeValue) {
+    throw new UnsupportedOperationException("Locality is ambiguous for client!");
+}
+
+@Override
+public UUID addLocalEntryListener(@Nonnull MapListener listener,
+                                  @Nonnull Predicate<K, V> predicate,
+                                  @Nullable K key,
+                                  boolean includeValue) {
+    throw new UnsupportedOperationException("Locality is ambiguous for client!");
+}
+----
+
+NOTE: Currently, using both the {client-name} and the Member code (including the Embed client) on the same JVM is not supported.
+It will be supported in the future versions.
+
 
 
 == Client API

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -1,8 +1,9 @@
-= Java Thin Client
+= {client-name}
 :page-api-reference: https://docs.hazelcast.org/docs/{page-latest-supported-java-client}/javadoc
 :url-cloud-signup: https://cloud.hazelcast.com/sign-up
 :page-toclevels: 3
-:description: The Java Thin Client is a lightweight client that connects to the cluster and performs all operations through the connected node. It does not become a part of the cluster topology, never holds any data, and is not used as a destination for compute calculations. The Java Thin Client supports simplified maintenance, a clear separation of client and cluster codebases, optimization of deployment, and opportunities for further optimization specific to the Java Thin Client.
+:client-name: Thin Java Client
+:description: The {client-name} is a lightweight client that connects to the cluster and performs all operations through the connected node. It does not become a part of the cluster topology, never holds any data, and is not used as a destination for compute calculations. The {client-name} supports simplified maintenance, a clear separation of client and cluster codebases, optimization of deployment, and opportunities for further optimization specific to the {client-name}.
 [[java-client]]
 
 {description}
@@ -34,7 +35,7 @@ The `pom.xml` file is updated as follows:
 
 The client API is your gateway to access your Hazelcast cluster, including distributed objects and data pipelines (jobs).
 
-First, you must configure your client. Currently, the Java Thin Client supports only programmatic configuration, as follows:
+First, you must configure your client. Currently, the {client-name} supports only programmatic configuration, as follows:
 
 
 [source,java]
@@ -44,7 +45,7 @@ clientConfig.setClusterName("dev");
 clientConfig.getNetworkConfig().addAddress("10.90.0.1", "10.90.0.2:5702");
 ----
 
-For further information, see <<configuring-the-java-client, Configuring the Java Thin Client >>.
+For further information, see <<configuring-the-java-client, Configuring the {client-name} >>.
 
 After completing the client configuration, you must initialize the `HazelcastInstance` that you want to connect to the cluster as follows:
 
@@ -136,9 +137,9 @@ that `queue.offer` operation may rerun and this causes the same objects to be of
 
 === Using Supported Distributed Data Structures
 
-NOTE: Currently, the Java Thin Client only implements distributed map.
+NOTE: Currently, the {client-name} only implements distributed map.
 
-==== Using Map with the Java Thin Client
+==== Using Map with the {client-name}
 
 You can use any distributed map object with the client, as follows:
 
@@ -157,7 +158,7 @@ for more information.
 
 === Using Client Services
 
-The Java Thin Client provides the services discussed below for some common functionalities on the client side.
+The {client-name} provides the services discussed below for some common functionalities on the client side.
 
 ==== Using Distributed Executor Service
 
@@ -222,7 +223,7 @@ each distributed data structure in this documentation.
 
 === Async Start and Reconnect Modes
 
-The Java Thin Client can be configured to connect to a cluster asynchronously during
+The {client-name} can be configured to connect to a cluster asynchronously during
 client start-up and reconnection after a cluster disconnect.
 Both of these options are configured using `ClientConnectionStrategyConfig`.
 
@@ -253,7 +254,7 @@ if (clientStateListener.awaitConnected()) {
 }
 ----
 
-The Java Thin Client can also be configured to specify
+The {client-name} can also be configured to specify
 how it reconnects after a cluster disconnection.
 The options are as follows:
 
@@ -267,15 +268,15 @@ See the <<java-client-connection-strategy>> section to learn how to configure
 these.
 
 [[configuring-java-client]]
-== Configuring Java Thin Client
+== Configuring {client-name}
 
 === Declarative vs. Programmatic Configuration
 
 In the declarative configuration approach, settings are defined in configuration files, in XML or YAML format. This method allows for a clear separation of configuration from the application code, making it easier to manage and modify configurations without altering the codebase.
 
-NOTE: The Java Thin Client currently does not support declarative configuration. This support will be added in future releases.
+NOTE: The {client-name} currently does not support declarative configuration. This support will be added in future releases.
 
-The programmatic configuration approach involves setting configurations directly within the application code using the provided API. Using this method, configurations can be dynamically adjusted at runtime based on the application's needs. For programmatic configuration of the Java Thin Client, instantiate a `ClientConfig` object and configure the desired aspects. An example is shown below:
+The programmatic configuration approach involves setting configurations directly within the application code using the provided API. Using this method, configurations can be dynamically adjusted at runtime based on the application's needs. For programmatic configuration of the {client-name}, instantiate a `ClientConfig` object and configure the desired aspects. An example is shown below:
 
 [source,java]
 ----
@@ -289,10 +290,10 @@ NOTE: In the subsequent sections, all examples will be provided using the progra
 [[client-network]]
 === Client Network
 
-All network related configuration of the Java Thin Client is performed in the class
+All network related configuration of the {client-name} is performed in the class
 `ClientNetworkConfig` when using programmatic configuration.
 
-Some examples of the programmatic configuration of the network for the Java Thin Client are provided below.
+Some examples of the programmatic configuration of the network for the {client-name} are provided below.
 
 [[configuring-address-list]]
 ==== Configuring Address List
@@ -330,7 +331,7 @@ Its default value is *5000* milliseconds.
 ==== Setting Outbound Ports
 
 You may want to restrict outbound ports to be used by Hazelcast-enabled applications.
-To fulfill this requirement, you can configure the Java Thin Client to use only defined outbound ports.
+To fulfill this requirement, you can configure the {client-name} to use only defined outbound ports.
 
 Example:
 
@@ -354,7 +355,7 @@ Since each xref:overview:data-partitioning.adoc[data partition] uses the well kn
 each client can send an operation to the cluster member that owns the partition that holds their data,
 which increases the overall throughput and efficiency.
 
-NOTE: The **Smart Client** mode is currently not implemented in the Java Thin Client. Support for Smart Client will be added in the future versions.
+NOTE: The **Smart Client** mode is currently not implemented in the {client-name}. Support for Smart Client will be added in the future versions.
 
 **Unisocket Client**:  In the Unisocket mode, the clients only connect to one of the configured addresses.
 This single member behaves as a gateway to the other members.
@@ -363,7 +364,7 @@ returns the response back to the client returned from that member.
 
 Using the Unisocket mode is necessary in scenarios where clients are required to connect to only a single member rather than to each member in the cluster. This requirement may arise due to firewalls, security considerations, or specific networking issues.
 
-Since the Java Thin Client currently only supports the Unisocket mode, you need to disable Smart routing in the client network configuration as follows:
+Since the {client-name} currently only supports the Unisocket mode, you need to disable Smart routing in the client network configuration as follows:
 
 [source,java]
 ----
@@ -559,7 +560,7 @@ See the xref:serialization:serialization.adoc[Serialization chapter].
 
 === Defining Client Labels
 
-You can define labels in your Java Thin Client, similar to the way it can
+You can define labels in your {client-name}, similar to the way it can
 be done for the xref:management:cluster-utilities.adoc[members].
 Through the client labels, you can assign special roles for your clients and
 use these roles to perform some actions specific to those client connections.
@@ -601,7 +602,7 @@ all the waiting invocations receive a `HazelcastClientOfflineException`.
 Its default value is `ON`.
 
 The below example of programmatic configuration shows how to configure
-the Java Thin Client's starting and reconnecting modes.
+the {client-name}'s starting and reconnecting modes.
 
 [source,java]
 ----
@@ -777,7 +778,7 @@ The client configurations must be exactly the same except the following configur
 * `NetworkConfig.DiscoveryConfig`
 
 
-== Java Thin Client Failure Detectors
+== {client-name} Failure Detectors
 
 The client failure detectors are responsible to determine if a member in the cluster is unreachable or crashed.
 The most important problem in the failure detection is to distinguish
@@ -788,7 +789,7 @@ A workaround to this limitation is to use unreliable failure detectors.
 An unreliable failure detector allows a member to suspect that others have failed,
 usually based on liveness criteria but it can make mistakes to a certain degree.
 
-The Java Thin Client has two built-in failure detectors: Deadline Failure Detector and
+The {client-name} has two built-in failure detectors: Deadline Failure Detector and
 Ping Failure Detector. These client failure detectors work independently from
 the member failure detectors, e.g., you do not need to enable the member failure detectors
 to benefit from the client ones.
@@ -920,7 +921,7 @@ regardless of the other detectors.
 [[client-system-properties]]
 == Client System Properties
 
-There are some advanced client configuration properties to tune some aspects of the Java Thin Client.
+There are some advanced client configuration properties to tune some aspects of the {client-name}.
 You can set them as property name and value pairs through declarative configuration,
 programmatic configuration, or JVM system property. See the xref:ROOT:system-properties.adoc[System Properties appendix]
 to learn how to set these properties.

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -1,14 +1,12 @@
-= {client-name}
-:page-api-reference: https://docs.hazelcast.org/docs/{page-latest-supported-java-client}/javadoc
+= {java-standard-client-name}
 :url-cloud-signup: https://cloud.hazelcast.com/sign-up
 :page-toclevels: 3
-:client-name: Thin Java Client
-:description: The {client-name} is a lightweight client that connects to the cluster and performs all operations through the connected node. It does not become a part of the cluster topology, never holds any data, and is not used as a destination for compute calculations. The {client-name} supports simplified maintenance, a clear separation of client and cluster codebases, optimization of deployment, and opportunities for further optimization specific to the {client-name}.
+:description: The {java-standard-client-name} is a lightweight client that connects to the cluster and performs all operations through the connected node. It does not become a part of the cluster topology, never holds any data, and is not used as a destination for compute calculations. The {java-standard-client-name} supports simplified maintenance, a clear separation of client and cluster codebases, optimization of deployment, and opportunities for further optimization specific to the {java-standard-client-name}.
 [[java-client]]
 
 {description}
 
-== Getting Started
+== Get Started
 
 To get started, include the `hazelcast-java-client-{full-version}.jar` dependency in your classpath. Once included, you can start using this client as if
 you are using the Hazelcast API. The differences are discussed below.
@@ -16,7 +14,7 @@ you are using the Hazelcast API. The differences are discussed below.
 NOTE: If you have a Hazelcast {enterprise-product-name} license, you do not need to set the license key in your clients to use the xref:getting-started:editions.adoc#features-in-hazelcast-enterprise[{enterprise-product-name} features]. It is sufficient to set the license on the member side, and include the `hazelcast-enterprise-java-client-{full-version}.jar` dependency in your classpath.
 
 If using Maven, add the `hazelcast` dependency
-to your `pom.xml`, or to the `hazelcast-enterprise` dependency if you want the client to use {enterprise-product-name} features, and you have the Hazelcast {enterprise-product-name} license),
+to your `pom.xml`, or to the `hazelcast-enterprise` dependency if you want the client to use {enterprise-product-name} features, and you have the Hazelcast {enterprise-product-name} license,
 which might have been done when starting using Hazelcast.
 
 The `pom.xml` file is updated as follows:
@@ -30,7 +28,7 @@ The `pom.xml` file is updated as follows:
 </dependency>
 ----
 == Migrating from Embed client
-To migrate from the Embed client to {client-name}, the only change required is in the `pom.xml` file:
+To migrate from the Embed client to {java-standard-client-name}, the only change required is in the `pom.xml` file:
 [source,xml,subs="attributes+"]
 ----
 <dependency>
@@ -39,7 +37,7 @@ To migrate from the Embed client to {client-name}, the only change required is i
     <version>{full-version}</version>
 </dependency>
 ----
-The {client-name} is mostly compatible with the Embed client. However, one notable difference is that methods which threw `UnsupportedOperationException` in the Embed client are not present at all in the {client-name}. For example, the following methods from `ClientMapProxy`:
+The {java-standard-client-name} is mostly compatible with the Embed client. However, one notable difference is that methods which threw `UnsupportedOperationException` in the Embed client are not present at all in the {java-standard-client-name}. For example, the following methods from `ClientMapProxy`:
 [source,java]
 ----
 @Override
@@ -63,7 +61,7 @@ public UUID addLocalEntryListener(@Nonnull MapListener listener,
 }
 ----
 
-NOTE: Currently, using both the {client-name} and the Member code (including the Embed client) on the same JVM is not supported.
+NOTE: Currently, using both the {java-standard-client-name} and the Member code (including the Embed client) on the same JVM is not supported.
 It will be supported in the future versions.
 
 
@@ -72,7 +70,7 @@ It will be supported in the future versions.
 
 The client API is your gateway to access your Hazelcast cluster, including distributed objects and data pipelines (jobs).
 
-First, you must configure your client. Currently, the {client-name} supports only programmatic configuration, as follows:
+First, you must configure your client. Currently, the {java-standard-client-name} supports only programmatic configuration, as follows:
 
 
 [source,java]
@@ -82,7 +80,7 @@ clientConfig.setClusterName("dev");
 clientConfig.getNetworkConfig().addAddress("10.90.0.1", "10.90.0.2:5702");
 ----
 
-For further information, see <<configuring-the-java-client, Configuring the {client-name} >>.
+For further information, see <<configuring-the-java-client, Configuring the {java-standard-client-name} >>.
 
 After completing the client configuration, you must initialize the `HazelcastInstance` that you want to connect to the cluster as follows:
 
@@ -174,9 +172,9 @@ that `queue.offer` operation may rerun and this causes the same objects to be of
 
 === Using Supported Distributed Data Structures
 
-NOTE: Currently, the {client-name} only implements distributed map.
+NOTE: Currently, the {java-standard-client-name} only implements distributed map.
 
-==== Using Map with the {client-name}
+==== Using Map with the {java-standard-client-name}
 
 You can use any distributed map object with the client, as follows:
 
@@ -195,7 +193,7 @@ for more information.
 
 === Using Client Services
 
-The {client-name} provides the services discussed below for some common functionalities on the client side.
+The {java-standard-client-name} provides the services discussed below for some common functionalities on the client side.
 
 ==== Using Distributed Executor Service
 
@@ -260,7 +258,7 @@ each distributed data structure in this documentation.
 
 === Async Start and Reconnect Modes
 
-The {client-name} can be configured to connect to a cluster asynchronously during
+The {java-standard-client-name} can be configured to connect to a cluster asynchronously during
 client start-up and reconnection after a cluster disconnect.
 Both of these options are configured using `ClientConnectionStrategyConfig`.
 
@@ -291,7 +289,7 @@ if (clientStateListener.awaitConnected()) {
 }
 ----
 
-The {client-name} can also be configured to specify
+The {java-standard-client-name} can also be configured to specify
 how it reconnects after a cluster disconnection.
 The options are as follows:
 
@@ -305,15 +303,15 @@ See the <<java-client-connection-strategy>> section to learn how to configure
 these.
 
 [[configuring-java-client]]
-== Configuring {client-name}
+== Configuring {java-standard-client-name}
 
 === Declarative vs. Programmatic Configuration
 
 In the declarative configuration approach, settings are defined in configuration files, in XML or YAML format. This method allows for a clear separation of configuration from the application code, making it easier to manage and modify configurations without altering the codebase.
 
-NOTE: The {client-name} currently does not support declarative configuration. This support will be added in future releases.
+NOTE: The {java-standard-client-name} currently does not support declarative configuration. This support will be added in future releases.
 
-The programmatic configuration approach involves setting configurations directly within the application code using the provided API. Using this method, configurations can be dynamically adjusted at runtime based on the application's needs. For programmatic configuration of the {client-name}, instantiate a `ClientConfig` object and configure the desired aspects. An example is shown below:
+The programmatic configuration approach involves setting configurations directly within the application code using the provided API. Using this method, configurations can be dynamically adjusted at runtime based on the application's needs. For programmatic configuration of the {java-standard-client-name}, instantiate a `ClientConfig` object and configure the desired aspects. An example is shown below:
 
 [source,java]
 ----
@@ -327,10 +325,10 @@ NOTE: In the subsequent sections, all examples will be provided using the progra
 [[client-network]]
 === Client Network
 
-All network related configuration of the {client-name} is performed in the class
+All network related configuration of the {java-standard-client-name} is performed in the class
 `ClientNetworkConfig` when using programmatic configuration.
 
-Some examples of the programmatic configuration of the network for the {client-name} are provided below.
+Some examples of the programmatic configuration of the network for the {java-standard-client-name} are provided below.
 
 [[configuring-address-list]]
 ==== Configuring Address List
@@ -368,7 +366,7 @@ Its default value is *5000* milliseconds.
 ==== Setting Outbound Ports
 
 You may want to restrict outbound ports to be used by Hazelcast-enabled applications.
-To fulfill this requirement, you can configure the {client-name} to use only defined outbound ports.
+To fulfill this requirement, you can configure the {java-standard-client-name} to use only defined outbound ports.
 
 Example:
 
@@ -392,7 +390,7 @@ Since each xref:overview:data-partitioning.adoc[data partition] uses the well kn
 each client can send an operation to the cluster member that owns the partition that holds their data,
 which increases the overall throughput and efficiency.
 
-NOTE: The **Smart Client** mode is currently not implemented in the {client-name}. Support for Smart Client will be added in the future versions.
+NOTE: The **Smart Client** mode is currently not implemented in the {java-standard-client-name}. Support for Smart Client will be added in the future versions.
 
 **Unisocket Client**:  In the Unisocket mode, the clients only connect to one of the configured addresses.
 This single member behaves as a gateway to the other members.
@@ -401,7 +399,7 @@ returns the response back to the client returned from that member.
 
 Using the Unisocket mode is necessary in scenarios where clients are required to connect to only a single member rather than to each member in the cluster. This requirement may arise due to firewalls, security considerations, or specific networking issues.
 
-Since the {client-name} currently only supports the Unisocket mode, you need to disable Smart routing in the client network configuration as follows:
+Since the {java-standard-client-name} currently only supports the Unisocket mode, you need to disable Smart routing in the client network configuration as follows:
 
 [source,java]
 ----
@@ -434,7 +432,7 @@ Its default value is `false` (disabled).
 
 [blue]*Hazelcast {enterprise-product-name}*
 
-Following is a client configuration to set a socket intercepter.
+Following is a client configuration to set a socket interceptor.
 Any class implementing `com.hazelcast.nio.SocketInterceptor` is a socket interceptor.
 
 
@@ -597,7 +595,7 @@ See the xref:serialization:serialization.adoc[Serialization chapter].
 
 === Defining Client Labels
 
-You can define labels in your {client-name}, similar to the way it can
+You can define labels in your {java-standard-client-name}, similar to the way it can
 be done for the xref:management:cluster-utilities.adoc[members].
 Through the client labels, you can assign special roles for your clients and
 use these roles to perform some actions specific to those client connections.
@@ -639,7 +637,7 @@ all the waiting invocations receive a `HazelcastClientOfflineException`.
 Its default value is `ON`.
 
 The below example of programmatic configuration shows how to configure
-the {client-name}'s starting and reconnecting modes.
+the {java-standard-client-name}'s starting and reconnecting modes.
 
 [source,java]
 ----
@@ -815,7 +813,7 @@ The client configurations must be exactly the same except the following configur
 * `NetworkConfig.DiscoveryConfig`
 
 
-== {client-name} Failure Detectors
+== {java-standard-client-name} Failure Detectors
 
 The client failure detectors are responsible to determine if a member in the cluster is unreachable or crashed.
 The most important problem in the failure detection is to distinguish
@@ -826,7 +824,7 @@ A workaround to this limitation is to use unreliable failure detectors.
 An unreliable failure detector allows a member to suspect that others have failed,
 usually based on liveness criteria but it can make mistakes to a certain degree.
 
-The {client-name} has two built-in failure detectors: Deadline Failure Detector and
+The {java-standard-client-name} has two built-in failure detectors: Deadline Failure Detector and
 Ping Failure Detector. These client failure detectors work independently from
 the member failure detectors, e.g., you do not need to enable the member failure detectors
 to benefit from the client ones.
@@ -958,7 +956,7 @@ regardless of the other detectors.
 [[client-system-properties]]
 == Client System Properties
 
-There are some advanced client configuration properties to tune some aspects of the {client-name}.
+There are some advanced client configuration properties to tune some aspects of the {java-standard-client-name}.
 You can set them as property name and value pairs through declarative configuration,
 programmatic configuration, or JVM system property. See the xref:ROOT:system-properties.adoc[System Properties appendix]
 to learn how to set these properties.

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -13,7 +13,7 @@ you are using the Hazelcast API. The differences are discussed below.
 
 NOTE: If you have a Hazelcast {enterprise-product-name} license, you do not need to set the license key in your clients to use the xref:getting-started:editions.adoc#features-in-hazelcast-enterprise[{enterprise-product-name} features] - setting it on the member side is enough. In this case, you only need to include the `hazelcast-enterprise-java-client-{full-version}.jar` dependency in your classpath.
 
-If using Maven, add the `hazelcast` dependency
+If using Maven, add the `hazelcast-java-client` dependency
 to your `pom.xml`, or to the `hazelcast-enterprise` dependency if you want the client to use {enterprise-product-name} features, and you have the Hazelcast {enterprise-product-name} license,
 which might have been done when starting using Hazelcast.
 

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -1,0 +1,1088 @@
+= Java Thin Client
+:page-api-reference: https://docs.hazelcast.org/docs/{page-latest-supported-java-client}/javadoc
+:url-cloud-signup: https://cloud.hazelcast.com/sign-up
+:page-toclevels: 3
+:description: The Java Thin Client is a lightweight client that connects to the cluster and performs all operations through the connected node. It does not become a part of the cluster topology, never holds any data, and is not used as a destination for compute calculations. The Java Thin Client supports simplified maintenance, a clear separation of client and cluster codebases, optimization of deployment, and opportunities for further optimization specific to the Java Thin Client.
+[[java-client]]
+
+{description}
+
+== Getting Started
+
+To get started, include the `hazelcast-java-client-{full-version}.jar` dependency in your classpath. Once included, you can start using this client as if
+you are using the Hazelcast API. The differences are discussed below.
+
+NOTE: If you have a Hazelcast {enterprise-product-name} license, you do not need to set the license key in your clients to use the xref:getting-started:editions.adoc#features-in-hazelcast-enterprise[{enterprise-product-name} features]. It is sufficient to set the license on the member side, and include the `hazelcast-enterprise-java-client-{full-version}.jar` dependency in your classpath.
+
+If using Maven, add the `hazelcast` dependency
+to your `pom.xml`, or to the `hazelcast-enterprise` dependency if you want the client to use {enterprise-product-name} features, and you have the Hazelcast {enterprise-product-name} license),
+which might have been done when starting using Hazelcast.
+
+The `pom.xml` file is updated as follows:
+
+[source,xml,subs="attributes+"]
+----
+<dependency>
+    <groupId>com.hazelcast</groupId>
+    <artifactId>hazelcast-java-client</artifactId>
+    <version>{full-version}</version>
+</dependency>
+----
+
+
+== Client API
+
+The client API is your gateway to access your Hazelcast cluster, including distributed objects and data pipelines (jobs).
+
+First, you must configure your client. Currently, the Java Thin Client supports only programmatic configuration, as follows:
+
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.setClusterName("dev");
+clientConfig.getNetworkConfig().addAddress("10.90.0.1", "10.90.0.2:5702");
+----
+
+For further information, see <<configuring-the-java-client, Configuring the Java Thin Client >>.
+
+After completing the client configuration, you must initialize the `HazelcastInstance` that you want to connect to the cluster as follows:
+
+```java
+HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+```
+
+You can create a map and populate it with some data as follows:
+
+[source,java]
+----
+IMap<String, Customer> mapCustomers = client.getMap("customers"); //creates the map proxy
+
+mapCustomers.put("1", new Customer("Joe", "Smith"));
+mapCustomers.put("2", new Customer("Ali", "Selam"));
+mapCustomers.put("3", new Customer("Avi", "Noyan"));
+----
+
+For further information about using maps, see xref:data-structures:map.adoc[].
+
+Lastly, after setting up your client, you can shut it down as follows:
+
+```java
+client.shutdown();
+```
+
+The code line provided above releases all used resources and closes all connections to the cluster.
+
+[[handling-failures]]
+=== Handling Failures
+
+The main areas are around client connections and retry-able operations. Some approaches to avoiding such failures are provided below.
+
+**Handling Client Connection Failure:**
+
+While the client initially tries to connect to one of the members in the
+`ClientNetworkConfig.addressList`, it is possible that not all members are available.
+Instead of giving up, throwing an exception and stopping,
+the client continues to attempt to connect as configured.
+For information on the available configuration, see <<configuring-client-connection-retry, Configuring Client Connection Retry>>.
+
+The client executes each operation through the already established connection to the cluster.
+If this connection disconnects or drops, the client tries to reconnect as configured.
+
+The initial connection is established using one of the addresses provided in the <<configuring-address-list, address list>>.
+The client gets the addresses of other members in the cluster from the first connected member.
+
+If you use a <<client-network,discovery mechanism>> to find the initial member for the connection instead of an address list,
+you can use the same property to configure whether the initial member connection uses the private or public address.
+
+For an example of this scenario, refer to
+link:https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-expose-externally[Connect to Hazelcast from Outside Kubernetes, window=_blank] in the Operator documentation.
+
+**Handling Retry-able Operation Failure:**
+
+While sending the requests to related members, operations can fail due to various reasons.
+Read-only operations are retried by default. If you want to enable retry for the other operations,
+you can set the `redoOperation` to `true`. See the <<enabling-redo-operation, Enabling Redo Operation section>>.
+
+You can set a timeout for retrying the operations sent to a member.
+This can be provided by using the property `hazelcast.client.invocation.timeout.seconds` in `ClientProperties`.
+The client retries an operation within this given period, of course, if it is a read-only operation, or
+you enabled the `redoOperation` as stated in the above paragraph.
+This timeout value is important when there is a failure resulted by any of the following causes:
+
+* Member throws an exception.
+* Connection between the client and member is closed.
+* Client's heartbeat requests are timed out.
+
+See the <<client-system-properties, Client System Properties section>>
+for the description of the `hazelcast.client.invocation.timeout.seconds` property.
+
+When any failure happens between a client and member
+(such as an exception on the member side or connection issues), an operation is retried if:
+
+* it is certain that it has not run on the member yet
+* it is idempotent such as a read-only operation; that is, retrying does not have a side effect.
+
+If it is not certain whether the operation has run on the member,
+then the non-idempotent operations are not retried.
+However, as explained in the first paragraph of this section,
+you can force all client operations to be retried (`redoOperation`)
+when there is a failure between the client and member.
+But in this case, you should know that some operations may run multiple times causing conflicts.
+For example, assume that your client sent a `queue.offer` operation to the member and
+then the connection is lost. Since there will be no respond for this operation,
+you will not know whether it has run on the member or not. If you enabled `redoOperation`,
+that `queue.offer` operation may rerun and this causes the same objects to be offered twice in the member's queue.
+
+=== Using Supported Distributed Data Structures
+
+NOTE: Currently, the Java Thin Client only implements distributed map.
+
+==== Using Map with the Java Thin Client
+
+You can use any distributed map object with the client, as follows:
+
+[source,java]
+----
+Imap<Integer, String> map = client.getMap("myMap");
+
+map.put(1, "John");
+String value= map.get(1);
+map.remove(1);
+----
+
+Locality is ambiguous for the client, so the `addLocalEntryListener()` and
+`localKeySet()` methods are not supported. See xref:data-structures:map.adoc[]
+for more information.
+
+=== Using Client Services
+
+The Java Thin Client provides the services discussed below for some common functionalities on the client side.
+
+==== Using Distributed Executor Service
+
+The distributed executor service is for distributed computing.
+It can be used to execute tasks on the cluster on a designated partition or on all the partitions.
+It can also be used to process entries. See xref:computing:executor-service.adoc[] for more information.
+
+```java
+IExecutorService executorService = client.getExecutorService("default");
+```
+
+After getting an instance of `IExecutorService`, you can use the instance as
+the interface with the one provided on the server side. See
+xref:computing:distributed-computing.adoc[] for detailed usage.
+
+==== Finding the Partition of a Key
+
+You use partition service to find the partition of a key.
+It returns all partitions. See the example code below.
+
+[source,java]
+----
+PartitionService partitionService = client.getPartitionService();
+
+//partition of a key
+Partition partition = partitionService.getPartition(key);
+
+//all partitions
+Set<Partition> partitions = partitionService.getPartitions();
+----
+
+==== Handling Lifecycle
+
+Lifecycle handling does the following:
+
+* Checks if the client is running
+* Shuts down the client gracefully
+* Terminates the client ungracefully (forced shutdown)
+* Adds or removes lifecycle listeners
+
+[source,java]
+----
+LifecycleService lifecycleService = client.getLifecycleService();
+
+if(lifecycleService.isRunning()){
+    //it is running
+}
+
+//shutdown client gracefully
+lifecycleService.shutdown();
+----
+
+
+=== Client Listeners
+
+You can configure listeners to listen to various event types on the client side.
+You can configure global events not relating to any distributed object through
+<<configuring-client-listeners, Client ListenerConfig>>.
+You should configure distributed object listeners like map entry listeners or
+list item listeners through their proxies. See the related sections under
+each distributed data structure in this documentation.
+
+=== Async Start and Reconnect Modes
+
+The Java Thin Client can be configured to connect to a cluster asynchronously during
+client start-up and reconnection after a cluster disconnect.
+Both of these options are configured using `ClientConnectionStrategyConfig`.
+
+You can configure asynchronous client start by setting the configuration element `async-start` to `true`.
+This configuration changes the behavior of the `HazelcastClient.newHazelcastClient()` call.
+It returns a client instance without waiting to establish a cluster connection.
+Until the client connects to cluster, it throws `HazelcastClientOfflineException`
+on any network dependent operations to ensure that they won't cause a block.
+If you want to check or wait the client to complete its cluster connection,
+you can use the built-in lifecycle listener:
+
+
+[source,java]
+----
+ClientStateListener clientStateListener = new ClientStateListener(clientConfig);
+HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+
+//Client started but may not be connected to cluster yet.
+
+//check connection status
+clientStateListener.isConnected();
+
+//blocks until client completes connect to cluster
+if (clientStateListener.awaitConnected()) {
+	//connected successfully
+} else {
+	//client failed to connect to cluster
+}
+----
+
+The Java Thin Client can also be configured to specify
+how it reconnects after a cluster disconnection.
+The options are as follows:
+
+* Client can reject to reconnect to the cluster and trigger the client shutdown process.
+* Client can open a connection to the cluster by blocking all waiting invocations.
+* Client can open a connection to the cluster without blocking the waiting invocations.
+All invocations receive `HazelcastClientOfflineException` during the establishment of cluster connection.
+If cluster connection fails to connect, then client shutdown is triggered.
+
+See the <<java-client-connection-strategy>> section to learn how to configure
+these.
+
+[[configuring-java-client]]
+== Configuring Java Thin Client
+
+=== Declarative vs. Programmatic Configuration
+
+In the declarative configuration approach, settings are defined in configuration files, in XML or YAML format. This method allows for a clear separation of configuration from the application code, making it easier to manage and modify configurations without altering the codebase.
+
+NOTE: The Java Thin Client currently does not support declarative configuration. This support will be added in future releases.
+
+The programmatic configuration approach involves setting configurations directly within the application code using the provided API. Using this method, configurations can be dynamically adjusted at runtime based on the application's needs. For programmatic configuration of the Java Thin Client, instantiate a `ClientConfig` object and configure the desired aspects. An example is shown below:
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.setClusterName("dev");
+clientConfig.setLoadBalancer(yourLoadBalancer);
+----
+
+NOTE: In the subsequent sections, all examples will be provided using the programmatic approach.
+
+[[client-network]]
+=== Client Network
+
+All network related configuration of the Java Thin Client is performed in the class
+`ClientNetworkConfig` when using programmatic configuration.
+
+Some examples of the programmatic configuration of the network for the Java Thin Client are provided below.
+
+[[configuring-address-list]]
+==== Configuring Address List
+
+Address List is the initial list of cluster addresses to which the client will connect.
+The client uses this list to find an alive member. Although it may be enough to give
+only one address of a member in the cluster (since all members communicate with each other),
+it is recommended that you give the addresses for all the members.
+
+For example:
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+networkConfig.addAddress("10.1.1.21", "10.1.1.22:5703");
+----
+
+[[setting-connection-timeout]]
+==== Setting Connection Timeout
+
+Connection timeout is the timeout value in milliseconds for members to
+accept client connection requests. Example configurations are provided below.
+
+Example:
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.getNetworkConfig().setConnectionTimeout(5000);
+----
+
+Its default value is *5000* milliseconds.
+
+==== Setting Outbound Ports
+
+You may want to restrict outbound ports to be used by Hazelcast-enabled applications.
+To fulfill this requirement, you can configure the Java Thin Client to use only defined outbound ports.
+
+Example:
+
+[source,java]
+----
+NetworkConfig networkConfig = config.getNetworkConfig();
+// ports between 34700 and 34710
+networkConfig.addOutboundPortDefinition("34700-34710");
+// comma separated ports
+networkConfig.addOutboundPortDefinition("34700,34701,34702,34703");
+networkConfig.addOutboundPort(34705);
+----
+
+[[java-client-operation-modes]]
+==== Setting Smart Routing
+
+Hazelcast clients have two operation modes because of the distributed nature of the data and cluster.
+
+**Smart Client**: In the Smart mode, the clients connect to each cluster member.
+Since each xref:overview:data-partitioning.adoc[data partition] uses the well known and consistent hashing algorithm,
+each client can send an operation to the cluster member that owns the partition that holds their data,
+which increases the overall throughput and efficiency.
+
+NOTE: The **Smart Client** mode is currently not implemented in the Java Thin Client. Support for Smart Client will be added in the future versions.
+
+**Unisocket Client**:  In the Unisocket mode, the clients only connect to one of the configured addresses.
+This single member behaves as a gateway to the other members.
+For any operation requested from the client, it redirects the request to the relevant member and
+returns the response back to the client returned from that member.
+
+Using the Unisocket mode is necessary in scenarios where clients are required to connect to only a single member rather than to each member in the cluster. This requirement may arise due to firewalls, security considerations, or specific networking issues.
+
+Since the Java Thin Client currently only supports the Unisocket mode, you need to disable Smart routing in the client network configuration as follows:
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+networkConfig.setSmartRouting(false);
+----
+
+Note that you need also to disable Smart routing for the clients which
+want to use temporary permissions defined in a member.
+See the xref:security:native-client-security.adoc#handling-permissions-when-a-new-member-joins[Handling Permissions section].
+
+[[enabling-redo-operation]]
+==== Enabling Redo Operation
+
+It enables/disables redo-able operations as described in
+<<handling-failures, Handling Retry-able Operation Failure>>.
+The following is an example configuration.
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+networkConfig().setRedoOperation(true);
+----
+
+Its default value is `false` (disabled).
+
+==== Setting a Socket Interceptor
+
+[blue]*Hazelcast {enterprise-product-name}*
+
+Following is a client configuration to set a socket intercepter.
+Any class implementing `com.hazelcast.nio.SocketInterceptor` is a socket interceptor.
+
+
+[source,java]
+----
+public interface SocketInterceptor {
+    void init(Properties properties);
+    void onConnect(Socket connectedSocket) throws IOException;
+}
+----
+
+`SocketInterceptor` has two steps. First, it is initialized by the configured properties.
+Second, it is informed just after the socket is connected using the `onConnect` method.
+
+
+[source,java]
+----
+SocketInterceptorConfig socketInterceptorConfig = clientConfig
+               .getNetworkConfig().getSocketInterceptorConfig();
+
+MyClientSocketInterceptor myClientSocketInterceptor = new MyClientSocketInterceptor();
+
+socketInterceptorConfig.setEnabled(true);
+socketInterceptorConfig.setImplementation(myClientSocketInterceptor);
+----
+
+If you want to configure the socket interceptor with a class name instead of an instance,
+see the example below.
+
+[source,java]
+----
+SocketInterceptorConfig socketInterceptorConfig = clientConfig
+            .getNetworkConfig().getSocketInterceptorConfig();
+
+socketInterceptorConfig.setEnabled(true);
+
+//These properties are provided to interceptor during init
+socketInterceptorConfig.setProperty("kerberos-host","kerb-host-name");
+socketInterceptorConfig.setProperty("kerberos-config-file","kerb.conf");
+
+socketInterceptorConfig.setClassName(MyClientSocketInterceptor.class.getName());
+----
+
+NOTE: See the xref:security:socket-interceptor.adoc[Socket Interceptor section] for more information.
+
+==== Configuring Network Socket Options
+
+You can configure the network socket options using `SocketOptions`. It has the following methods:
+
+* `socketOptions.setKeepAlive(x)`: Enables/disables the *SO_KEEPALIVE* socket option.
+Its default value is `true`.
+* `socketOptions.setTcpNoDelay(x)`: Enables/disables the *TCP_NODELAY* socket option.
+Its default value is `true`.
+* `socketOptions.setReuseAddress(x)`: Enables/disables the *SO_REUSEADDR* socket option.
+Its default value is `true`.
+* `socketOptions.setLingerSeconds(x)`: Enables/disables *SO_LINGER* with the specified linger time in seconds.
+Its default value is `3`.
+* `socketOptions.setBufferSize(x)`: Sets the *SO_SNDBUF* and *SO_RCVBUF* options to the specified value in KB for this Socket.
+Its default value is `32`.
+
+
+[source,java]
+----
+SocketOptions socketOptions = clientConfig.getNetworkConfig().getSocketOptions();
+socketOptions.setBufferSize(32)
+             .setKeepAlive(true)
+             .setTcpNoDelay(true)
+             .setReuseAddress(true)
+             .setLingerSeconds(3);
+----
+
+==== Enabling Client TLS/SSL
+
+[blue]*Hazelcast {enterprise-product-name}*
+
+You can use TLS/SSL to secure the connection between the client and the members.
+If you want TLS/SSL enabled for the client-cluster connection, you should set `SSLConfig`.
+Once set, the connection (socket) is established out of an TLS/SSL factory defined either by
+a factory class name or factory implementation. See the xref:security:tls-ssl.adoc[TLS/SSL section].
+
+As explained in the TLS/SSL section, Hazelcast members have keyStores used to
+identify themselves (to other members) and the clients have trustStore used to
+define which members they can trust. The clients also have their keyStores and
+members have their trustStores so that the members can
+know which clients they can trust: see the xref:security:tls-ssl.adoc#mutual-authentication[Mutual Authentication section].
+
+```java
+Properties properties = new Properties();
+properties.setProperty("protocol", "TLSv1.2");
+properties.setProperty("trustCertCollectionFile", "/path/server.crt");
+
+SSLConfig sslConfig = new SSLConfig().setEnabled(true)
+                                     .setProperties(properties);
+sslConfig.setFactoryClassName(BasicSSLContextFactory.class.getName())
+         .setFactoryImplementation(new BasicSSLContextFactory());
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.getNetworkConfig().setSSLConfig(sslConfig);
+```
+Please note that the paths in the properties here are *absolute paths* to the resources in classpath.
+
+To enable mutual authentication on the client, add to the properties:
+```java
+properties.setProperty("keyFile", "/path/client.pem");
+properties.setProperty("keyCertChainFile", "/path/client.crt");
+```
+To use the OpenSSL engine instead of the Basic SSL context,
+replace the SSL context factory class name and implementation as follows:
+```java
+sslConfig.setFactoryClassName(OpenSSLEngineFactory.class.getName())
+        .setFactoryImplementation(new OpenSSLEngineFactory());
+```
+
+=== Configuring Client Cluster
+
+Clients should provide a cluster name in order to connect to the cluster.
+You can configure it using `ClientConfig`, as shown below.
+
+```java
+clientConfig.setClusterName("dev");
+```
+
+[[configuring-client-listeners]]
+=== Configuring Client Listeners
+
+You can configure global event listeners not related to any distributed object using `ListenerConfig` as shown below.
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+ListenerConfig listenerConfig = new ListenerConfig(LifecycleListenerImpl);
+clientConfig.addListenerConfig(listenerConfig);
+----
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+ListenerConfig listenerConfig = new ListenerConfig("com.hazelcast.example.MembershipListenerImpl");
+clientConfig.addListenerConfig(listenerConfig);
+----
+
+You can add the following types of event listeners:
+
+* LifecycleListener
+* MembershipListener
+* DistributedObjectListener
+
+[[client-security-configuration]]
+=== Configuring Client Security
+
+In the cases where the security established with `Config` is not enough, and
+you want your clients connecting securely to the cluster, you can use `ClientSecurityConfig`.
+This configuration has a `credentials` parameter to set the IP address and UID.
+See the https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/client/config/ClientSecurityConfig.html[ClientSecurityConfig Javadoc^].
+
+[[client-serialization-configuration]]
+=== Client Serialization Configuration
+
+For the client side serialization, use the Hazelcast configuration.
+See the xref:serialization:serialization.adoc[Serialization chapter].
+
+=== Defining Client Labels
+
+You can define labels in your Java Thin Client, similar to the way it can
+be done for the xref:management:cluster-utilities.adoc[members].
+Through the client labels, you can assign special roles for your clients and
+use these roles to perform some actions specific to those client connections.
+
+You can also group your clients using the client labels.
+These client groups can be blacklisted in the Hazelcast Management Center so that
+they can be prevented from connecting to a cluster. See the related section in the
+Hazelcast Management Center Reference Manual for more information about this topic.
+
+Example:
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.setInstanceName("ExampleClientName");
+clientConfig.addLabel("user");
+clientConfig.addLabel("bar");
+
+HazelcastClient.newHazelcastClient(clientConfig);
+----
+
+[[java-client-connection-strategy]]
+=== Java Client Connection Strategy
+
+You can configure the client's starting mode as async or sync using
+the configuration element `async-start`. When it is set to `true` (async),
+Hazelcast creates the client without waiting a connection to the cluster.
+In this case, the client instance throws an exception until it connects to the cluster.
+If it is `false`, the client is not created until the cluster is ready to use clients and
+a connection with the cluster is established. Its default value is `false` (sync)
+
+You can also configure how the client reconnects to the cluster after a disconnection.
+This is configured using the configuration element `reconnect-mode`; it has three options
+(`OFF`, `ON` or `ASYNC`). The option `OFF` disables the reconnection.
+`ON` enables reconnection in a blocking manner where all the waiting invocations are blocked until
+a cluster connection is established or failed.
+The option `ASYNC` enables reconnection in a non-blocking manner where
+all the waiting invocations receive a `HazelcastClientOfflineException`.
+Its default value is `ON`.
+
+The below example of programmatic configuration shows how to configure
+the Java Thin Client's starting and reconnecting modes.
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.getConnectionStrategyConfig()
+            .setAsyncStart(true)
+            .setReconnectMode(ClientConnectionStrategyConfig.ReconnectMode.ASYNC);
+----
+
+[[configuring-client-connection-retry]]
+=== Configuring Client Connection Retry
+
+When the client is disconnected from the cluster or trying to connect to a one
+for the first time, it searches for new connections. You can configure the frequency
+of the connection attempts and client shutdown behavior using
+`ConnectionRetryConfig` (programmatically).
+
+[source,java]
+----
+ClientConfig config = new ClientConfig();
+ClientConnectionStrategyConfig connectionStrategyConfig = config.getConnectionStrategyConfig();
+ConnectionRetryConfig connectionRetryConfig = connectionStrategyConfig.getConnectionRetryConfig();
+connectionRetryConfig.setInitialBackoffMillis(1000)
+                     .setMaxBackoffMillis(60000)
+                     .setMultiplier(2)
+                     .setClusterConnectTimeoutMillis(50000)
+                     .setJitter(0.2);
+
+----
+
+The following are configuration element descriptions:
+
+* `initial-backoff-millis`: Specifies how long to wait (backoff), in milliseconds, after the first failure before retrying.
+Its default value is 1000 ms.
+* `max-backoff-millis`: Specifies the upper limit for the backoff in milliseconds.
+Its default value is 30000 ms.
+* `multiplier`: Factor to multiply the backoff after a failed retry.
+Its default value is 1.05.
+* `cluster-connect-timeout-millis`: Timeout value in milliseconds for the client to give up
+to connect to the current cluster. Its default value is `-1`, i.e., infinite.
+For the default value, the client will not stop trying to
+connect to the target cluster (infinite timeout). If the failover client is used
+with the default value of this configuration element, the failover client will try
+to connect alternative clusters after 120000 ms (2 minutes). For any other value,
+both the client and the failover client will use this as it is.
+* `jitter`: Specifies by how much to randomize backoffs. Its default value is 0.
+
+A pseudo-code is as follows:
+
+[source,java]
+----
+ begin_time = getCurrentTime()
+ current_backoff_millis = INITIAL_BACKOFF_MILLIS
+ while (TryConnect(connectionTimeout)) != SUCCESS) {
+    if (getCurrentTime() - begin_time >= CLUSTER_CONNECT_TIMEOUT_MILLIS) {
+         // Give up to connecting to the current cluster and switch to another if exists.
+         // For the default values, CLUSTER_CONNECT_TIMEOUT_MILLIS is infinite for the
+         // client and equal to the 120000 ms (2 minutes) for the failover client.
+    }
+    Sleep(current_backoff_millis + UniformRandom(-JITTER * current_backoff_millis, JITTER * current_backoff_millis))
+    current_backoff = Min(current_backoff_millis * MULTIPLIER, MAX_BACKOFF_MILLIS)
+}
+----
+
+Note that, `TryConnect` above tries to connect to any member that the client knows,
+and for each connection we have a connection timeout; see the
+<<setting-connection-timeout, Setting Connection Timeout section>>.
+
+[[blue-green-deployment-and-disaster-recovery]]
+== Blue-Green Deployment
+[[blue-green-mechanism]]
+[blue]*Hazelcast {enterprise-product-name} Feature*
+
+Blue-green deployment refers to a client connection technique that reduces system downtime by deploying two mirrored clusters: blue (active) and green (idle). One of these clusters is running in production while the other is on standby.
+
+Using the blue-green mechanism, clients can connect to another cluster automatically when they are blacklisted from their currently connected cluster. See the xref:{page-latest-supported-mc}@management-center:monitor-imdg:monitor-clients.adoc#changing-cluster-client-filtering[Hazelcast Management Center Reference Manual] for information about blacklisting the clients.
+
+The client's behavior after this disconnection depends on its
+<<java-client-connection-strategy, `reconnect-mode`>>.
+The following are the options when you are using the blue-green mechanism, i.e.,
+you have alternative clusters for your clients to connect:
+
+* If `reconnect-mode` is set to `ON`, the client changes the cluster and
+blocks the invocations while doing so.
+* If `reconnect-mode` is set to `ASYNC`, the client changes the cluster
+in the background and throws `ClientOfflineException` while doing so.
+* If `reconnect-mode` is set to `OFF`, the client does not change the cluster; it shuts down immediately.
+
+NOTE: Here it could be the case that the whole cluster is restarted.
+In this case, the members in the restarted cluster
+reject the client's connection request, since the client is trying to connect to the old cluster.
+So, the client needs to search for a new cluster, if available and
+according to the blue-green configuration (see the following configuration related sections in this section).
+
+Consider the following notes for the blue-green mechanism (also valid for the disaster
+recovery mechanism described in the next section):
+
+* When a client disconnects from a cluster and
+connects to a new one the `InitialMemberEvent` and `CLIENT_CHANGED_CLUSTER` events are fired.
+* When switching clusters, the client reuses its UUID.
+* The client's listener service re-registers its listeners on the new cluster;
+the listener service opens a new connection to all members in the current
+<<client-network, member list>> and registers the listeners for each connection.
+* The client's Near Caches and Continuous Query Caches are cleared when
+the client joins a new cluster successfully.
+* If the new cluster's partition size is different, the client is rejected by the cluster.
+The client is not able to connect to a cluster with different partition count.
+* The state of any running job on the original cluster will be undefined. * Streaming jobs may continue running on the original cluster if the cluster is still alive and the switching happened due to a network problem. If you try to query the state of the job using the Job interface, you’ll get a `JobNotFoundException`.
+
+=== Disaster Recovery Mechanism
+
+When one of your clusters is gone due to a failure, the connection between
+your clients and members in that cluster is gone too.
+When a client is disconnected because of a failure in the cluster,
+it first tries to reconnect to the same cluster.
+
+The client's behavior after this disconnection depends on its
+<<java-client-connection-strategy, `reconnect-mode`>>, and it has the same options
+that are described in the above section (Blue-Green Mechanism).
+
+If you have provided alternative clusters for your clients to connect,
+the client tries to connect to those alternative clusters (depending on the `reconnect-mode`).
+
+When a failover starts, i.e., the client is disconnected and was configured
+to connect to alternative clusters, the current <<client-network, member list>> is not considered;
+the client cuts all the connections before attempting to connect to a new cluster and tries the clusters as configured.
+See the below configuration related sections.
+
+=== Configuring Without CNAME
+
+Let's first give example configurations and describe the configuration elements.
+
+
+[source,java]
+----
+ClientConfig clientConfig = new ClientConfig();
+clientConfig.setClusterName("cluster-a");
+ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+networkConfig.addAddress("10.216.1.18", "10.216.1.19");
+
+ClientConfig clientConfig2 = new ClientConfig();
+clientConfig2.setClusterName("cluster-b");
+ClientNetworkConfig networkConfig2 = clientConfig2.getNetworkConfig();
+networkConfig2.addAddress( "10.214.2.10", "10.214.2.11");
+
+ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
+clientFailoverConfig.addClientConfig(clientConfig).addClientConfig(clientConfig2).setTryCount(10)
+HazelcastInstance client = HazelcastClient.newHazelcastFailoverClient(clientFailoverConfig);
+----
+
+The following are the descriptions for the configuration elements:
+
+* `try-count`: Count of connection retries by the client to the alternative clusters.
+When this value is reached and the client still could not connect to a cluster, the client
+shuts down. Note that this value applies to the alternative clusters whose configurations are provided
+with the `client` element. For the above example, two alternative clusters are given
+with the `try-count` set as `4`. This means the number of connection attempts is
+4 x 2 = 8.
+* `client`: Path to the client configuration that corresponds to an alternative cluster that the client will try to connect.
+
+The client configurations must be exactly the same except the following configuration options:
+
+* `SecurityConfig`
+* `NetworkConfig.Addresses`
+* `NetworkConfig.SocketInterceptorConfig`
+* `NetworkConfig.SSLConfig`
+* `NetworkConfig.AwsConfig`
+* `NetworkConfig.GcpConfig`
+* `NetworkConfig.AzureConfig`
+* `NetworkConfig.KubernetesConfig`
+* `NetworkConfig.EurekaConfig`
+* `NetworkConfig.CloudConfig`
+* `NetworkConfig.DiscoveryConfig`
+
+
+== Java Thin Client Failure Detectors
+
+The client failure detectors are responsible to determine if a member in the cluster is unreachable or crashed.
+The most important problem in the failure detection is to distinguish
+whether a member is still alive but slow, or has crashed.
+But according to the famous http://dl.acm.org/citation.cfm?doid=3149.214121[FLP result^],
+it is impossible to distinguish a crashed member from a slow one in an asynchronous system.
+A workaround to this limitation is to use unreliable failure detectors.
+An unreliable failure detector allows a member to suspect that others have failed,
+usually based on liveness criteria but it can make mistakes to a certain degree.
+
+The Java Thin Client has two built-in failure detectors: Deadline Failure Detector and
+Ping Failure Detector. These client failure detectors work independently from
+the member failure detectors, e.g., you do not need to enable the member failure detectors
+to benefit from the client ones.
+
+=== Client Deadline Failure Detector
+
+_Deadline Failure Detector_ uses an absolute timeout for missing/lost heartbeats.
+After timeout, a member is considered as crashed/unavailable and marked as suspected.
+
+_Deadline Failure Detector_ has two configuration properties:
+
+* `hazelcast.client.heartbeat.interval`: This is the interval at which client sends
+heartbeat messages to members.
+* `hazelcast.client.heartbeat.timeout`: This is the timeout which defines when
+a cluster member is suspected, because it has not sent any response back to client requests.
+
+NOTE: The value of `hazelcast.client.heartbeat.interval` should be smaller than
+that of `hazelcast.client.heartbeat.timeout`. In addition, the value of system property
+xref:ROOT:system-properties.adoc#client-max-no[`hazelcast.client.max.no.heartbeat.seconds`], which is set on the member side,
+should be larger than that of `hazelcast.client.heartbeat.interval`.
+
+The following is a programmatic configuration example showing how you can configure the Deadline Failure Detector
+for your client:
+
+
+[source,java]
+----
+ClientConfig config = ...;
+config.setProperty("hazelcast.client.heartbeat.timeout", "60000");
+config.setProperty("hazelcast.client.heartbeat.interval", "5000");
+[...]
+----
+
+=== Client Ping Failure Detector
+
+In addition to the Deadline Failure Detector, the Ping Failure Detector may be configured on your client.
+Please note that this detector is disabled by default. The Ping Failure Detector
+operates at Layer 3 of the OSI protocol and provides much quicker and more deterministic
+detection of hardware and other lower level events.
+When the JVM process has enough permissions to create RAW sockets, the implementation
+chooses to rely on ICMP Echo requests. This is preferred.
+
+If there are not enough permissions, it can be configured to fallback on attempting
+a TCP Echo on port 7. In the latter case, both a successful connection or an explicit rejection
+is treated as "Host is Reachable". Or, it can be forced to use only RAW sockets.
+This is not preferred as each call creates a heavyweight socket and moreover the Echo service is typically disabled.
+
+For the Ping Failure Detector to rely **only** on the ICMP Echo requests,
+the following criteria need to be met:
+
+* Supported OS: as of Java 1.8 only Linux/Unix environments are supported.
+* The Java executable must have the `cap_net_raw` capability.
+* The file `ld.conf` must be edited to overcome the rejection by the dynamic
+linker when loading libs from untrusted paths.
+* ICMP Echo Requests must not be blocked by the receiving hosts.
+
+The details of these requirements are explained in the
+xref:clusters:failure-detector-configuration.adoc#requirements-and-linuxunix-configuration[Requirements section] of
+Hazelcast members' xref:clusters:failure-detector-configuration.adoc#ping-failure-detector[Ping Failure Detector].
+
+If any of the above criteria isn't met, then `isReachable` will always
+fallback on TCP Echo attempts on port 7.
+
+An example programmatic configuration to use the Ping Failure Detector is
+as follows:
+
+[source,java]
+----
+ClientConfig config = ...;
+
+ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+ClientIcmpPingConfig clientIcmpPingConfig = networkConfig.getClientIcmpPingConfig();
+clientIcmpPingConfig.setIntervalMilliseconds(1000)
+        .setTimeoutMilliseconds(1000)
+        .setTtl(255)
+        .setMaxAttempts(2)
+        .setEchoFailFastOnStartup(false)
+        .setEnabled(true);
+----
+
+The following are the descriptions of configuration elements and attributes:
+
+* `enabled`: Enables the legacy ICMP detection mode, works cooperatively with
+the existing failure detector and only kicks-in after a pre-defined period
+has passed with no heartbeats from a member. Its default value is `false`.
+* `timeout-milliseconds`: Number of milliseconds until a ping attempt is
+considered failed if there was no reply. Its default value is *1000* milliseconds.
+* `max-attempts`: Maximum number of ping attempts before the member gets
+suspected by the detector. Its default value is *3*.
+* `interval-milliseconds`: Interval, in milliseconds, between each ping attempt.
+1000ms (1 sec) is also the minimum interval allowed. Its default value is *1000* milliseconds.
+* `ttl`: Maximum number of hops the packets should go through.
+Its default value is *255*. You can set to *0* to use your system's default TTL.
+
+In the above example configuration, the Ping Failure Detector attempts 2 pings,
+one every second, and waits up to 1 second for each to complete.
+If there is no successful ping after 2 seconds, the member gets suspected.
+
+To enforce the xref:clusters:failure-detector-configuration.adoc#requirements-and-linuxunix-configuration[Requirements],
+the property `echo-fail-fast-on-startup` can also be set to `true`, in which case Hazelcast fails to start if any of the requirements
+isn't met.
+
+Unlike the Hazelcast members, Ping Failure Detector works always in parallel with
+Deadline Failure Detector on the clients.
+Below is a summary table of all possible configuration combinations of the Ping Failure Detector.
+
+|===
+| ICMP| Fail-Fast| Description| Linux| Windows | macOS
+
+| true
+| false
+| Parallel ping detector, works in parallel with the configured failure detector.
+Checks periodically if members are live (OSI Layer 3) and suspects them immediately,
+regardless of the other detectors.
+| Supported ICMP Echo if available - Falls back on TCP Echo on port 7
+| Supported TCP Echo on port 7
+| Supported ICMP Echo if available - Falls back on TCP Echo on port 7
+
+| true
+| true
+| Parallel ping detector, works in parallel with the configured failure detector.
+Checks periodically if members are live (OSI Layer 3) and suspects them immediately,
+regardless of the other detectors.
+| Supported - Requires OS Configuration Enforcing ICMP Echo if available - No start up if not available
+| Not Supported
+| Not Supported - Requires root privileges
+|===
+
+[[client-system-properties]]
+== Client System Properties
+
+There are some advanced client configuration properties to tune some aspects of the Java Thin Client.
+You can set them as property name and value pairs through declarative configuration,
+programmatic configuration, or JVM system property. See the xref:ROOT:system-properties.adoc[System Properties appendix]
+to learn how to set these properties.
+
+NOTE: When you want to reconfigure a system property, you need to restart the clients for
+which the property is modified.
+
+The table below lists the client configuration properties with their descriptions.
+
+[cols="4a,1,1,4a"]
+.Client System Properties
+|===
+|Property Name | Default Value | Type | Description
+
+|`hazelcast.client.concurrent.window.ms`
+|100
+|int
+|Property needed for concurrency detection so that write through and dynamic response handling
+can be done correctly. This property sets the window for a concurrency detection (duration when it signals
+that a concurrency has been detected), even if there are no further updates in that window.
+Normally in a concurrent system the windows keeps sliding forward so it always remains concurrent.
+Setting it too high effectively disables the optimization because once concurrency has been detected
+it will keep that way. Setting it too low could lead to suboptimal performance because the system
+will try write through and other optimizations even though the system is concurrent.
+
+|`hazelcast.discovery.enabled`
+|false
+|bool
+|Enables/disables the Discovery SPI lookup over the old native implementations.
+See xref:extending-hazelcast:discovery-spi.adoc[Discovery SPI] for more information.
+
+|`hazelcast.discovery.public.ip.enabled`
+|null
+|bool
+|Overrides client behavior when the member has both public and private addresses available.
+When set to `true`, the client assumes that it needs to use public IP addresses reported by the members.
+When set to `false`, the client always uses private addresses reported by the members. If it is `null`,
+the client will try to infer how the discovery mechanism should be based on the reachability of the members.
+As the client's inference is not 100% reliable and can result in false-negatives, we recommend that it is overridden by
+setting to `true` when the client cannot connect to members using their public addresses.
+
+|`hazelcast.client.event.queue.capacity`
+|1000000
+|int
+|Default value of the capacity of executor that handles the incoming event packets.
+
+|`hazelcast.client.event.thread.count`
+|5
+|int
+|Thread count for handling the incoming event packets.
+
+|`hazelcast.client.heartbeat.interval`
+|5000
+|int
+|Frequency of the heartbeat messages sent by the clients to members.
+
+|`hazelcast.client.heartbeat.timeout`
+|60000
+|int
+|Timeout for the heartbeat messages sent by the client to members.
+If no messages pass between the client and member within the given time via
+this property in milliseconds, the connection will be closed.
+
+|`hazelcast.client.invocation.backoff.timeout.millis`
+|-1
+|int
+|Controls the maximum timeout, in milliseconds, to wait for an invocation space to be available.
+If an invocation cannot be made because there are too many pending invocations,
+then an exponential backoff is done to give the system time to deal with
+the backlog of invocations. This property controls how long an invocation is
+allowed to wait before getting a `HazelcastOverloadException`.
+When set to -1 then `HazelcastOverloadException` is thrown immediately without any waiting.
+
+|`hazelcast.client.invocation.retry.pause.millis`
+|1000
+|int
+|Pause time between each retry cycle of an invocation in milliseconds.
+
+|`hazelcast.client.invocation.timeout.seconds`
+|120
+|int
+|Period, in seconds, to give up the invocation when a member in the member list is not reachable,
+or the member fails with an exception, or the client's heartbeat requests are timed out.
+
+|`hazelcast.client.io.balancer.interval.seconds`
+|20
+|int
+|Interval in seconds between each `IOBalancer`
+execution. By default, Hazelcast uses 3 threads to read
+data from TCP connections and 3 threads to write data to connections.
+`IOBalancer` detects and fixes the fluctuations when these threads are not
+utilized equally. The shorter intervals catch I/O imbalances faster, but they cause higher overhead.
+A value smaller than 1 disables the balancer.
+
+|`hazelcast.client.io.input.thread.count`
+|-1
+|int
+|Controls the number of I/O input threads. Defaults to -1, i.e., the system decides.
+If the client is a Smart client, it defaults to 3, otherwise it defaults to 1.
+
+|`hazelcast.client.io.output.thread.count`
+|-1
+|int
+|Controls the number of I/O output threads. Defaults to -1, i.e., the system decides.
+If the client is a Smart client, it defaults to 3, otherwise it defaults to 1.
+
+|`hazelcast.client.io.write.through`
+|true
+|bool
+|Optimization that allows sending of packets over the network to be done on the calling thread if the
+conditions are right. This can reduce the latency and increase the performance for low threaded environments.
+
+|`hazelcast.client.max.concurrent.invocations`
+|Integer.MAX_VALUE
+|int
+|Maximum allowed number of concurrent invocations. You can apply a constraint on
+the number of concurrent invocations in order to prevent the system from overloading.
+If the maximum number of concurrent invocations is exceeded and a new invocation comes in,
+Hazelcast throws `HazelcastOverloadException`.
+
+|`hazelcast.client.operation.backup.timeout.millis`
+|5000
+|int
+|If an operation has sync backups, this property specifies how long the invocation will wait for acks from the backup replicas.
+If acks are not received from some backups, there will not be any rollback on other successful replicas.
+
+|`hazelcast.client.operation.fail.on.indeterminate.state`
+|false
+|bool
+|When this configuration is enabled, if an operation has sync backups and acks are not received from backup replicas
+in time, or the member which owns primary replica of the target partition leaves the cluster, then the invocation fails
+with `IndeterminateOperationStateException`. However, even if the invocation fails,
+there will not be any rollback on other successful replicas.
+
+|`hazelcast.client.response.thread.count`
+|2
+|int
+|Number of the response threads.
+By default, there are two response threads; this gives stable and good performance.
+If set to 0, the response threads are bypassed and the response handling is done
+on the I/O threads. Under certain conditions this can give a higher throughput, but
+setting to 0 should be regarded as an experimental feature.
+If set to 0, the IO_OUTPUT_THREAD_COUNT is really going to matter because the
+inbound thread will have more work to do. By default, when TLS is not enabled,
+there is just one inbound thread.
+
+|`hazelcast.client.response.thread.dynamic`
+|true
+|bool
+|Enables dynamic switching between processing the responses on the I/O threads and offloading the response threads.
+Under certain conditions (single threaded clients) processing on the I/O
+thread can increase the performance because useless handover to the response
+thread is removed. Also, the response thread is not created until it is needed.
+Especially for ephemeral clients, reducing the threads can lead to
+increased performance and reduced memory usage.
+
+|`hazelcast.client.shuffle.member.list`
+|true
+|string
+|The client shuffles the given member list to prevent all the clients to connect
+to the same member when this property is `true`. When it is set to `false`,
+the client tries to connect to the members in the given order.
+
+|===
+

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -11,7 +11,7 @@
 To get started, include the `hazelcast-java-client-{full-version}.jar` dependency in your classpath. Once included, you can start using this client as if
 you are using the Hazelcast API. The differences are discussed below.
 
-NOTE: If you have a Hazelcast {enterprise-product-name} license, you do not need to set the license key in your clients to use the xref:getting-started:editions.adoc#features-in-hazelcast-enterprise[{enterprise-product-name} features]. It is sufficient to set the license on the member side, and include the `hazelcast-enterprise-java-client-{full-version}.jar` dependency in your classpath.
+NOTE: If you have a Hazelcast {enterprise-product-name} license, you do not need to set the license key in your clients to use the xref:getting-started:editions.adoc#features-in-hazelcast-enterprise[{enterprise-product-name} features] - setting it on the member side is enough. In this case, you only need to include the `hazelcast-enterprise-java-client-{full-version}.jar` dependency in your classpath.
 
 If using Maven, add the `hazelcast` dependency
 to your `pom.xml`, or to the `hazelcast-enterprise` dependency if you want the client to use {enterprise-product-name} features, and you have the Hazelcast {enterprise-product-name} license,

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -116,19 +116,23 @@ The main areas are around client connections and retry-able operations. Some app
 
 **Handling Client Connection Failure:**
 
-While the client is trying to connect initially to one of the members in the
-`ClientNetworkConfig.addressList`, all the members might be not available.
-Instead of giving up, throwing an exception and stopping the client,
-the client retries to connect as configured which is described in the
-<<configuring-client-connection-retry, Configuring Client Connection Retry section>>.
+While the client initially tries to connect to one of the members in the
+`ClientNetworkConfig.addressList`, it is possible that not all members are available.
+Instead of giving up, throwing an exception and stopping,
+the client continues to attempt to connect as configured.
+For information on the available configuration, see <<configuring-client-connection-retry, Configuring Client Connection Retry>>.
 
-The client executes each operation through the already established connection(s) to the cluster.
-If these connection(s) disconnect or drop, the client tries to reconnect as configured.
+The client executes each operation through the already established connection to the cluster.
+If this connection disconnects or drops, the client tries to reconnect as configured.
 
-If using the `MULTI_MEMBER` cluster routing mode, and the cluster has multiple partition groups defined 
-and the client connection to a partition group fails, connectivity is maintained by failing over to an alternative partition group.
-If the connection is lost, which occurs only if all members of the partition group become unavailable, there is no attempt to retry the connection before failing over to another partition group.
-For further information on client cluster routing modes, see <<client-cluster-routing-modes,Client Cluster Routing Modes>>.
+The initial connection is established using one of the addresses provided in the <<configuring-address-list, address list>>.
+The client gets the addresses of other members in the cluster from the first connected member.
+
+If you use a <<client-network,discovery mechanism>> to find the initial member for the connection instead of an address list,
+you can use the same property to configure whether the initial member connection uses the private or public address.
+
+For an example of this scenario, refer to
+link:https://docs.hazelcast.com/tutorials/hazelcast-platform-operator-expose-externally[Connect to Hazelcast from Outside Kubernetes, window=_blank] in the Operator documentation.
 
 **Handling Retry-able Operation Failure:**
 
@@ -761,71 +765,6 @@ When a failover starts, i.e., the client is disconnected and was configured
 to connect to alternative clusters, the current <<client-network, member list>> is not considered;
 the client cuts all the connections before attempting to connect to a new cluster and tries the clusters as configured.
 See the below configuration related sections.
-
-[[ordering-of-clusters-when-clients-try-to-connect]]
-=== Ordering of Clusters When Clients Try to Connect
-
-The order of the clusters, that the client will try to connect
-in a blue-green or disaster recovery scenario, is decided by
-the order of these cluster declarations as given in the client configuration.
-
-Each time the client is disconnected from a cluster and it cannot connect back to the same one,
-the configured list is iterated over. Count of these iterations before
-the client decides to shut down is provided using the `try-count` configuration element.
-See the following configuration related sections.
-
-We didn't go over the configuration yet (see the following configuration related sections),
-but for the sake of explaining the ordering, assume that you have
-`client-config1`, `client-config2` and `client-config3`
-in the given order as shown below (in your `hazelcast-client-failover` XML or YAML file).
-This means you have three alternative clusters.
-
-[tabs] 
-==== 
-XML:: 
-+ 
--- 
-[source,xml]
-----
-<hazelcast-client-failover>
-    <try-count>4</try-count>
-    <clients>
-        <client>client-config1.xml</client>
-        <client>client-config2.xml</client>
-        <client>client-config3.xml</client>
-    </clients>
-</hazelcast-client-failover>
-----
---
-
-YAML::
-+
-[source,yaml]
-----
-hazelcast-client-failover:
-  try-count: 4
-  clients:
-    - client-config1.yaml
-    - client-config2.yaml
-    - client-config3.yaml
-----
-====
-
-And let's say the client is disconnected from the cluster
-whose configuration is given by `client-config2.xml`.
-Then, the client tries to connect to the next cluster in this list,
-whose configuration is given by `client-config3.xml`. When the end of the list is reached,
-which is so in this example, and the client could not connect to `client-config3`,
-then `try-count` is incremented and the client continues to try to connect starting with `client-config1`.
-
-This iteration continues until the client connects to a cluster or `try-count` is reached to the configured value.
-When the iteration reaches this value and the client still could not connect to a cluster,
-it shuts down. Note that, if `try-count` was set to `1` in the above example,
-and the client could not connect to `client-config3`, it would shut down since
-it already tried once to connect to an alternative cluster.
-
-The following sections describe how you can configure the Java client for
-blue-green and disaster recovery scenarios.
 
 === Configuring Without CNAME
 

--- a/docs/modules/clients/pages/java-thin-client.adoc
+++ b/docs/modules/clients/pages/java-thin-client.adoc
@@ -805,6 +805,13 @@ sslConfig.setFactoryClassName(OpenSSLEngineFactory.class.getName())
         .setFactoryImplementation(new OpenSSLEngineFactory());
 ```
 
+=== Configuring Client Near Cache
+
+The Hazelcast distributed map supports a local Near Cache for remotely stored entries to
+increase the performance of local read operations. Since the client always requests data from
+the cluster members, it can be helpful in some use cases to configure a Near Cache on the client side.
+See the xref:performance:near-cache.adoc[Near Cache section] for a detailed explanation of the Near Cache feature and its configuration.
+
 === Configuring Client Cluster
 
 Clients should provide a cluster name in order to connect to the cluster.


### PR DESCRIPTION
Based on https://github.com/hazelcast/hz-docs/blob/main/docs/modules/clients/pages/java.adoc