### PR TITLE
LDAP authentication incorrect member DN placeholder value

### DIFF
--- a/docs/modules/security/pages/security-realms.adoc
+++ b/docs/modules/security/pages/security-realms.adoc
@@ -159,11 +159,11 @@ This option is only used when the `role-mapping-mode` option has the value `attr
 This option is only used when the `role-mapping-mode` option has the value `reverse`.
 
 | `role-filter`
-| `([role-mapping-attribute]=\{MEMBERDN})`
-| LDAP search string which usually contains a placeholder `\{MEMBERDN}` to be
-replaced by the provided login name, e.g., `(member=\{MEMBERDN})`.
+| `([role-mapping-attribute]=\{memberDN})`
+| LDAP search string which usually contains a placeholder `\{memberDN}` to be
+replaced by the provided login name, e.g., `(member=\{memberDN})`.
 
-If the role search recursion is enabled (see `role-recursion-max-depth`), the `\{MEMBERDN}`
+If the role search recursion is enabled (see `role-recursion-max-depth`), the `\{memberDN}`
 is replaced by role DNs in the recurrent searches.
 
 This option is only used when the `role-mapping-mode` option has the value `reverse`.


### PR DESCRIPTION
`{MEMBERDN}` is incorrect, it needs to be written as `{memberDN}`

pls refer to https://hazelcast.atlassian.net/browse/SUP-604