### PR TITLE
1011: Added note about override

### DIFF
--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -1068,7 +1068,7 @@ These operations log a warning and are shown in the Management Center with detai
 |`hazelcast.socket.bind.any`
 | true
 | bool
-| Bind both server-socket and client-sockets to any local interface.
+| Bind both server-socket and client-sockets to any local interface. For ZIP and TAR distributions, this is overridden by false in configuration files.
 
 |`hazelcast.socket.buffer.direct`
 | false


### PR DESCRIPTION
Added clarification for ZIP and TAR distributions, which are overridden as false in configuration files