### PR TITLE
Remove Hazelcast Platform Operator source link

### DIFF
--- a/docs/modules/kubernetes/pages/deploying-in-kubernetes.adoc
+++ b/docs/modules/kubernetes/pages/deploying-in-kubernetes.adoc
@@ -72,7 +72,6 @@ https://helm.sh/[Helm^] is a package manager for Kubernetes. Hazelcast is distri
 
 * https://github.com/hazelcast/charts/tree/master/stable/hazelcast[hazelcast/hazelcast^]
 * https://github.com/hazelcast/charts/tree/master/stable/hazelcast-enterprise[hazelcast/hazelcast-enterprise^]
-* https://github.com/hazelcast/charts/tree/master/stable/hazelcast-platform-operator[hazelcast/hazelcast-platform-operator^]
 
 See the xref:kubernetes:helm-hazelcast-chart.adoc[Hazelcast Helm Charts documentation] for more details.
 


### PR DESCRIPTION
In https://github.com/hazelcast/charts/commit/1fa25c7a9aeeccae5bd1b72424e53104368c157f the source was removed from the `charts` repository, this PR updates the documentation to suit.