### PR TITLE
Fix duplicate links in configuration-guide.adoc

### DIFF
--- a/docs/modules/mapstore/pages/configuration-guide.adoc
+++ b/docs/modules/mapstore/pages/configuration-guide.adoc
@@ -11,7 +11,7 @@ If you use Hazelcast in client/server mode, make sure to add the MapStore to the
 
 To configure a MapStore, you must provide the <<class-name, name>> of your class that implements the MapStore.
 
-NOTE: Follow the instructions in xref:mapstore:configuring-a-generic-maploader.adoc[] or xref:mapstore:configuring-a-generic-maploader.adoc[] for this step if you are using a pre-built Mapstore.
+NOTE: Follow the instructions in xref:mapstore:configuring-a-generic-maploader.adoc[] or xref:mapstore:configuring-a-generic-mapstore.adoc[] for this step if you are using a pre-built Mapstore.
 
 [tabs] 
 ==== 


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hz-docs/issues/1245

Is it a duplicate or did someone intend to make the 2nd item point to the other page?