### PR TITLE
typo: removed reference to map connector

### DIFF
--- a/docs/modules/integrate/pages/reliable-topic-connector.adoc
+++ b/docs/modules/integrate/pages/reliable-topic-connector.adoc
@@ -5,8 +5,7 @@ used as a data sink within a pipeline.
 
 == Installing the Connector
 
-The map connector is included in the full and slim
-distributions of Hazelcast.
+This connector is included in the full and slim distributions of Hazelcast.
 
 == Permissions
 [.enterprise]*{enterprise-product-name}*


### PR DESCRIPTION
Removed the reference to map connector in the reliable topic page