### PR TITLE
Add docs for hazelcast.async.join.strategy.enabled

### DIFF
--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -698,7 +698,7 @@ seconds, or after this upper limit elapsed (whichever comes first). Once the
 pre-join phase ends, the master moves into the join phase, during which it
 will only admit members that have already tried joining during the pre-join
 phase and are still trying to. Once the join phase is complete, the master
-will again start admitting new members.
+will again start admitting new members. See `hazelcast.async.join.strategy.enabled` for how this behaviour can change.
 
 |`hazelcast.mc.executor.thread.count`
 |int
@@ -1168,7 +1168,7 @@ make their first join requests. Once `hazelcast.wait.seconds.before.join`
 elapses since the last first-timer join request (i.e., where the member hasn't
 made any previous join request), or the pre-join phase has lasted for
 `hazelcast.max.wait.seconds.before.join` seconds, the phase ends and the
-master starts forming the cluster.
+master starts forming the cluster. See `hazelcast.async.join.strategy.enabled` for how this behaviour can change.
 
 |`hazelcast.wan.consumer.ack.delay.backoff.init`
 |1
@@ -1205,6 +1205,11 @@ thus slowing down the WAN publishers on the source side that send WAN events to 
 | 1
 | int
 | Number of parallel connections between members. Not having more connections than IO threads is recommended.
+
+|`hazelcast.async.join.strategy.enabled`
+| true
+| bool
+| Controls the behaviour of `hazelcast.wait.seconds.before.join` and `hazelcast.max.wait.seconds.before.join`. If set to `true`, joining members will return immediately without blocking. The cluster remains in the same state until the configured timeouts have elapsed, and new members will behave like lite members. After the timeouts have elapsed and no new members are queued to join, cluster repartitioning is performed in the background. This async strategy reduces latency significantly for new members joining clusters.
 
 
 |===


### PR DESCRIPTION
In 5.4 this property was introduced by a community PR in this commit: https://github.com/hazelcast/hazelcast-mono/commit/4b29147d648875b629997916ac881b26e856ab41

However, documentation was not updated to reflect - this PR resolves that by making the appropriate updates.