### PR TITLE
HZX-1173: tweak wording related to LRO issue

### DIFF
--- a/docs/modules/ROOT/pages/production-checklist.adoc
+++ b/docs/modules/ROOT/pages/production-checklist.adoc
@@ -53,7 +53,7 @@ Consider the following for VMWare ESX:
 * Network performance issues, including timeouts, might occur with LRO (Large Receive Offload)
 enabled on Linux virtual machines and ESXi/ESX hosts. We have specifically had
 this reported in VMware environments, but it could potentially impact other environments as well.
-We strongly recommend disabling LRO when running in virtualized environments, see https://kb.vmware.com/s/article/1027511.
+Although this issue is observed only under certain conditions, we strongly recommend either using the e1000 device driver, or disabling LRO when running in virtualized environments. For more information, see https://kb.vmware.com/s/article/1027511.
 
 === Windows
 


### PR DESCRIPTION
Small change to the wording for the LRO issue to make it clear that there is an alternative to disabling (using the e1000 device driver) and that the issue occurs only under certain conditions