### PR TITLE
Fix production build errors

### DIFF
--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -2,9 +2,12 @@ site:
   title: Documentation
   url: http:localhost:5000
 content:
-  sources: 
+  sources:
   - url: .
     branches: HEAD
+    start_path: docs
+  - url: https://github.com/hazelcast/hz-docs
+    branches: [v/5.5]
     start_path: docs
   - url: https://github.com/hazelcast/hazelcast-docs
     branches: [main]
@@ -13,7 +16,7 @@ content:
     branches: [main]
     start_path: docs
   - url: https://github.com/hazelcast/management-center-docs
-    branches: [main]
+    branches: [main, v/5.5]
     start_path: docs
   - url: https://github.com/hazelcast/cloud-docs
     branches: [main]
@@ -140,7 +143,7 @@ content:
   - url: https://github.com/hazelcast/clc-docs
     branches: main
     start_path: docs
-ui: 
+ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
     snapshot: true

--- a/docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
+++ b/docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
@@ -116,7 +116,7 @@ Here is the expected response body:
 
 == Step 2. Create map with new configuration
 
-Access the `/map/{mapName}/{key}` POST endpoint to create the map and add an entry:
+Access the `/map/\{mapName}/\{key}` POST endpoint to create the map and add an entry:
 
 [tabs]
 ====
@@ -136,7 +136,7 @@ curl -X POST \
 Using Swagger UI::
 +
 - Open the Swagger UI at http://localhost:8443/swagger-ui/index.html.
-- Navigate to the `/map/{mapName}/{key}` POST endpoint under the *Data Controller* section.
+- Navigate to the `/map/\{mapName}/\{key}` POST endpoint under the *Data Controller* section.
 - Click **Try it out**.
 - Enter `my-map` and `1` in the 'mapName' and `key` fields respectively.
 - Enter the value in the request body section:
@@ -154,7 +154,7 @@ You can use https://docs.hazelcast.com/management-center/latest/data-structures/
 
 == Step 3. Create queue with new configuration
 
-Access the `/queue/{queueName}` POST endpoint to create the queue and add an item:
+Access the `/queue/\{queueName}` POST endpoint to create the queue and add an item:
 
 [tabs]
 ====
@@ -174,7 +174,7 @@ curl -X POST \
 Using Swagger UI::
 +
 - Open the Swagger UI at http://localhost:8443/swagger-ui/index.html.
-- Navigate to the `/queue/{queueName}` POST endpoint under the *Data Controller* section.
+- Navigate to the `/queue/\{queueName}` POST endpoint under the *Data Controller* section.
 - Click **Try it out**.
 - Enter `my-queue` in the 'queueName' field.
 - Enter the item value in the request body section:
@@ -210,14 +210,14 @@ curl -X 'POST' \
 Using Swagger UI::
 +
 - Open the Swagger UI at http://localhost:8443/swagger-ui/index.html.
-- Navigate to the `/map/{mapName}/{key}` POST endpoint under the *Config Controller* section.
+- Navigate to the `/map/\{mapName}/\{key}` POST endpoint under the *Config Controller* section.
 - Click **Try it out**.
 - Click **Execute**.
 ====
 
 == Next Steps
 
-If you're interested in learning more about the topics introduced in this tutorial, see: 
+If you're interested in learning more about the topics introduced in this tutorial, see:
 
 * xref:enterprise-rest-api.adoc#update-dynamic-configuration-using-rest[REST Dynamic Configuration]
 * xref:configuration:dynamic-config.adoc[Dynamic Configuration for Members]

--- a/docs/modules/maintain-cluster/pages/enterprise-rest-api.adoc
+++ b/docs/modules/maintain-cluster/pages/enterprise-rest-api.adoc
@@ -24,9 +24,9 @@ NOTE: The REST API comes packaged with Spring framework and FasterXML Jackson de
 
 REST service is disabled by default; to enable the REST service you must change the configuration as follows:
 
-[tabs] 
-==== 
-XML:: 
+[tabs]
+====
+XML::
 +
 --
 [source,xml]
@@ -64,11 +64,11 @@ The default port for the REST API is `8443`. To change it to another port, updat
 
 NOTE: If the port is occupied, the server instance will fail to start. To run multiple server instances with REST on the same machine, each instance should have a separate configuration file with a unique port assigned to it.
 
-[tabs] 
-==== 
-XML:: 
-+ 
--- 
+[tabs]
+====
+XML::
++
+--
 [source,xml]
 ----
 <hazelcast>
@@ -151,7 +151,7 @@ XML::
                         </user>
                     </simple>
                 </authentication>
-                <access-control-service> 
+                <access-control-service>
                     <factory-class-name>com.hazelcast.internal.rest.access.DefaultAccessControlServiceFactory</factory-class-name>
                 </access-control-service>
             </realm>
@@ -180,7 +180,7 @@ hazelcast:
                 password: 'restpassword'
                 roles:
                   - admin
-        access-control-service: 
+        access-control-service:
           factory-class-name: com.hazelcast.internal.rest.access.DefaultAccessControlServiceFactory
 ----
 
@@ -413,7 +413,7 @@ On the Swagger page, each endpoint is listed with a caret icon on the right side
 
 image::rest-api-swagger-expanding-an-endpoint.png[Example Swagger UI showing cluster endpoint]
 
-After expanding the endpoint, let's send a request. Click **Try it out**. There are no parameters for this example but if there were you could enter these here. Click  **Execute** to send the request. 
+After expanding the endpoint, let's send a request. Click **Try it out**. There are no parameters for this example but if there were you could enter these here. Click  **Execute** to send the request.
 
 image::rest-api-swagger-clicking-execute-button.png[]
 
@@ -530,7 +530,7 @@ curl -X 'POST' \
 
 === Destroy a CP Group
 
-You can send a `DELETE` request to the endpoint at `/hazelcast/rest/api/v1/cp/groups/{group-name}` to unconditionally destroy the given active CP group. For example, using cURL:
+You can send a `DELETE` request to the endpoint at `/hazelcast/rest/api/v1/cp/groups/\{group-name}` to unconditionally destroy the given active CP group. For example, using cURL:
 
 [source,shell]
 ----
@@ -540,7 +540,7 @@ curl -X 'DELETE' \
 ----
 
 * If successful, it will return a `200` response without body.
-* If you try to destroy METADATA group, it will return a `400` response: 
+* If you try to destroy METADATA group, it will return a `400` response:
 
 [source,json]
 ----
@@ -567,7 +567,7 @@ TIP: For a short tutorial showing how to dynamically add a data structure using 
 
 The endpoint requires that you send a XML/YAML server configuration file with the required changes. The response will be two lists in JSON format:
 
-- The first `addedConfigs` list includes the newly added configuration among the configurations sent to the server. 
+- The first `addedConfigs` list includes the newly added configuration among the configurations sent to the server.
 - The second `ignoredConfigs` list includes ignored configurations which were in the sent configuration list but could not be applied by the server. These could include duplicates, or static configurations (which cannot be applied dynamically).
 
 Whether a dynamic configuration can be applied or not depends on the type of request. For some updates, you can change configuration parameters for an existing configuration; for other updates, you cannot change the configuration dynamically. For more detail on which configuration parameters can be changed dynamically and which cannot, see xref:configuration:dynamic-config.adoc[Dynamic Configuration for Members].

--- a/docs/modules/maintain-cluster/pages/shutdown.adoc
+++ b/docs/modules/maintain-cluster/pages/shutdown.adoc
@@ -7,10 +7,10 @@
 
 To send a command to shut down the cluster, use one of the following options:
 
-[tabs] 
-==== 
-CLI:: 
-+ 
+[tabs]
+====
+CLI::
++
 --
 NOTE: To use the CLI to shut down a cluster, you must first xref:clients:rest.adoc[enable the REST API].
 
@@ -18,6 +18,8 @@ NOTE: To use the CLI to shut down a cluster, you must first xref:clients:rest.ad
 ----
 bin/hz-cluster-admin -a <address> -c <cluster-name> -o shutdown
 ----
+--
+
 REST API::
 +
 --

--- a/docs/modules/migrate/pages/upgrading-from-imdg-3.adoc
+++ b/docs/modules/migrate/pages/upgrading-from-imdg-3.adoc
@@ -307,6 +307,7 @@ mapConfig.addIndexConfig(indexConfig);
     </map>
     ...
 </hazelcast>
+----
 
 2+|Dynamic Index Create
 
@@ -2248,7 +2249,7 @@ See the following table for the before/after snippets.
 
 == Deprecation of User Code Deployment
 
-The adding of Java classes to members using {ucd} was deprecated in Platform 5.4. 
+The adding of Java classes to members using {ucd} was deprecated in Platform 5.4.
 
 The {ucn} feature, which extends {ucd} to allow you to redeploy your classes, is available for Enterprise users.
 

--- a/docs/modules/release-notes/pages/5-4-0.adoc
+++ b/docs/modules/release-notes/pages/5-4-0.adoc
@@ -227,7 +227,7 @@ https://github.com/hazelcast/hazelcast/pull/24800[#24800]
 
 === API Documentation
 
-* Detailed the existing partition aware interface description to explain the requirements when calculating the partition ID in case partition aware is implemented. See {platform-javadocs}/{full-version}/com/hazelcast/partition/PartitionAware.html. #875
+* Detailed the existing partition aware interface description to explain the requirements when calculating the partition ID in case partition aware is implemented. See link:https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/partition/PartitionAware.html[`Interface PartitionAware<T>`].
 
 == Fixes
 
@@ -312,7 +312,7 @@ With this fix, only the members on which the jobs have not been completed are qu
 https://github.com/hazelcast/hazelcast/pull/24734[#24734]
 * The evaluation tool for IMDG 3.x users (Hazelcast 3 Connector) is removed. In the upcoming releases, a new tool for migrating data from 3.x versions will be introduced.
 https://github.com/hazelcast/hazelcast/pull/25051[#25051]
-* Transactions have been deprecated, and will be removed as of Hazelcast version 7.0. 
+* Transactions have been deprecated, and will be removed as of Hazelcast version 7.0.
 An improved version of this feature is under consideration. If you are already using transactions, get in touch and share your use case. Your feedback will help us to develop a solution that meets your needs.
 * Portable Serialization has been deprecated. We recommend you use Compact Serialization as Portable Serialization will be removed as of version 7.0.
 * The user code deployment API is deprecated, and will be removed in Hazelcast Platform version 6.0. #223


### PR DESCRIPTION
Fixes

```
6:38:38 PM: [15:38:38.847] WARN (asciidoctor): skipping reference to missing attribute: mapname
6:38:38 PM:     file: docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
6:38:38 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:38 PM: [15:38:38.848] WARN (asciidoctor): skipping reference to missing attribute: key
6:38:38 PM:     file: docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
6:38:38 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:38 PM: [15:38:38.849] WARN (asciidoctor): skipping reference to missing attribute: mapname
6:38:38 PM:     file: docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
6:38:38 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:38 PM: [15:38:38.849] WARN (asciidoctor): skipping reference to missing attribute: key
6:38:38 PM:     file: docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
6:38:38 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:38 PM: [15:38:38.850] WARN (asciidoctor): skipping reference to missing attribute: queuename
6:38:38 PM:     file: docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
6:38:38 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:38 PM: [15:38:38.851] WARN (asciidoctor): skipping reference to missing attribute: queuename
6:38:38 PM:     file: docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
6:38:38 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:38 PM: [15:38:38.853] WARN (asciidoctor): skipping reference to missing attribute: mapname
6:38:38 PM:     file: docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
6:38:38 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:38 PM: [15:38:38.853] WARN (asciidoctor): skipping reference to missing attribute: key
6:38:38 PM:     file: docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
6:38:38 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:38 PM: [15:38:38.905] WARN (asciidoctor): skipping reference to missing attribute: group-name
6:38:38 PM:     file: docs/modules/maintain-cluster/pages/enterprise-rest-api.adoc
6:38:38 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:39 PM: [15:38:39.308] WARN (asciidoctor): unterminated open block
6:38:39 PM:     file: docs/modules/maintain-cluster/pages/shutdown.adoc:49
6:38:39 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:39 PM: [15:38:39.814] WARN (asciidoctor): unterminated listing block
6:38:39 PM:     file: docs/modules/migrate/pages/upgrading-from-imdg-3.adoc:295
6:38:39 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
6:38:41 PM: [15:38:41.631] WARN (asciidoctor): skipping reference to missing attribute: platform-javadocs
6:38:41 PM:     file: docs/modules/release-notes/pages/5-4-0.adoc
6:38:41 PM:     source: https://github.com/hazelcast/hz-docs (branch: main | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66d72c95e732700008b85034#L134