### PR TITLE
Make backporting action use PRs to support protected branches [DOC-268]

### DIFF
--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -10,9 +10,6 @@ on:
         required: true
         type: string
 
-env:
-  REPO_LOCATION: repo
-
 jobs:
   backport:
     runs-on: ubuntu-latest
@@ -35,13 +32,11 @@ jobs:
         with:
           # ensure the backport target branch is checked out, too
           fetch-depth: 0
-          path: ${{ env.REPO_LOCATION }}
 
       - if: ${{ steps.check_pr_labels.outputs.result == 'true' }}
         uses: hazelcast/backport/.github/actions/backport@main
         with:
           GITHUB_TOKEN: ${{ github.token }}
-          REPO_LOCATION: ${{ env.REPO_LOCATION }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           REF_TO_BACKPORT: ${{ github.sha }}
           BACKPORT_OPTIONS: --omit-labels

--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -43,5 +43,5 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           REPO_LOCATION: ${{ env.REPO_LOCATION }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
-          COMMIT_SHA: ${{ github.sha }}
+          REF_TO_BACKPORT: ${{ github.sha }}
           BACKPORT_OPTIONS: --omit-labels

--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -15,6 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Print accessible environment variables
+        if: runner.debug == '1'
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "${GITHUB_CONTEXT}"
+          printenv
+
       - name: Check PR for backport label
         id: check_pr_labels
         uses: shioyang/check-pr-labels-on-push-action@v1.0.12
@@ -29,15 +37,36 @@ jobs:
         if: ${{ steps.check_pr_labels.outputs.result == 'true' }}
         uses: actions/checkout@v4
         with:
+          # ensure the backport target branch is checked out, too
           fetch-depth: 0
+          path: repo
+
+      - name: Checkout Backport tool
+        if: ${{ steps.check_pr_labels.outputs.result == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          repository: hazelcast/backport
+          path: backport
 
       - name: Checkout maintenance branch and cherry-pick
         if: ${{ steps.check_pr_labels.outputs.result == 'true' }}
+        working-directory: repo
         run: |
+          # Git metadata is required but not available out-of-the-box, inherit from the action
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-          git fetch
-          git checkout ${{ inputs.target-branch }}
-          git cherry-pick -x --strategy=recursive -X theirs $GITHUB_SHA
-          git push
+          # Add "upstream" remote as checkout action doesn't include by default
+          git remote add upstream "${{ github.event.repository.clone_url }}"
+          git fetch --all
+
+          backport_target_branch=upstream/"${{ inputs.target-branch }}"
+          echo "::debug::Running backport script to backport "${GITHUB_SHA}" into \"${backport_target_branch}\""
+
+          ${GITHUB_WORKSPACE}/backport/backport \
+            "${GITHUB_SHA}" \
+            "${backport_target_branch}" \
+            --non-interactive \
+            --omit-labels
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+env:
+  REPO_LOCATION: repo
+
 jobs:
   backport:
     runs-on: ubuntu-latest
@@ -23,6 +26,7 @@ jobs:
           labels: ${{ inputs.label-to-check-for }}
 
       - name: See result
+        if: runner.debug == '1'
         run: echo "${{ steps.check_pr_labels.outputs.result }}"
 
       - name: Checkout repository
@@ -31,34 +35,13 @@ jobs:
         with:
           # ensure the backport target branch is checked out, too
           fetch-depth: 0
-          path: repo
+          path: ${{ env.REPO_LOCATION }}
 
-      - name: Checkout Backport tool
-        if: ${{ steps.check_pr_labels.outputs.result == 'true' }}
-        uses: actions/checkout@v4
+      - if: ${{ steps.check_pr_labels.outputs.result == 'true' }}
+        uses: hazelcast/backport/.github/actions/backport@main
         with:
-          repository: hazelcast/backport
-          path: backport
-
-      - name: Checkout maintenance branch and cherry-pick
-        if: ${{ steps.check_pr_labels.outputs.result == 'true' }}
-        working-directory: repo
-        run: |
-          # Git metadata is required but not available out-of-the-box, inherit from the action
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-
-          # Add "upstream" remote as checkout action doesn't include by default
-          git remote add upstream "${{ github.event.repository.clone_url }}"
-          git fetch --all
-
-          backport_target_branch=upstream/"${{ inputs.target-branch }}"
-          echo "::debug::Running backport script to backport "${GITHUB_SHA}" into \"${backport_target_branch}\""
-
-          ${GITHUB_WORKSPACE}/backport/backport \
-            "${GITHUB_SHA}" \
-            "${backport_target_branch}" \
-            --non-interactive \
-            --omit-labels
-        env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO_LOCATION: ${{ env.REPO_LOCATION }}
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+          COMMIT_SHA: ${{ github.sha }}
+          BACKPORT_OPTIONS: --omit-labels

--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -15,14 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Print accessible environment variables
-        if: runner.debug == '1'
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "${GITHUB_CONTEXT}"
-          printenv
-
       - name: Check PR for backport label
         id: check_pr_labels
         uses: shioyang/check-pr-labels-on-push-action@v1.0.12


### PR DESCRIPTION
In [DOC-255](https://hazelcast.atlassian.net/browse/DOC-255), branch protection was added - preventing direct `push`es.

Instead, the backport workflow should create PRs to backport the changes. This gives the _possibility_ for pre-merge checks to be run (i.e. preventing introducing dead links etc).

Leverages [_existing_ `backport` tool](https://github.com/hazelcast/backport), but exposed some issues which need to be addressed **before this can be merged**:
- https://github.com/hazelcast/backport/pull/14
- https://github.com/hazelcast/backport/pull/15
- https://github.com/hazelcast/backport/pull/16
- https://github.com/hazelcast/backport/pull/17

Tested in a [test repo](https://github.com/JackPGreen2/hz-docs), where a [dummy PR](https://github.com/JackPGreen2/hz-docs/pull/5) was [successfully backported](https://github.com/JackPGreen2/hz-docs/pull/16). However, due to the complexity of fork-triggering, it wil need to be re-tested once merged.

Fixes: [DOC-268](https://hazelcast.atlassian.net/browse/DOC-268)

[DOC-255]: https://hazelcast.atlassian.net/browse/DOC-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-268]: https://hazelcast.atlassian.net/browse/DOC-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ