### PR TITLE
Update configuring-for-map-and-cache.adoc

### DIFF
--- a/docs/modules/wan/pages/configuring-for-map-and-cache.adoc
+++ b/docs/modules/wan/pages/configuring-for-map-and-cache.adoc
@@ -30,7 +30,7 @@ hazelcast:
     my-shared-map:
       wan-replication-ref:
         london-wan-rep:
-          merge-policy: PassThroughMergePolicy
+          merge-policy-class-name: PassThroughMergePolicy
           republishing-enabled: false
 ----
 --
@@ -46,7 +46,7 @@ XML::
     </wan-replication>
     <map name="my-shared-map">
         <wan-replication-ref name="london-wan-rep">
-            <merge-policy>PassThroughMergePolicy</merge-policy>
+            <merge-policy-class-name>PassThroughMergePolicy</merge-policy-class-name>
             <republishing-enabled>false</republishing-enabled>
         </wan-replication-ref>
     </map>
@@ -68,7 +68,7 @@ You see that we have `my-shared-map` configured to replicate itself to the clust
 `wan-replication-ref` has the following elements;
 
 * `name`: Name of the `wan-replication` configuration. `IMap` or `ICache` instance uses this `wan-replication` configuration.
-* `merge-policy`: Policy to resolve conflicts that occur when the target cluster already has the replicated entry key.
+* `merge-policy-class-name`: Policy to resolve conflicts that occur when the target cluster already has the replicated entry key.
 This configuration element is optional. If it is not specified, `com.hazelcast.spi.merge.PassThroughMergePolicy`
 will be used as the merge policy.
 * `republishing-enabled`: When enabled, an incoming event to a member is forwarded to target cluster of that member.
@@ -78,7 +78,7 @@ replicate to each other. If not otherwise specified, the default value for repub
 
 When using Active-Active Replication, multiple clusters can simultaneously update the same
 entry in a distributed data structure. You can configure a merge policy to resolve these potential
-conflicts, as shown in the above example configuration (using the `merge-policy` sub-element under
+conflicts, as shown in the above example configuration (using the `merge-policy-class-name` sub-element under
 the `wan-replication-ref` element).
 
 Hazelcast provides the following merge policies for `IMap`:
@@ -125,7 +125,7 @@ hazelcast:
     my-shared-cache:
       wan-replication-ref:
         london-wan-rep:
-          merge-policy: PassThroughMergePolicy
+          merge-policy-class-name: PassThroughMergePolicy
           republishing-enabled: true
 ----
 --
@@ -141,7 +141,7 @@ XML::
     </wan-replication>
     <cache name="my-shared-cache">
         <wan-replication-ref name="london-wan-rep">
-            <merge-policy>PassThroughMergePolicy</merge-policy>
+            <merge-policy-class-name>PassThroughMergePolicy</merge-policy-class-name>
             <republishing-enabled>true</republishing-enabled>
         </wan-replication-ref>
     </cache>


### PR DESCRIPTION
Correction required in docs. Config merge-policy under WAN should be replaced with merge-policy-class-name in the docs