### PR TITLE
Revert "Remove hardcoded `Editions` content [DI-333] (#1359)" [5.0]

### DIFF
--- a/docs/modules/getting-started/pages/editions.adoc
+++ b/docs/modules/getting-started/pages/editions.adoc
@@ -44,47 +44,8 @@ source and closed source applications.
 
 == Enterprise License
 
-== Full and Slim Distributions
-[[full-slim]]
-
-The following installation options offer a full and slim distribution:
-
-- Docker
-- ZIP/TAR Binaries
-- Java
-
-Other installation options offer only the full distribution.
-
-You can find more information on installing the Hazelcast editions in the following topics:
-
-* For the {enterprise-product-name}, see the xref:install-enterprise.adoc[] topic
-* For the {open-source-product-name}, see the xref:install-hazelcast.adoc[] topic
-
-=== Full Distribution
-
-The full distribution contains all available Hazelcast connectors, libraries, and Management Center.
-
-.Full distribution content explanation
-[%collapsible]
-====
-- `bin` — utility scripts for application management
-- `config` - application configuration files (including reference examples)
-- `lib` — application and dependency binaries
-- `licenses` — application and dependency licenses
-- `management-center` — bundled Management Center distribution
-====
-
-=== Slim Distribution
-
-The slim distribution allows you to save memory by excluding Management Center and connectors. You add the additional components as required.
-
-To install a slim distribution, you can use any of the available installation options by appending `-slim` to the version number in the command; for example, to install the slim distribution of {full-version}, use `{full-version}-slim`.
-
-.Slim distribution content explanation
-[%collapsible]
-====
-- `bin` — utility scripts for application management
-- `config` - application configuration files (including reference examples)
-- `lib` — application and dependency binaries
-- `licenses` — application and dependency licenses
-====
+Hazelcast Enterprise edition is a commercial product of Hazelcast, Inc. and distributed under
+a commercial license that must be acquired
+before using it in any type of released software. Feel free to contact
+http://hazelcast.com/contact/[Hazelcast sales department^]
+for more information about commercial offers.


### PR DESCRIPTION
This reverts commit 65d7038de5d677aac12ad0ef95d61890f501064b.

Backported from https://github.com/hazelcast/hz-docs/pull/1359 but introduced references to documents not found in this version. As it's a non-maintenance branch, no changes were even required - reverted.