### PR TITLE
Improve coherence between 'Serializing Pipelines' examples

### DIFF
--- a/docs/modules/pipelines/pages/serialization.adoc
+++ b/docs/modules/pipelines/pages/serialization.adoc
@@ -29,7 +29,7 @@ its flipside: it is easy to overlook what’s going on.
 
 If the lambda references a variable in the outer scope, the variable is
 captured and must also be serializable. If it references an instance
-variable of the enclosing class, it implicitly captures this so the
+variable of the enclosing class, it implicitly captures `this` so the
 entire class will be serialized. For example, this will fail because
 `JetJob1` does not implement `Serializable`:
 
@@ -75,8 +75,10 @@ surrounding class. We can simply achieve this by assigning to a local
 variable, then referring to that variable inside the lambda:
 
 ```java
-class JetJob3 {
+class JetJob3 implements Serializable {
     private String instanceVar;
+    // A non-serializable field.
+    private OutputStream fileOut;
 
     Pipeline buildPipeline() {
         Pipeline p = Pipeline.create();


### PR DESCRIPTION
The third example in _Serializing Pipelines_ doesn't follow the second one in a cohesive manner, which causes `kapa.ai` to give examples that don't fit the explanation text. See [the relevant Slack discussion](https://hazelcast.slack.com/archives/C035HQET5/p1723034714614779).