### PR TITLE
Bump C# client version

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -30,7 +30,7 @@ asciidoc:
     # https://github.com/hazelcast/hazelcast-cpp-client/releases
     page-latest-supported-cplusplus-client: '5.3.0'
     # https://github.com/hazelcast/hazelcast-csharp-client/releases
-    page-latest-supported-csharp-client: '5.4.0'
+    page-latest-supported-csharp-client: '5.5.0'
     # https://github.com/hazelcast/hazelcast-python-client/releases
     page-latest-supported-python-client: '5.5.0'
     # https://github.com/hazelcast/hazelcast-nodejs-client/releases


### PR DESCRIPTION
Bump C# client version following [release](https://github.com/hazelcast/hazelcast-csharp-client/releases/tag/v5.5.0).