### PR TITLE
Correct PassThroughMergePolicy documentation [DOC-174]

### DIFF
--- a/docs/modules/wan/pages/configuring-for-map-and-cache.adoc
+++ b/docs/modules/wan/pages/configuring-for-map-and-cache.adoc
@@ -88,7 +88,7 @@ the target map if it does not exist in the target map.
 * `HigherHitsMergePolicy`: Incoming entry merges from the source map to
 the target map if the source entry has more hits than the target one.
 * `PassThroughMergePolicy`: Incoming entry merges from the source map to
-the target map unless the incoming entry is not null.
+the target map unless the incoming entry is null.
 * `ExpirationTimeMergePolicy`: Incoming entry merges from the source map to
 the target map if the source entry will expire later than the destination entry.
 Please note that this merge policy can only be used when the clusters' clocks are in sync.
@@ -169,7 +169,7 @@ the target cache if it does not exist in the target cache.
 * `HigherHitsMergePolicy`: Incoming entry merges from the source cache to
 the target cache if the source entry has more hits than the target one.
 * `PassThroughMergePolicy`: Incoming entry merges from the source cache to
-the target cache unless the incoming entry is not null.
+the target cache unless the incoming entry is null.
 * `ExpirationTimeMergePolicy`: Incoming entry merges from the source cache to
 the target cache if the source entry will expire later than the destination entry.
 Please note that this merge policy can only be used when the clusters' clocks are in sync.


### PR DESCRIPTION
Per the code and javadoc this should read ".. unless the incoming entry is null." 

Javadoc :

`Merges data structure entries from source to destination directly unless the merging entry is {@code null}`