### PR TITLE
No snapshot releases for OSS

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -10,6 +10,7 @@ asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
     full-version: '6.0.0-SNAPSHOT'
+    last-oss-version: '5.5.0'
     # The minor.patch version, which is used as a variable in the docs for things like file versions
     minor-version: '6.0-SNAPSHOT'
     # The snapshot version for installing with brew

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -20,7 +20,7 @@ You must use one of the following installation methods if you want to install th
 * <<Using the Binary>>
 * <<Using Java>>
 
-To install a slim distribution, append `-slim` to the version number in the commands shown in the following sections; for example, to install the slim distribution of {full-version}, use `{full-version}-slim`.
+To install a slim distribution, append `-slim` to the version number in the commands shown in the following sections; for example, to install the slim distribution of {last-oss-version}, use `{last-oss-version}-slim`.
 
 == Using a Package Manager
 
@@ -38,23 +38,13 @@ Mac::
 --
 
 To install on macOS, use the Homebrew package manager.
-ifdef::snapshot[]
 
 [source,bash,subs="attributes+"]
 ----
 brew tap hazelcast/hz
-brew install hazelcast@{version-brew}
+brew install hazelcast@{last-oss-version}
 ----
-endif::[]
 
-ifndef::snapshot[]
-
-[source,bash,subs="attributes+"]
-----
-brew tap hazelcast/hz
-brew install hazelcast@{full-version}
-----
-endif::[]
 --
 
 Linux::
@@ -63,43 +53,23 @@ Linux::
 
 . Check that you have the GNU Wget package installed. You'll use Wget to download the GPG keys for the Hazelcast package.
 +
-```bash
+[source,bash]
+----
 wget -V
-```
+----
 +
 If you do not see a version number, download and install link:https://www.gnu.org/software/wget/[Wget^].
 +
 
 . Use either of these package managers to install Hazelcast, depending on your Linux distribution:
 +
-ifdef::snapshot[]
-
 .Debian
-[source,shell]
-----
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
-echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian snapshot main" | sudo tee -a /etc/apt/sources.list
-sudo apt update && sudo apt install hazelcast
-----
-+
-.RPM
-[source,shell]
-----
-wget https://repository.hazelcast.com/rpm/snapshot/hazelcast-rpm.repo -O hazelcast-snapshot-rpm.repo
-sudo mv hazelcast-snapshot-rpm.repo /etc/yum.repos.d/
-sudo yum install hazelcast
-----
-+
-endif::[]
-+
-ifndef::snapshot[]
 
-.Debian
 [source,shell,subs="attributes+"]
 ----
 wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
-sudo apt update && sudo apt install hazelcast={full-version}
+sudo apt update && sudo apt install hazelcast={last-oss-version}
 ----
 +
 .RPM
@@ -107,10 +77,9 @@ sudo apt update && sudo apt install hazelcast={full-version}
 ----
 wget https://repository.hazelcast.com/rpm/stable/hazelcast-rpm-stable.repo -O hazelcast-rpm-stable.repo
 sudo mv hazelcast-rpm-stable.repo /etc/yum.repos.d/
-sudo yum install hazelcast-{full-version}
+sudo yum install hazelcast-{last-oss-version}
 ----
 +
-endif::[]
 --
 Windows::
 +
@@ -160,13 +129,8 @@ Download the latest snapshot archive and extract the binaries.
 Mac:: 
 + 
 --
-ifdef::snapshot[]
-Go to the link:https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/{full-version}/[snapshot repository] and click the download link for the TAR file that has the most up-to-date timestamp in the *Last Modified* columns.
-endif::[]
-ifndef::snapshot[]
 . Download a package from https://hazelcast.com/get-started/download/?utm_source=docs-website[hazelcast.com^].
 . Extract the downloaded package.
-endif::[]
 --
 Linux:: 
 + 
@@ -182,13 +146,8 @@ endif::[]
 Windows:: 
 +
 --
-ifdef::snapshot[]
-Go to the link:https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast-distribution/{full-version}/[snapshot repository] and click the download link for the ZIP file that has the most up-to-date timestamp in the *Last Modified* columns.
-endif::[]
-ifndef::snapshot[]
 . Download a package from https://hazelcast.com/get-started/download/?utm_source=docs-website[hazelcast.com^].
 . Extract the downloaded package.
-endif::[]
 --
 ====
 // end::binary[]
@@ -219,41 +178,18 @@ The Java package includes both a member API and a Java client API. The member AP
 +
 --
 // tag::maven-full[]
-ifdef::snapshot[]
-[source,xml,subs="attributes+"]
-----
-<repositories>
-    <repository>
-        <id>snapshot-repository</id>
-        <name>Maven2 Snapshot Repository</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        <releases>
-            <enabled>false</enabled>
-        </releases>
-    </repository>
-</repositories>
 
-<dependencies>
-   <dependency>
-       <groupId>com.hazelcast</groupId>
-       <artifactId>hazelcast</artifactId>
-       <version>{full-version}</version>
-   </dependency>
-</dependencies>
-----
-endif::[]
-ifndef::snapshot[]
 [source,xml,subs="attributes+"]
 ----
 <dependencies>
    <dependency>
        <groupId>com.hazelcast</groupId>
        <artifactId>hazelcast</artifactId>
-       <version>{full-version}</version>
+       <version>{last-oss-version}</version>
    </dependency>
 </dependencies>
 ----
-endif::[]
+
 // end::maven-full[]
 --
 
@@ -264,10 +200,7 @@ endif::[]
 If you aren't using a build tool:
 
 ifdef::snapshot[]
-* link:https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast/{full-version}/[download the Hazelcast JAR file]
-endif::[]
-ifndef::snapshot[]
-* link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{full-version}/hazelcast-{full-version}.jar[download the Hazelcast JAR file]
+* link:https://oss.sonatype.org/content/repositories/snapshots/com/hazelcast/hazelcast/{last-oss-version}/[download the Hazelcast JAR file]
 endif::[]
 * add it to your classpath.
 
@@ -277,7 +210,7 @@ endif::[]
 You can use Hazelcast as a module in the http://openjdk.java.net/projects/jigsaw/[Java Platform Module System] (JPMS).
 
 To run your application with Hazelcast
-libraries on the modulepath, use the `com.hazelcast.core` for `hazelcast-{full-version}.jar` module name.
+libraries on the modulepath, use the `com.hazelcast.core` for `hazelcast-{last-oss-version}.jar` module name.
 
 The JPMS comes with stricter visibility rules. It affects
 Hazelcast which uses the internal Java API to reach the best performance results.
@@ -307,7 +240,7 @@ java --add-modules java.se \
   --add-opens java.management/sun.management=ALL-UNNAMED \
   --add-opens jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED \
   --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
-  -jar hazelcast-{full-version}.jar
+  -jar hazelcast-{last-oss-version}.jar
 ----
 
 .Running a Member on the Modulepath
@@ -324,7 +257,7 @@ java --add-modules java.se \
   --module-path lib \ <1>
   --module com.hazelcast.core/com.hazelcast.core.server.HazelcastMemberStarter
 ----
-<1> This example expects the `hazelcast-{full-version}.jar` file in the `lib` directory.
+<1> This example expects the `hazelcast-{last-oss-version}.jar` file in the `lib` directory.
 
 // end::modular[]
 


### PR DESCRIPTION
- Introduced property to set last OSS version (it can be different than EE version)
- removed all snapshot version-related parts from OSS install guide