### PR TITLE
Fix schema version definition in `understanding-configuration`

### DIFF
--- a/docs/modules/configuration/pages/understanding-configuration.adoc
+++ b/docs/modules/configuration/pages/understanding-configuration.adoc
@@ -23,7 +23,7 @@ The following topics are also relevant to static configuration:
 - xref:pattern-matcher.adoc[Configuration Pattern Matcher]
 - xref:using-wildcards.adoc[Using Wildcards]
 
-NOTE: Hazelcast performs schema validation through the `hazelcast-config-{full-version}.xsd` file,
+NOTE: Hazelcast performs schema validation through the `hazelcast-config-{minor-version}.xsd` file,
 which comes with Hazelcast libraries. If an error occurs in declarative or programmatic configuration, Hazelcast throws a meaningful exception.
 
 Static configuration cannot be changed at runtime. However, you can add <<dynamic-configuration, dynamic configuration>> for some features.


### PR DESCRIPTION
On [this page](https://docs.hazelcast.com/hazelcast/latest/configuration/understanding-configuration#static-configuration) the configuration references a schema named `hazelcast-config-5.5.2.xsd`, but the schemas are [actually only major-minor versioned](https://github.com/hazelcast/hazelcast/tree/master/hazelcast/src/main/resources).