### PR TITLE
Clarify (lack of) backup redistribution on data structure level [HZG-156]

### DIFF
--- a/docs/modules/fault-tolerance/pages/backups.adoc
+++ b/docs/modules/fault-tolerance/pages/backups.adoc
@@ -9,9 +9,9 @@ for more information about the partitioning.
 
 [IMPORTANT]
 ====
-Hazelcast does not support backup redistribution on a data structure level. Thus, changing the backup count of a nonempty data structure is **not** supported. For example, for a map with a nonzero backup count:
+Hazelcast does not support backup redistribution on a data structure level. Thus, changing the backup count of a nonempty data structure is **not** supported. For example, for a map:
 
-1. increasing the backup countfootnote:change-backup-count[The backup count of a map can only be changed by modifying the xref:configuration:understanding-configuration.adoc#static-configuration[static configuration] and restarting the cluster.] does **not** create additional copies of existing map entries,
+1. increasing the backup countfootnote:change-backup-count[The backup count of an empty map can only be changed by modifying the xref:configuration:understanding-configuration.adoc#static-configuration[static configuration] and restarting the cluster.] does **not** create additional copies of existing map entries,
 2. decreasing the backup countfootnote:change-backup-count[] does **not** remove any backups of existing map entries, so some backups will have stale data if the map entries are overwritten, and
 3. if some backups are lost due to node failure, additional copies are **not** created on other nodes to meet the backup count.
 ====

--- a/docs/modules/fault-tolerance/pages/backups.adoc
+++ b/docs/modules/fault-tolerance/pages/backups.adoc
@@ -7,6 +7,17 @@ The distribution happens on the partition level; the data and its backups are st
 memory partitions. See the xref:overview:data-partitioning.adoc[Data Partitioning] and xref:clusters:partition-group-configuration.adoc[Partition Grouping]
 for more information about the partitioning.
 
+[IMPORTANT]
+====
+Hazelcast does not support backup redistribution on data structure level. For example, for a map with a nonzero backup count,
+
+1. increasing the backup count does **not** create additional copies of existing map entries,
+2. decreasing the backup count does **not** remove any backups of existing map entries, so some backups will have stale data if the map entries are overwritten, and
+3. if some backups are lost due to node failure, additional copies are **not** created on other nodes to meet the backup count.
+
+Thus, it is unsupported to change the backup count of a data structure once it was populated with data.
+====
+
 When a member in your cluster is lost, Hazelcast redistributes the backups
 on the remaining members so that every partition has a backup.
 The number of backups is configurable.

--- a/docs/modules/fault-tolerance/pages/backups.adoc
+++ b/docs/modules/fault-tolerance/pages/backups.adoc
@@ -9,13 +9,11 @@ for more information about the partitioning.
 
 [IMPORTANT]
 ====
-Hazelcast does not support backup redistribution on data structure level. For example, for a map with a nonzero backup count,
+Hazelcast does not support backup redistribution on a data structure level. Thus, changing the backup count of a nonempty data structure is **not** supported. For example, for a map with a nonzero backup count:
 
-1. increasing the backup count does **not** create additional copies of existing map entries,
-2. decreasing the backup count does **not** remove any backups of existing map entries, so some backups will have stale data if the map entries are overwritten, and
+1. increasing the backup countfootnote:change-backup-count[The backup count of a map can only be changed by modifying the xref:configuration:understanding-configuration.adoc#static-configuration[static configuration] and restarting the cluster.] does **not** create additional copies of existing map entries,
+2. decreasing the backup countfootnote:change-backup-count[] does **not** remove any backups of existing map entries, so some backups will have stale data if the map entries are overwritten, and
 3. if some backups are lost due to node failure, additional copies are **not** created on other nodes to meet the backup count.
-
-Thus, it is unsupported to change the backup count of a data structure once it was populated with data.
 ====
 
 When a member in your cluster is lost, Hazelcast redistributes the backups


### PR DESCRIPTION
The info-box is intended to clarify the following sentence.
> The distribution happens on the partition level; the data and its backups are stored in the memory partitions.

If you don't like its position, you can move it at the end of the page.