### PR TITLE
Revert "Fix pdf conversion error [REL-295][v/5.5]"

### DIFF
--- a/docs/modules/cp-subsystem/pages/configuration.adoc
+++ b/docs/modules/cp-subsystem/pages/configuration.adoc
@@ -196,7 +196,7 @@ You can handle loss of the response in two ways:
 Use these configuration options to configure the CP Subsystem.
 
 .CP Subsystem configuration options
-[cols="a,a,m,a",options="header"]
+[cols="1a,1a,1m,2a",options="header"]
 |===
 |Option|Description|Default|Example
 
@@ -1224,7 +1224,7 @@ config.getCPSubsystemConfig().setRaftAlgorithmConfig(raftConfig);
 --
 ====
 
-[cols="a,a,m,a",options="header"]
+[cols="1a,1a,1m,2a",options="header"]
 |===
 |Option|Description|Default|Example
 


### PR DESCRIPTION
Reverts hazelcast/hz-docs#1244

PDf now generated; table rendering in HTML not quite as good so reverting change and creating Jira for fixing issue properly: https://hazelcast.atlassian.net/browse/DOCS-902