### PR TITLE
Update capacity-planning.adoc to reflect ZGC being production ready

### DIFF
--- a/docs/modules/ROOT/pages/capacity-planning.adoc
+++ b/docs/modules/ROOT/pages/capacity-planning.adoc
@@ -542,9 +542,7 @@ collector. We found it to work well without any tuning parameters. Its
 current downside is that it handles less throughput compared to G1 and,
 being non-generational, doesn't work well if you have a lot of static
 data on the heap (for example, if your data pipeline has a `hashJoin`
-stage). ZGC is an experimental collector under intense development, so
-you can expect further improvements, including generational GC behavior,
-in the future.
+stage).
 
 In our tests we found that as of JDK version 14.0.2, the other
 low-latency collector, Shenandoah, still did not perform as well as ZGC


### PR DESCRIPTION
ZGC was declared [production ready](https://wiki.openjdk.org/display/zgc/Main) as of JDK 15.