### PR TITLE
Fix production build errors v/5.2

### DIFF
--- a/docs/modules/configuration/pages/configuring-programmatically.adoc
+++ b/docs/modules/configuration/pages/configuring-programmatically.adoc
@@ -58,7 +58,8 @@ Hazelcast configuration also by using its default lookup mechanism.
 |link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/config/Config.html#loadFromStream-java.io.InputStream-java.util.Properties-[`Config.loadFromStream()`]
 |Creates `Config` from the provided XML or YAML stream content.
 
-|link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/config/XmlConfigBuilder.html[]
+|link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/config/XmlConfigBuilder.html[`Class XmlConfigBuilder`]
+|A XML `ConfigBuilder` implementation.
 
 |===
 

--- a/docs/modules/getting-started/pages/blue-green.adoc
+++ b/docs/modules/getting-started/pages/blue-green.adoc
@@ -4,14 +4,14 @@
 
 {description}
 
-When clients are connected to a single cluster, that cluster becomes a single point of failure. If the cluster fails for any reason, the client cannot connect to it and the application may break. To make clients more robust, you can set up a blue-green cluster deployment, which provides a client failover mechanism that reroutes client connections to a different cluster without requiring a client network configuration update or client restart. 
+When clients are connected to a single cluster, that cluster becomes a single point of failure. If the cluster fails for any reason, the client cannot connect to it and the application may break. To make clients more robust, you can set up a blue-green cluster deployment, which provides a client failover mechanism that reroutes client connections to a different cluster without requiring a client network configuration update or client restart.
 
-You can use a blue-green deployment in the following scenarios: 
+You can use a blue-green deployment in the following scenarios:
 
 * To manually redirect client traffic to a secondary cluster while you perform maintenance or software updates.
 * To automatically redirect client traffic to a secondary cluster during a disaster recovery scenario.
 
-In both cases, you will need to manually deploy a xref:{page-latest-supported-mc}@management-center:clusters:client-filtering.adoc[client filter] to the secondary cluster to force clients to reconnect to the original, primary cluster when it is back online.  
+In both cases, you will need to manually deploy a xref:{page-latest-supported-mc}@management-center:clusters:client-filtering.adoc[client filter] to the secondary cluster to force clients to reconnect to the original, primary cluster when it is back online.
 
 This tutorial focuses on the disaster recovery scenario, where you will complete the following steps:
 
@@ -35,7 +35,7 @@ To complete this tutorial, you need the following:
 |xref:getting-started:enterprise-overview.adoc[]
 
 |Docker network with the name `hazelcast-network`
-|Use the `docker network create hazelcast-network` command 
+|Use the `docker network create hazelcast-network` command
 
 |===
 
@@ -51,9 +51,9 @@ Run the following command on the terminal:
 docker run \
     --network hazelcast-network \
     --rm \
-    -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5701 \
+    -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5701 \ <1>
     -e HZ_CLUSTERNAME=blue \
-    -e HZ_LICENSEKEY=<your license key> \ <1>
+    -e HZ_LICENSEKEY=<your license key> \ <2>
     -p 5701:5701 hazelcast/hazelcast-enterprise:{full-version}
 ----
 <1> Replace the `<host_ip>` placeholder with the IP address of your Docker host.
@@ -63,7 +63,7 @@ You should see your cluster name in the console along with the IP address of the
 
 [source,shell,subs="attributes+"]
 ----
-2021-12-01 18:26:42,369 [ INFO] [main] [c.h.i.c.ClusterService]: [172.18.0.2]:5701 [blue] [{full-version}] 
+2021-12-01 18:26:42,369 [ INFO] [main] [c.h.i.c.ClusterService]: [172.18.0.2]:5701 [blue] [{full-version}]
 
 Members {size:1, ver:1} [
 	Member [172.18.0.2]:5701 - c00213e1-da50-4b5f-a53b-ccfe4a1ebeea this
@@ -81,9 +81,9 @@ Start another local single-member cluster called `green`.
 docker run \
     --network hazelcast-network \
     --rm \
-    -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5702 \
+    -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5702 \ <1>
     -e HZ_CLUSTERNAME=green \
-    -e HZ_LICENSEKEY=<your license key> \ <1>
+    -e HZ_LICENSEKEY=<your license key> \ <2>
     -p 5702:5701 hazelcast/hazelcast-enterprise:{full-version}
 ----
 <1> Replace the `<host_ip>` placeholder with the IP address of your Docker host.
@@ -93,7 +93,7 @@ See the `green` cluster is formed:
 
 [source,shell,subs="attributes+"]
 ----
-2021-12-01 18:28:46,299 [ INFO] [main] [c.h.i.c.ClusterService]: [172.18.0.3]:5701 [green] [{full-version}] 
+2021-12-01 18:28:46,299 [ INFO] [main] [c.h.i.c.ClusterService]: [172.18.0.3]:5701 [green] [{full-version}]
 
 Members {size:1, ver:1} [
 	Member [172.18.0.3]:5701 - 72f5520c-8c27-4501-9199-a8da6b58c0b4 this
@@ -128,11 +128,11 @@ For this, you need to create two client configurations for the same client, and 
 . Create the client configuration file for the `blue` cluster, called `client-blue.yaml` (or `client-blue.xml`)
 and place it in the `resources` directory:
 +
-[tabs] 
-==== 
-YAML:: 
-+ 
--- 
+[tabs]
+====
+YAML::
++
+--
 .client-blue.yaml
 [source,yaml]
 ----
@@ -172,11 +172,11 @@ For testing/development purposes, set to 1000 milliseconds to see the client con
 . Create the client configuration for the `green` cluster, called `client-green.yaml` (or `client-green.xml`)
 and place it in the `resources` directory:
 +
-[tabs] 
-==== 
-YAML:: 
-+ 
--- 
+[tabs]
+====
+YAML::
++
+--
 .client-green.yaml
 [source,yaml]
 ----
@@ -217,11 +217,11 @@ For testing/development purposes, set to 1000 milliseconds to see the client con
 The name of the client failover configuration file must be `hazelcast-client-failover` (`hazelcast-client-failover.yaml` or `hazelcast-client-failover.xml`).
 Place this failover configuration file in the `resources` directory.
 +
-[tabs] 
-==== 
-YAML:: 
-+ 
--- 
+[tabs]
+====
+YAML::
++
+--
 .hazelcast-client-failover.yaml
 [source,yaml]
 ----
@@ -261,15 +261,15 @@ see xref:clients:java#ordering-of-clusters-when-clients-try-to-connect.adoc[Orde
 
 In this step, you'll start the client.
 
-[tabs] 
-==== 
-Java:: 
+[tabs]
+====
+Java::
 +
 
 . Install the xref:getting-started:install-hazelcast.adoc#use-java[Java client library].
 . Add the following to the `MyClient.java` file.
 +
--- 
+--
 [source,java,subs="attributes+"]
 ----
 import com.hazelcast.client.HazelcastClient;
@@ -334,7 +334,7 @@ const { Client } = require('hazelcast-client');
             }
         ]
       });
-        
+
     } catch (err) {
         console.error('Error occurred:', err);
     }
@@ -377,7 +377,7 @@ Dec 01, 2021 8:16:45 PM com.hazelcast.core.LifecycleService
 INFO: hz.client_1 [green] [{full-version}] HazelcastClient {full-version} (20210922 - dbaeffe) is CLIENT_CONNECTED
 ----
 
-NOTE: In this type of failover scenario, the client does not automatically reconnect to the `blue` cluster when it is back online. Instead, you need to deploy a deny list to block client connections to the `green` cluster. The client will then use the failover configuration (in <<step-3, Step 3>>) to reconnect to the original cluster. When the client is reconnected, you can remove the client filter. 
+NOTE: In this type of failover scenario, the client does not automatically reconnect to the `blue` cluster when it is back online. Instead, you need to deploy a deny list to block client connections to the `green` cluster. The client will then use the failover configuration (in <<step-3, Step 3>>) to reconnect to the original cluster. When the client is reconnected, you can remove the client filter.
 
 == Step 6. Shut Down the Cluster
 
@@ -386,7 +386,7 @@ move to the other tutorials. To shut down the cluster, close the terminals in wh
 
 == Next Steps
 
-If you're interested in learning more about the topics introduced in this tutorial, see: 
+If you're interested in learning more about the topics introduced in this tutorial, see:
 
 * xref:clients:java#blue-green-deployment-and-disaster-recovery.adoc[Blue-Green Deployment].
 * xref:{page-latest-supported-mc}@management-center:clusters:client-filtering.adoc[Filtering Client Connections].

--- a/docs/modules/getting-started/pages/persistence.adoc
+++ b/docs/modules/getting-started/pages/persistence.adoc
@@ -28,7 +28,7 @@ To complete this tutorial, you need the following:
 |xref:getting-started:enterprise-overview.adoc[]
 
 |Docker network with the name `hazelcast-network`
-|Use the `docker network create hazelcast-network` command 
+|Use the `docker network create hazelcast-network` command
 
 |===
 
@@ -41,12 +41,12 @@ You'll start the first member in a cluster called `hello-world`. Run the followi
 docker run \
     --name first-member --network hazelcast-network \
     --rm \
-    -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5701 \
+    -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5701 \ <1>
     -e HZ_CLUSTERNAME=hello-world \
-    -e HZ_LICENSEKEY=<your license key> \ <1>
-    -e HZ_PERSISTENCE_ENABLED=true \ <2>
-    -e HZ_MAP_MYDISTRIBUTEDMAP_DATAPERSISTENCE_ENABLED=true \ <3>
-    -v ~/persist:/opt/hazelcast/persistence \ <4>
+    -e HZ_LICENSEKEY=<your license key> \ <2>
+    -e HZ_PERSISTENCE_ENABLED=true \ <3>
+    -e HZ_MAP_MYDISTRIBUTEDMAP_DATAPERSISTENCE_ENABLED=true \ <4>
+    -v ~/persist:/opt/hazelcast/persistence \ <5>
     -p 5701:5701 hazelcast/hazelcast-enterprise:{full-version}
 ----
 <1> Replace the `<host_ip>` placeholder with the IP address of your Docker host.
@@ -182,7 +182,7 @@ image:map-details.png[Map details]
 
 Now, you'll shut down the whole cluster using Management Center.
 
-. While in Management Center, go to **Cluster** > **Administration**, and select the **Cluster State** tab. 
+. While in Management Center, go to **Cluster** > **Administration**, and select the **Cluster State** tab.
 +
 image:cluster-state.png[Shutting down the cluster]
 . Click on the **Shutdown** button and confirm it on the dialog shown afterwards.
@@ -198,7 +198,7 @@ Restart the cluster by starting all the members; run the commands in Step 1 and 
 
 Once all the members are started, go to Management Center, and you can see that it reconnects to the cluster.
 Check your map as instructed in Step 4 above; you will see the map and its data has been recovered.
-If the persistence was not enabled, the data would be lost in case of a cluster shutdown. 
+If the persistence was not enabled, the data would be lost in case of a cluster shutdown.
 
 == Step 8. Shut Down the Cluster
 

--- a/docs/modules/getting-started/pages/wan.adoc
+++ b/docs/modules/getting-started/pages/wan.adoc
@@ -30,7 +30,7 @@ To complete this tutorial, you need the following:
 |xref:getting-started:enterprise-overview.adoc[]
 
 |Docker network with the name `hazelcast-network`
-|Use the `docker network create hazelcast-network` command 
+|Use the `docker network create hazelcast-network` command
 
 |===
 
@@ -43,8 +43,8 @@ which means it does not need WAN Replication to be configured. Run the following
 ----
 docker run \
     --network hazelcast-network \
-    -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5701 \
-    -e HZ_LICENSEKEY=<your license key> \ <1>
+    -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5701 \ <1>
+    -e HZ_LICENSEKEY=<your license key> \ <2>
     -e HZ_CLUSTERNAME=london \
     hazelcast/hazelcast-enterprise:{full-version}
 ----
@@ -55,7 +55,7 @@ The member is up and running now.
 
 [source,shell,subs="attributes+"]
 ----
-2021-11-23 11:08:15,055 [ INFO] [main] [c.h.i.c.ClusterService]: [172.18.0.3]:5701 [london] [{full-version}] 
+2021-11-23 11:08:15,055 [ INFO] [main] [c.h.i.c.ClusterService]: [172.18.0.3]:5701 [london] [{full-version}]
 
 Members {size:1, ver:1} [
 	Member [172.18.0.3]:5701 - bed20746-1505-449b-9f4a-548bcdbe12b8 this
@@ -130,7 +130,7 @@ Here is your other single-member cluster:
 
 [source,shell,subs="attributes+"]
 ----
-2021-11-23 11:39:14,198 [ INFO] [main] [c.h.i.c.ClusterService]: [172.18.0.4]:5701 [tokyo] [{full-version}] 
+2021-11-23 11:39:14,198 [ INFO] [main] [c.h.i.c.ClusterService]: [172.18.0.4]:5701 [tokyo] [{full-version}]
 
 Members {size:1, ver:1} [
 	Member [172.18.0.4]:5701 - 98d9a815-5eb3-4341-bec1-e9816cee44b5 this
@@ -182,7 +182,7 @@ docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{full-versio
 [source,sql]
 ----
 CREATE MAPPING cities (__key INT, country VARCHAR, city VARCHAR)
-TYPE IMap 
+TYPE IMap
 OPTIONS ('keyFormat'='int', 'valueFormat' = 'json-flat');
 ----
 . Then, type the following command and press kbd:[Enter] to add data to the map.
@@ -211,8 +211,8 @@ You can also see the map and its entries in Management Center, using the SQL bro
 +
 image:wan/map-tokyo.png[Cities map in Tokyo cluster]
 . Click on **SQL Browser** located on the very top right of the user interface and choose `cities` in the *select a map* field.
-The SQL browser then shows the default query in its editor, `SELECT * FROM cities;`. 
-. Click on **Execute Query**; you will see the data you've put in. 
+The SQL browser then shows the default query in its editor, `SELECT * FROM cities;`.
+. Click on **Execute Query**; you will see the data you've put in.
 +
 image:wan/map-entries.png[Management Center's SQL Browser shows the map data]
 . Close the SQL browser.
@@ -233,7 +233,7 @@ Open the SQL browser, type in the following query.
 [source,sql]
 ----
 CREATE MAPPING cities (__key INT, country VARCHAR, city VARCHAR)
-TYPE IMap 
+TYPE IMap
 OPTIONS ('keyFormat'='int', 'valueFormat' = 'json-flat');
 ----
 . Click **Execute Query**.

--- a/docs/modules/kubernetes/pages/helm-hazelcast-chart.adoc
+++ b/docs/modules/kubernetes/pages/helm-hazelcast-chart.adoc
@@ -81,7 +81,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 |Parameter|Description|Default
 
 | image.repository| Hazelcast Image name | hazelcast/hazelcast
-| image.tag| Hazelcast Image tag| {VERSION}
+| image.tag| Hazelcast Image tag| \{VERSION}
 | image.pullPolicy| Image pull policy| IfNotPresent
 | image.pullSecrets | Specify docker-registry secret names as an array| nil
 | cluster.memberCount | Number of Hazelcast members| 3
@@ -89,7 +89,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | hazelcast.javaOpts| Additional JAVA_OPTS properties for Hazelcast member| nil
 | hazelcast.loggingLevel| Level of Hazelcast logs (OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE and ALL)| nil
 | hazelcast.existingConfigMap| ConfigMap which contains Hazelcast configuration file(s) that are used instead of hazelcast.yaml file embedded into values.yaml | nil
-| hazelcast.yaml| Hazelcast YAML Configuration (hazelcast.yaml embedded into values.yaml)| {DEFAULT_HAZELCAST_YAML}
+| hazelcast.yaml| Hazelcast YAML Configuration (hazelcast.yaml embedded into values.yaml)| \{DEFAULT_HAZELCAST_YAML}
 | hazelcast.configurationFiles | Hazelcast configuration files| nil
 | annotations | Hazelcast Statefulset annotations| nil
 | affinity| Hazelcast Node affinity| nil
@@ -169,7 +169,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | jet.enabled| Turn on and off Hazelcast Jet engine| true
 | mancenter.enabled| Turn on and off Management Center application| true
 | mancenter.image.repository| Hazelcast Management Center Image name| hazelcast/management-center
-| mancenter.image.tag | Hazelcast Management Center Image tag (NOTE: must be the same or one minor release greater than Hazelcast image version) | {VERSION}
+| mancenter.image.tag | Hazelcast Management Center Image tag (NOTE: must be the same or one minor release greater than Hazelcast image version) | \{VERSION}
 | mancenter.image.pullPolicy| Image pull policy| IfNotPresent
 | mancenter.image.pullSecrets | Specify docker-registry secret names as an array| nil
 | mancenter.contextPath | The value for the `MC_CONTEXT_PATH` environment variable. It sets the prefix of all URL paths in Management Center| nil
@@ -180,7 +180,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | mancenter.licenseKey| License Key for Hazelcast Management Center, if not provided, can be filled in the web interface| nil
 | mancenter.licenseKeySecretName| Kubernetes Secret Name, where Management Center License Key is stored (can be used instead of licenseKey)| nil
 | mancenter.adminCredentialsSecretName | Kubernetes Secret Name for admin credentials. Secret has to contain `username` and `password` literals. please check Management Center documentation for password requirements| nil
-| mancenter.existingConfigMap | ConfigMap which contains Hazelcast Client configuration file(s) that are used instead of hazelcast-client.yaml file embedded into values.yaml | {DEFAULT_HAZELCAST_CLIENT_YAML}
+| mancenter.existingConfigMap | ConfigMap which contains Hazelcast Client configuration file(s) that are used instead of hazelcast-client.yaml file embedded into values.yaml | \{DEFAULT_HAZELCAST_CLIENT_YAML}
 | mancenter.yaml | Hazelcast Client YAML Configuration (hazelcast-client.yaml used to connect to Hazelcast cluster | nil
 | mancenter.annotations | Management Center Statefulset annotations | nil
 | mancenter.affinity| Management Center Node affinity| nil

--- a/docs/modules/kubernetes/pages/helm-hazelcast-enterprise-chart.adoc
+++ b/docs/modules/kubernetes/pages/helm-hazelcast-enterprise-chart.adoc
@@ -84,7 +84,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 |Parameter|Description|Default
 
 |image.repository|Hazelcast Image name|hazelcast/hazelcast-enterprise
-|image.tag|Hazelcast Image tag|{VERSION}
+|image.tag|Hazelcast Image tag|\{VERSION}
 |image.pullPolicy|Image pull policy|IfNotPresent
 |image.pullSecrets|Specify docker-registry secret names as an array|nil
 |cluster.memberCount|Number of Hazelcast members|3
@@ -95,7 +95,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 |hazelcast.javaOpts|Additional JAVA_OPTS properties for Hazelcast member|nil
 |hazelcast.loggingLevel|Level of Hazelcast logs (OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE and ALL)|nil
 |hazelcast.existingConfigMap|ConfigMap which contains Hazelcast configuration file(s) that are used instead hazelcast.yaml embedded into values.yaml|nil
-|hazelcast.yaml|Hazelcast YAML Configuration (hazelcast.yaml embedded into values.yaml)|{DEFAULT_HAZELCAST_YAML}
+|hazelcast.yaml|Hazelcast YAML Configuration (hazelcast.yaml embedded into values.yaml)|\{DEFAULT_HAZELCAST_YAML}
 |hazelcast.configurationFiles|Hazelcast configuration files|nil
 |annotations| Hazelcast Statefulset annotations| nil
 |affinity|Hazelcast Node affinity|nil
@@ -182,7 +182,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 |env|Additional Environment variables|[]
 |mancenter.enabled|Turn on and off Management Center application|true
 |mancenter.image.repository|Hazelcast Management Center Image name|hazelcast/management-center
-|mancenter.image.tag|Hazelcast Management Center Image tag (NOTE: must be the same or one minor release greater than Hazelcast image version)|{VERSION}
+|mancenter.image.tag|Hazelcast Management Center Image tag (NOTE: must be the same or one minor release greater than Hazelcast image version)|\{VERSION}
 |mancenter.image.pullPolicy|Image pull policy|IfNotPresent
 |mancenter.image.pullSecrets|Specify docker-registry secret names as an array|nil
 |mancenter.contextPath|The value for the `MC_CONTEXT_PATH` environment variable. It sets the prefix of all URL paths in Management Center|nil

--- a/docs/modules/kubernetes/pages/kubernetes-auto-discovery.adoc
+++ b/docs/modules/kubernetes/pages/kubernetes-auto-discovery.adoc
@@ -10,19 +10,27 @@ To make it easier to set up clusters in Kubernetes, Hazelcast allows members to 
 
 [cols="a,a,a"]
 |===
-| | Kubernetes API  | DNS Lookup
+|
+| Kubernetes API
+| DNS Lookup
 
-|*Description*    | Uses REST calls to Kubernetes master to fetch IP addresses of Pods | Uses DNS to resolve IPs of Pods related to the given service
+|*Description*
+| Uses REST calls to Kubernetes master to fetch IP addresses of Pods
+| Uses DNS to resolve IPs of Pods related to the given service
 
-| *Pros*           | Flexible, supports **3 different options**:
+| *Pros*
+| Flexible, supports **3 different options**:
 
 - Hazelcast cluster per service
 - Hazelcast cluster per multiple services (distinguished by labels)
-- Hazelcast cluster per namespace | **No additional configuration** required, resolving DNS does not require granting any permissions
+- Hazelcast cluster per namespace
+| **No additional configuration** required, resolving DNS does not require granting any permissions
 
-| *Cons*           | Requires setting up **RoleBinding** (to allow access to Kubernetes API)  | Limited to **headless Cluster IP** service
+| *Cons*
+| Requires setting up **RoleBinding** (to allow access to Kubernetes API)
+| Limited to **headless Cluster IP** service
 
-Limited to **Hazelcast cluster per service**  |
+Limited to **Hazelcast cluster per service**
 |===
 
 === Using Kubernetes in API Mode
@@ -62,11 +70,11 @@ spec:
 
 The second step is to configure the discovery plugin inside `hazelcast.yaml` or an equivalent Java-based configuration.
 
-[tabs] 
-==== 
-YAML:: 
-+ 
--- 
+[tabs]
+====
+YAML::
++
+--
 ```yaml
 hazelcast:
   network:
@@ -79,9 +87,9 @@ hazelcast:
         service-name: MY-SERVICE-NAME
 ```
 --
-Java:: 
-+ 
--- 
+Java::
++
+--
 ```java
 config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
 config.getNetworkConfig().getJoin().getKubernetesConfig().setEnabled(true)
@@ -96,19 +104,19 @@ There are several properties to configure, all of which are optional.
 * `namespace`: Kubernetes Namespace where Hazelcast is running; if not specified, the value is taken from the environment variables `KUBERNETES_NAMESPACE` or `OPENSHIFT_BUILD_NAMESPACE`. If those are not set, the namespace of the Pod will be used (retrieved from `/var/run/secrets/kubernetes.io/serviceaccount/namespace`).
 * `service-name`: service name used to scan only Pods connected to the given service; if not specified, then all Pods in the namespace are checked
 +
-NOTE: If you don't specify `service-name` and fall back to a `namespace` only discovery, all pods in the namespace must be Hazelcast member pods; other pods might block the member discovery process of the Hazelcast member pods. 
-* `service-label-name`, `service-label-value`: service label and value used to tag services, which together form the Hazelcast cluster. These properties can support multiple comma-separated values. For example: "label-1,label-2". You must use the same number of elements in `service-label-name` as `service-label-value`. 
-* `pod-label-name`, `pod-label-value`: pod label and value used to tag Pods, which together form the Hazelcast cluster. These properties can support multiple comma-separated values. For example: "label-1,label-2". You must use the same number of elements in `pod-label-name` as `pod-label-value`. 
+NOTE: If you don't specify `service-name` and fall back to a `namespace` only discovery, all pods in the namespace must be Hazelcast member pods; other pods might block the member discovery process of the Hazelcast member pods.
+* `service-label-name`, `service-label-value`: service label and value used to tag services, which together form the Hazelcast cluster. These properties can support multiple comma-separated values. For example: "label-1,label-2". You must use the same number of elements in `service-label-name` as `service-label-value`.
+* `pod-label-name`, `pod-label-value`: pod label and value used to tag Pods, which together form the Hazelcast cluster. These properties can support multiple comma-separated values. For example: "label-1,label-2". You must use the same number of elements in `pod-label-name` as `pod-label-value`.
 * `resolve-not-ready-addresses`: if set to `true`, it checks also the addresses of Pods which are not ready; `true` by default
 * `expose-externally`: if set to `true`, it fails fast if an external address cannot be found for each member; if set to `false`, it does not check for external member addresses; by default it tries to resolve external addresses but fails silently
 * `service-per-pod-label-name`, `service-per-pod-label-value`: service label and value used to tag services that expose each Hazelcast member with a separate Kubernetes service (for connecting Hazelcast Smart Client running outside the Kubernetes cluster)
 * `use-node-name-as-external-address`: if set to `true`, uses the node name to connect to a `NodePort` service instead of looking up the external IP using the API; `false` by default
-* `kubernetes-api-retries`: number of retries in case of issues while connecting to Kubernetes API; defaults to `3` 
+* `kubernetes-api-retries`: number of retries in case of issues while connecting to Kubernetes API; defaults to `3`
 * `kubernetes-master`: URL of Kubernetes Master; `https://kubernetes.default.svc` by default
 * `api-token`: API Token to Kubernetes API; if not specified, the value is taken from the file `/var/run/secrets/kubernetes.io/serviceaccount/token`
 * `ca-certificate`: CA Certificate for Kubernetes API; if not specified, the value is taken from the file `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
 * `service-port`: endpoint port of the service; if specified with a value greater than `0`, it overrides the default; `0` by default
- 
+
 You can use one of `service-name`,`service-label`(`service-label-name`, `service-label-value`) and `pod-label`(`pod-label-name`, `pod-label-value`) based discovery mechanisms, configuring two of them at once does not make sense.
 
 NOTE: If you don't specify any property at all, then the Hazelcast cluster is formed using all Pods in your current namespace. In other words, you can look at the properties as a grouping feature if you want to have multiple Hazelcast clusters in one namespace.
@@ -140,11 +148,11 @@ spec:
 
 The Hazelcast configuration to use DNS Lookup looks as follows.
 
-[tabs] 
-==== 
-YAML:: 
-+ 
--- 
+[tabs]
+====
+YAML::
++
+--
 ```yaml
 hazelcast:
   network:
@@ -153,10 +161,10 @@ hazelcast:
         enabled: true
         service-dns: MY-SERVICE-DNS-NAME
 ```
--- 
-Java:: 
-+ 
--- 
+--
+Java::
++
+--
 ```java
 config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
 config.getNetworkConfig().getJoin().getKubernetesConfig().setEnabled(true)
@@ -183,20 +191,20 @@ When using `ZONE_AWARE` configuration, backups are created in the other availabi
 
 NOTE: Your Kubernetes cluster must orchestrate Hazelcast Member Pods equally between the availability zones, otherwise Zone Aware feature may not work correctly.
 
-[tabs] 
-==== 
-YAML:: 
-+ 
--- 
+[tabs]
+====
+YAML::
++
+--
 ```yaml
 partition-group:
   enabled: true
   group-type: ZONE_AWARE
 ```
 --
-Java:: 
-+ 
--- 
+Java::
++
+--
 ```java
 config.getPartitionGroupConfig()
     .setEnabled(true)
@@ -210,16 +218,16 @@ Note the following aspects of `ZONE_AWARE`:
 * Kubernetes cluster must provide the link:https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone[well-known Kubernetes annotations]
 * Retrieving Zone Name uses Kubernetes API, so <<granting-permissions-to-use-kubernetes-api, RBAC must be configured>>
 * `ZONE_AWARE` feature works correctly when Hazelcast members are distributed equally in all zones, so your Kubernetes cluster must orchestrate Pods equally
- 
+
 Note also that retrieving Zone Name assumes that your container's hostname is the same as Pod Name, which is almost always true. If you happen to change your hostname in the container, then please define the following environment variable:
- 
+
 ```yaml
 env:
   - name: POD_NAME
     valueFrom:
       fieldRef:
         fieldPath: metadata.name
-``` 
+```
 
 === Node Aware
 
@@ -247,9 +255,9 @@ Note the following aspects of `NODE_AWARE`:
 
 * Retrieving name of the node uses Kubernetes API, so <<granting-permissions-to-use-kubernetes-api, RBAC must be configured>>
 * `NODE_AWARE` feature works correctly when Hazelcast members are distributed equally in all nodes, so your Kubernetes cluster must orchestrate Pods equally.
- 
+
 Note also that retrieving name of the node assumes that your container's hostname is the same as Pod Name, which is almost always true. If you happen to change your hostname in the container, then please define the following environment variable:
- 
+
 ```yaml
 env:
 - name: POD_NAME
@@ -280,11 +288,11 @@ For the client to discover the Hazelcast cluster, all it needs to know is the ad
 
 If you have a Hazelcast cluster and a Hazelcast client deployed on the same Kubernetes cluster, you should use the Kubernetes service name in the client's configuration.
 
-[tabs] 
-==== 
-YAML:: 
-+ 
--- 
+[tabs]
+====
+YAML::
++
+--
 ```yaml
 hazelcast-client:
   network:
@@ -292,16 +300,16 @@ hazelcast-client:
       - MY-SERVICE-NAME
 ```
 --
-Java:: 
-+ 
--- 
+Java::
++
+--
 ```java
 clientConfig.getNetworkConfig().addAddress("MY-SERVICE-NAME");
 ```
 --
-NodeJS:: 
-+ 
--- 
+NodeJS::
++
+--
 ```javascript
 const clientConfig = {
     network: {
@@ -312,25 +320,25 @@ const clientConfig = {
 };
 ```
 --
-Python:: 
-+ 
--- 
+Python::
++
+--
 ```python
 client = hazelcast.HazelcastClient(
     cluster_members=["MY-SERVICE-NAME"],
 )
 ```
 --
-C++:: 
-+ 
--- 
+C++::
++
+--
 ```cpp
 config.get_network_config().add_address({"MY-SERVICE-NAME", 5701})
 ```
 --
-Go:: 
-+ 
--- 
+Go::
++
+--
 ```go
 config.Cluster.Network.SetAddresses("MY-SERVICE-NAME:5701")
 ```

--- a/docs/modules/mapstore/pages/configuration-guide.adoc
+++ b/docs/modules/mapstore/pages/configuration-guide.adoc
@@ -11,13 +11,13 @@ If you use Hazelcast in client/server mode, make sure to add the MapStore to the
 
 To configure a MapStore, you must provide the <<class-name, name>> of your class that implements the MapStore.
 
-NOTE: Follow the instructions in xref:mapstore:configuring-a-generic-maploader.adoc[] or xref:mapstore:configuring-a-generic-mapstore.adoc[] for this step if you are using a pre-built Mapstore.
+NOTE: Follow the instructions in  xref:mapstore:configuring-a-generic-mapstore.adoc[] for this step if you are using a pre-built Mapstore.
 
-[tabs] 
-==== 
-XML:: 
-+ 
--- 
+[tabs]
+====
+XML::
++
+--
 [source,xml]
 ----
 <hazelcast>
@@ -46,8 +46,8 @@ hazelcast:
 ----
 --
 
-Java:: 
-+ 
+Java::
++
 --
 
 [source,java]
@@ -71,7 +71,7 @@ To configure a MapStore to use write-behind caching, set the <<write-delay-secon
 
 To improve cluster throughput, MapStore API calls, such as `load()` and `store()` operations, are offloaded by default. This way partition threads are not blocked by them.
 
-Because each partition in a member is managed by a single thread, the write operations to a given partition are handled one at a time in first-in-first-out order. However, MapStore operations may take a long time to connect to the external data source and complete, blocking the affected partitions. 
+Because each partition in a member is managed by a single thread, the write operations to a given partition are handled one at a time in first-in-first-out order. However, MapStore operations may take a long time to connect to the external data source and complete, blocking the affected partitions.
 To avoid blocking partition threads, MapStore operations communicate with the external data source asynchronously, using an <<configuring-the-offload-executor, executor>>.
 
 [NOTE]
@@ -85,12 +85,12 @@ To avoid blocking partition threads, MapStore operations communicate with the ex
 You can configure the executor service that handles asynchronous MapStore operations.
 The offload executor's name is `hz:map-store-offloadable`. You can configure the number of threads for this executor and its task queue capacity. See xref:computing:executor-service.adoc#configuring-executor-service[Configuring Executor Service] for a guide.
 
-[tabs] 
-==== 
+[tabs]
+====
 
-XML:: 
-+ 
--- 
+XML::
++
+--
 [source,xml]
 ----
 <hazelcast>
@@ -164,10 +164,10 @@ If you are using Java to configure the Mapstore, use the link:https://javadoc.io
 |true
 |
 
-[tabs] 
-==== 
-XML:: 
-+ 
+[tabs]
+====
+XML::
++
 --
 [source,xml]
 ----
@@ -178,8 +178,8 @@ XML::
 </hazelcast>
 ----
 --
-YAML:: 
-+ 
+YAML::
++
 --
 [source,yaml]
 ----
@@ -190,8 +190,8 @@ hazelcast:
         enabled: true
 ----
 --
-Java:: 
-+ 
+Java::
++
 --
 [source,java]
 ----
@@ -211,10 +211,10 @@ mapConfig.setMapStoreConfig(mapStoreConfig);
 a|`''` (empty)
 |
 
-[tabs] 
-==== 
-XML:: 
-+ 
+[tabs]
+====
+XML::
++
 --
 [source,xml]
 ----
@@ -226,8 +226,8 @@ XML::
 </hazelcast>
 ----
 --
-YAML:: 
-+ 
+YAML::
++
 --
 [source,yaml]
 ----
@@ -239,8 +239,8 @@ hazelcast:
         class-name: com.hazelcast.examples.DummyStore
 ----
 --
-Java:: 
-+ 
+Java::
++
 --
 
 [source,java]
@@ -260,11 +260,11 @@ mapConfig.setMapStoreConfig(mapStoreConfig);
 
 |true
 |
-[tabs] 
-==== 
-XML:: 
-+ 
--- 
+[tabs]
+====
+XML::
++
+--
 [source,xml]
 ----
 <hazelcast>
@@ -309,10 +309,10 @@ mapStoreConfig.setOffload(true);
 |0
 |
 
-[tabs] 
-==== 
-XML:: 
-+ 
+[tabs]
+====
+XML::
++
 --
 [source,xml]
 ----
@@ -327,8 +327,8 @@ XML::
 </hazelcast>
 ----
 --
-YAML:: 
-+ 
+YAML::
++
 --
 [source,yaml]
 ----
@@ -341,8 +341,8 @@ hazelcast:
         write-delay-seconds: 0
 ----
 --
-Java:: 
-+ 
+Java::
++
 --
 [source,java]
 ----
@@ -363,10 +363,10 @@ mapConfig.setMapStoreConfig(mapStoreConfig);
 |1
 |
 
-[tabs] 
-==== 
-XML:: 
-+ 
+[tabs]
+====
+XML::
++
 --
 [source,xml]
 ----
@@ -381,8 +381,8 @@ XML::
 </hazelcast>
 ----
 --
-YAML:: 
-+ 
+YAML::
++
 --
 [source,yaml]
 ----
@@ -395,8 +395,8 @@ hazelcast:
         write-batch-size: 1
 ----
 --
-Java:: 
-+ 
+Java::
++
 --
 [source,java]
 ----
@@ -417,10 +417,10 @@ mapConfig.setMapStoreConfig(mapStoreConfig);
 |true
 |
 
-[tabs] 
-==== 
-XML:: 
-+ 
+[tabs]
+====
+XML::
++
 --
 [source,xml]
 ----
@@ -435,8 +435,8 @@ XML::
 </hazelcast>
 ----
 --
-YAML:: 
-+ 
+YAML::
++
 --
 [source,yaml]
 ----
@@ -449,8 +449,8 @@ hazelcast:
         write-coalescing: true
 ----
 --
-Java:: 
-+ 
+Java::
++
 --
 [source,java]
 ----
@@ -476,10 +476,10 @@ NOTE: If you add xref:query:how-distributed-query-works.adoc#indexing-queries[in
 |LAZY
 |
 
-[tabs] 
-==== 
-XML:: 
-+ 
+[tabs]
+====
+XML::
++
 --
 [source,xml]
 ----
@@ -494,8 +494,8 @@ XML::
 </hazelcast>
 ----
 --
-YAML:: 
-+ 
+YAML::
++
 --
 [source,yaml]
 ----
@@ -508,8 +508,8 @@ hazelcast:
         initial-mode: LAZY
 ----
 --
-Java:: 
-+ 
+Java::
++
 --
 [source,java]
 ----

--- a/docs/modules/migrate/pages/upgrading-from-imdg-3.adoc
+++ b/docs/modules/migrate/pages/upgrading-from-imdg-3.adoc
@@ -307,6 +307,7 @@ mapConfig.addIndexConfig(indexConfig);
     </map>
     ...
 </hazelcast>
+----
 
 2+|Dynamic Index Create
 
@@ -1025,7 +1026,7 @@ public boolean onLogin() throws LoginException {
     CredentialsCallback cc = new CredentialsCallback();
     try {
         callbackHandler.handle(new Callback[] { cc });
-    } catch (IOException | UnsupportedCallbackException e) {
+    } catch (IOException \| UnsupportedCallbackException e) {
         throw new FailedLoginException("Unable to retrieve credentials. " + e.getMessage());
     }
     Credentials creds = cc.getCredentials();


### PR DESCRIPTION
Fixes

```
6:39:08 PM: [15:39:08.721] ERROR (asciidoctor): dropping cells from incomplete row detected end of table
6:39:08 PM:     file: docs/modules/configuration/pages/configuring-programmatically.adoc:62
6:39:08 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:10 PM: [15:39:10.721] WARN (asciidoctor): no callout found for <2>
6:39:10 PM:     file: docs/modules/getting-started/pages/blue-green.adoc:60
6:39:10 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:10 PM: [15:39:10.724] WARN (asciidoctor): no callout found for <2>
6:39:10 PM:     file: docs/modules/getting-started/pages/blue-green.adoc:90
6:39:10 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:11 PM: [15:39:11.062] WARN (asciidoctor): no callout found for <5>
6:39:11 PM:     file: docs/modules/getting-started/pages/persistence.adoc:56
6:39:11 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:11 PM: [15:39:11.121] WARN (asciidoctor): no callout found for <2>
6:39:11 PM:     file: docs/modules/getting-started/pages/wan.adoc:52
6:39:11 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:12 PM: [15:39:12.254] WARN (asciidoctor): skipping reference to missing attribute: version
6:39:12 PM:     file: docs/modules/kubernetes/pages/helm-hazelcast-chart.adoc
6:39:12 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:12 PM: [15:39:12.256] WARN (asciidoctor): skipping reference to missing attribute: default_hazelcast_yaml
6:39:12 PM:     file: docs/modules/kubernetes/pages/helm-hazelcast-chart.adoc
6:39:12 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:12 PM: [15:39:12.263] WARN (asciidoctor): skipping reference to missing attribute: version
6:39:12 PM:     file: docs/modules/kubernetes/pages/helm-hazelcast-chart.adoc
6:39:12 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:12 PM: [15:39:12.264] WARN (asciidoctor): skipping reference to missing attribute: default_hazelcast_client_yaml
6:39:12 PM:     file: docs/modules/kubernetes/pages/helm-hazelcast-chart.adoc
6:39:12 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:12 PM: [15:39:12.533] WARN (asciidoctor): skipping reference to missing attribute: version
6:39:12 PM:     file: docs/modules/kubernetes/pages/helm-hazelcast-enterprise-chart.adoc
6:39:12 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:12 PM: [15:39:12.534] WARN (asciidoctor): skipping reference to missing attribute: default_hazelcast_yaml
6:39:12 PM:     file: docs/modules/kubernetes/pages/helm-hazelcast-enterprise-chart.adoc
6:39:12 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:12 PM: [15:39:12.542] WARN (asciidoctor): skipping reference to missing attribute: version
6:39:12 PM:     file: docs/modules/kubernetes/pages/helm-hazelcast-enterprise-chart.adoc
6:39:12 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:12 PM: [15:39:12.568] ERROR (asciidoctor): dropping cells from incomplete row detected end of table
6:39:12 PM:     file: docs/modules/kubernetes/pages/kubernetes-auto-discovery.adoc:25
6:39:12 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:13 PM: [15:39:13.132] ERROR (asciidoctor): target of xref not found: mapstore:configuring-a-generic-maploader.adoc
6:39:13 PM:     file: docs/modules/mapstore/pages/configuration-guide.adoc
6:39:13 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:13 PM: [15:39:13.338] WARN (asciidoctor): unterminated listing block
6:39:13 PM:     file: docs/modules/migrate/pages/upgrading-from-imdg-3.adoc:295
6:39:13 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:13 PM: [15:39:13.395] WARN (asciidoctor): unterminated listing block
6:39:13 PM:     file: docs/modules/migrate/pages/upgrading-from-imdg-3.adoc:1020
6:39:13 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:13 PM: [15:39:13.397] WARN (asciidoctor): unterminated listing block
6:39:13 PM:     file: docs/modules/migrate/pages/upgrading-from-imdg-3.adoc:1038
6:39:13 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
6:39:13 PM: [15:39:13.397] ERROR (asciidoctor): dropping cells from incomplete row detected end of table
6:39:13 PM:     file: docs/modules/migrate/pages/upgrading-from-imdg-3.adoc:1038
6:39:13 PM:     source: https://github.com/hazelcast/hz-docs (branch: v/5.2 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66d72c95e732700008b85034#L200