### PR TITLE
Use latest `setup-node` in GitHub Actions

### DIFF
--- a/.github/workflows/adoc-html.yml
+++ b/.github/workflows/adoc-html.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4.0.2
+    - uses: actions/setup-node@v4
       with:
         node-version: 20
     - name: Convert adoc

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4.0.2
+    - uses: actions/setup-node@v4
       with:
         node-version: 20
     - name: Check for broken internal links


### PR DESCRIPTION
Rather than specifying a specific `setup-node` version, and having to [manually increment it](https://github.com/hazelcast/hz-docs/pulls?q=actions%2Fsetup-node), instead we can specify the latest `v4` as we do with other GitHub Actions (e.g. `checkout`).