### PR TITLE
Add note that all clients can view proxy names & types

### DIFF
--- a/docs/modules/security/pages/client-authorization.adoc
+++ b/docs/modules/security/pages/client-authorization.adoc
@@ -181,6 +181,11 @@ decides whether the current `Subject` has permission to access the requested res
 
 == Permissions
 
+All Hazelcast clients authorized to connect to a cluster are able to receive proxy information
+for data structures present on the cluster. This proxy only provides the client with the
+data structure's type and name. Permissions for other actions related to these data structures
+can be configured as required.
+
 The following is the list of client permissions that can be configured on the member:
 
 === All permissions


### PR DESCRIPTION
We had a customer raise this caveat in https://hazelcast.atlassian.net/browse/SUP-661 - as per my comment in this ticket, changing this behaviour is a significant ask due to Hazelcast's proxy based foundations.

Fixes https://hazelcast.atlassian.net/browse/HZG-249