### PR TITLE
Revert backport issue incrementing versions to `6.0` [5.5]

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -19,8 +19,8 @@ asciidoc:
     # All page-latest attributes are used as a variable in the docs for things like download links and search results
     page-latest-cli: '5.2021.09'
     # Must be lowercase because this is how the version appears in the docs
-    page-latest-supported-mc: '6.0-snapshot'
-    page-latest-supported-java-client: '6.0.0-SNAPSHOT'
+    page-latest-supported-mc: '5.5.0'
+    page-latest-supported-java-client: '5.5.0'
     # https://github.com/hazelcast/hazelcast-go-client/releases
     page-latest-supported-go-client: '1.4.2'
     # https://github.com/hazelcast/hazelcast-cpp-client/releases


### PR DESCRIPTION
When https://github.com/hazelcast/hz-docs/pull/1233 was backported in c635ad4c35fd46f75a559f256cc62d7e46b00b29, it seems to have copied additional changes not made in that PR, incrementing:
- `page-latest-supported-mc`
- `page-latest-supported-java-client`

This PR reverts that.