### PR TITLE
Update backing-up-maps.adoc

### DIFF
--- a/docs/modules/data-structures/pages/backing-up-maps.adoc
+++ b/docs/modules/data-structures/pages/backing-up-maps.adoc
@@ -143,7 +143,7 @@ hazelcast:
 
 Hazelcast offers several features for backing up your in-memory maps to files located on the local cluster member disk, in persistent memory, or to a system of record such as an external database. 
 
-* xref:storage:persistence.adoc[Persistence] provides for data recovery in the event of a planned or unplanned complete cluster shutdown. When enabled, each cluster member periodically writes a copy of all local map data to either the local disk drive or to persistent memory. When the cluster is restarted, each member reads the stored data back into memory. If all cluster members successfully recover the stored data, cluster operations resume as usual.
+* xref:storage:persistence.adoc[Persistence] provides for data recovery in the event of a planned or unplanned complete cluster shutdown. When enabled, each cluster member periodically writes a copy of all local map data to the local disk drive. When the cluster is restarted, each member reads the stored data back into memory. If all cluster members successfully recover the stored data, cluster operations resume as usual.
 
 * xref:mapstore:working-with-external-data.adoc[MapStore] provides for automatic write-through of map changes to an external system, and automatic loading of data from that external system when an application calls a map. Although this can function as a data safety feature, the primary purpose of MapStore is to maintain synchronization between a system of record and the in-memory map. 
 


### PR DESCRIPTION
removed "or to persistent memory" (and the 'either') as per the docs ticket