### PR TITLE
Remove hardcoded `Editions` content [DI-333]

### DIFF
--- a/docs/modules/getting-started/pages/editions.adoc
+++ b/docs/modules/getting-started/pages/editions.adoc
@@ -58,97 +58,14 @@ You can find more information on installing the Hazelcast editions in the follow
 
 The full distribution contains all available Hazelcast connectors, libraries, and Management Center.
 
-.What's included in the full distribution
+.Full distribution content explanation
 [%collapsible]
 ====
-[source,plain,subs="attributes+"]
-----
-├── LICENSE
-├── NOTICE
-├── bin
-│   ├── common.sh
-│   ├── hz-cli
-│   ├── hz-cli.bat
-│   ├── hz-cluster-admin
-│   ├── hz-cluster-cp-admin
-│   ├── hz-healthcheck
-│   ├── hz-start
-│   ├── hz-start.bat
-│   ├── hz-stop
-│   └── hz-stop.bat
-├── config
-│   ├── examples
-│   │   ├── hazelcast-client-full-example.xml
-│   │   ├── hazelcast-client-full-example.yaml
-│   │   ├── hazelcast-client.yaml
-│   │   ├── hazelcast-full-example.xml
-│   │   ├── hazelcast-full-example.yaml
-│   │   ├── hazelcast-security-hardened.yaml
-│   │   └── hazelcast.yaml
-│   ├── hazelcast-client.xml
-│   ├── hazelcast.xml
-│   ├── jmx_agent_config.yaml
-│   ├── jvm-client.options
-│   ├── jvm.options
-│   └── log4j2.properties
-├── custom-lib
-│   ├── hazelcast-3-connector-impl-{full-version}.jar
-│   ├── hazelcast-3.12.12.jar
-│   └── hazelcast-client-3.12.12.jar
-├── lib
-│   ├── cache-api-1.1.1.jar
-│   ├── hazelcast-3-connector-common-{full-version}.jar
-│   ├── hazelcast-3-connector-interface-{full-version}.jar
-│   ├── hazelcast-{full-version}.jar
-│   ├── hazelcast-download.properties
-│   ├── hazelcast-hibernate53-2.1.1.jar
-│   ├── hazelcast-jet-avro-{full-version}.jar
-│   ├── hazelcast-jet-cdc-debezium-{full-version}.jar
-│   ├── hazelcast-jet-cdc-mysql-{full-version}.jar
-│   ├── hazelcast-jet-cdc-postgres-{full-version}.jar
-│   ├── hazelcast-jet-csv-{full-version}.jar
-│   ├── hazelcast-jet-elasticsearch-7-{full-version}.jar
-│   ├── hazelcast-jet-files-azure-{full-version}.jar
-│   ├── hazelcast-jet-files-gcs-{full-version}.jar
-│   ├── hazelcast-jet-files-s3-{full-version}.jar
-│   ├── hazelcast-jet-grpc-{full-version}.jar
-│   ├── hazelcast-jet-hadoop-all-{full-version}.jar
-│   ├── hazelcast-jet-kafka-{full-version}.jar
-│   ├── hazelcast-jet-kinesis-{full-version}.jar
-│   ├── hazelcast-jet-protobuf-{full-version}.jar
-│   ├── hazelcast-jet-python-{full-version}.jar
-│   ├── hazelcast-jet-s3-{full-version}.jar
-│   ├── hazelcast-sql-{full-version}.jar
-│   ├── hazelcast-wm-4.0.jar
-│   ├── jansi-2.1.0.jar
-│   ├── jline-reader-3.19.0.jar
-│   ├── jline-terminal-3.19.0.jar
-│   ├── jline-terminal-jansi-3.19.0.jar
-│   ├── jmx_prometheus_javaagent-0.14.0.jar
-│   ├── log4j-api-2.14.0.jar
-│   ├── log4j-core-2.14.0.jar
-│   ├── log4j-slf4j-impl-2.14.0.jar
-│   ├── picocli-3.9.0.jar
-│   └── slf4j-api-1.7.30.jar
-└── licenses
-    ├── THIRD-PARTY.txt
-    ├── apache-v2-license.
-    ├── attribution.txt
-    └── hazelcast-community-license.txt
-├── management-center
-│   ├── ThirdPartyNotices.txt
-│   ├── bin
-│   │   ├── mc-conf.bat
-│   │   ├── mc-conf.sh
-│   │   ├── mc-start.cmd
-│   │   ├── mc-start.sh
-│   │   ├── start.bat
-│   │   ├── start.sh
-│   │   └── user-lib
-│   ├── hazelcast-management-center-{full-version}.jar
-│   └── license.txt
-└── release_notes.txt
-----
+- `bin` — utility scripts for application management
+// - `config` - application configuration files (including reference examples)
+- `lib` — application and dependency binaries
+- `custom-lib` — directory where custom classpath contents can be provided for a Jet pipeline stage, default location of the xref:ROOT:system-properties.adoc[`hazelcast.jet.custom.lib.dir`] property
+- `management-center` — bundled Management Center distribution
 ====
 
 === Slim Distribution
@@ -157,59 +74,10 @@ The slim distribution allows you to save memory by excluding Management Center a
 
 To install a slim distribution, you can use any of the available installation options by appending `-slim` to the version number in the command; for example, to install the slim distribution of {full-version}, use `{full-version}-slim`.
 
-.What's included in the slim distribution
+.Slim distribution content explanation
 [%collapsible]
 ====
-[source,plain,subs="attributes+"]
-----
-├── LICENSE
-├── NOTICE
-├── bin
-│   ├── common.sh
-│   ├── hz-cli
-│   ├── hz-cli.bat
-│   ├── hz-cluster-admin
-│   ├── hz-cluster-cp-admin
-│   ├── hz-healthcheck
-│   ├── hz-start
-│   ├── hz-start.bat
-│   ├── hz-stop
-│   └── hz-stop.bat
-├── config
-│   ├── examples
-│   │   ├── hazelcast-client-full-example.xml
-│   │   ├── hazelcast-client-full-example.yaml
-│   │   ├── hazelcast-client.yaml
-│   │   ├── hazelcast-full-example.xml
-│   │   ├── hazelcast-full-example.yaml
-│   │   ├── hazelcast-security-hardened.yaml
-│   │   └── hazelcast.yaml
-│   ├── hazelcast-client.xml
-│   ├── hazelcast.xml
-│   ├── jmx_agent_config.yaml
-│   ├── jvm-client.options
-│   ├── jvm.options
-│   └── log4j2.properties
-├── lib
-│   ├── cache-api-1.1.1.jar
-│   ├── hazelcast-{full-version}.jar
-│   ├── hazelcast-download.properties
-│   ├── hazelcast-hibernate53-2.1.1.jar
-│   ├── hazelcast-sql-{full-version}.jar
-│   ├── hazelcast-wm-4.0.jar
-│   ├── jansi-2.1.0.jar
-│   ├── jline-reader-3.19.0.jar
-│   ├── jline-terminal-3.19.0.jar
-│   ├── jline-terminal-jansi-3.19.0.jar
-│   ├── jmx_prometheus_javaagent-0.14.0.jar
-│   ├── log4j-api-2.14.0.jar
-│   ├── log4j-core-2.14.0.jar
-│   ├── log4j-slf4j-impl-2.14.0.jar
-│   ├── picocli-3.9.0.jar
-│   └── slf4j-api-1.7.30.jar
-└── licenses
-    ├── THIRD-PARTY.txt
-    ├── apache-v2-license.txt
-    └── hazelcast-community-license.txt
-----
+- `bin` — utility scripts for application management
+// - `config` - application configuration files (including reference examples)
+- `lib` — application and dependency binaries
 ====

--- a/docs/modules/getting-started/pages/editions.adoc
+++ b/docs/modules/getting-started/pages/editions.adoc
@@ -63,7 +63,6 @@ The full distribution contains all available Hazelcast connectors, libraries, an
 ====
 - `bin` — utility scripts for application management
 - `config` - application configuration files (including reference examples)
-- `custom-lib` — directory where custom classpath contents can be provided for a Jet pipeline stage, default location of the xref:ROOT:system-properties.adoc[`hazelcast.jet.custom.lib.dir`] property
 - `lib` — application and dependency binaries
 - `licenses` — application and dependency licenses
 - `management-center` — bundled Management Center distribution

--- a/docs/modules/getting-started/pages/editions.adoc
+++ b/docs/modules/getting-started/pages/editions.adoc
@@ -62,9 +62,10 @@ The full distribution contains all available Hazelcast connectors, libraries, an
 [%collapsible]
 ====
 - `bin` — utility scripts for application management
-// - `config` - application configuration files (including reference examples)
-- `lib` — application and dependency binaries
+- `config` - application configuration files (including reference examples)
 - `custom-lib` — directory where custom classpath contents can be provided for a Jet pipeline stage, default location of the xref:ROOT:system-properties.adoc[`hazelcast.jet.custom.lib.dir`] property
+- `lib` — application and dependency binaries
+- `licenses` — application and dependency licenses
 - `management-center` — bundled Management Center distribution
 ====
 
@@ -78,6 +79,7 @@ To install a slim distribution, you can use any of the available installation op
 [%collapsible]
 ====
 - `bin` — utility scripts for application management
-// - `config` - application configuration files (including reference examples)
+- `config` - application configuration files (including reference examples)
 - `lib` — application and dependency binaries
+- `licenses` — application and dependency licenses
 ====


### PR DESCRIPTION
The `Editions` page features a content listing of the various distributions,down to the exact filename of the JAR dependencies. This has not been maintained and become outdated.

The listing also doesn't explain what the contents are _actually for_.

There have been [discussions over the value of this content](https://hazelcast.slack.com/archives/C07066ELRRD/p1730463734768339), and as such updated it to provide a higher level summary.

Fixes: https://github.com/hazelcast/hz-docs/issues/1346, [DI-333](https://hazelcast.atlassian.net/browse/DI-333)

[DI-333]: https://hazelcast.atlassian.net/browse/DI-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ