### PR TITLE
Fix incorrect `last-oss-version` property reference

### DIFF
--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -69,7 +69,7 @@ If you do not see a version number, download and install link:https://www.gnu.or
 ----
 wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
-sudo apt update && sudo apt install hazelcast={last-oss-version}
+sudo apt update && sudo apt install hazelcast={os-version}
 ----
 +
 .RPM
@@ -195,7 +195,7 @@ The Java package includes both a member API and a Java client API. The member AP
 If you aren't using a build tool:
 
 ifdef::snapshot[]
-* link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{last-oss-version}/hazelcast-{last-oss-version}/[download the Hazelcast JAR file]
+* link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{os-version}/hazelcast-{os-version}/[download the Hazelcast JAR file]
 endif::[]
 ifndef::snapshot[]
 * link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{full-version}/hazelcast-{full-version}.jar[download the Hazelcast JAR file]


### PR DESCRIPTION
Fixes:
```
[15:12:03.020] WARN (asciidoctor): skipping reference to missing attribute: last-oss-version
    file: /home/runner/work/hz-docs/hz-docs/docs/modules/getting-started/pages/install-hazelcast.adoc
    source: /home/runner/work/hz-docs/hz-docs (branch: HEAD <worktree> | start path: docs)
```