### PR TITLE
Revert "Optimize backport.yml"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -3,17 +3,20 @@ on:
  push:
   branches:
    - main
-
-env:
-  MAINTENANCE_BRANCHES: "['5.3', '5.4', '5.5']"
-
 jobs:
+  get-maintenance-branches:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: "['5.3', '5.4', '5.5']"
+    steps:
+      - run: exit 0
 
   backport-to-all-branch:
+    needs: get-maintenance-branches
     strategy:
       fail-fast: false
       matrix:
-        branch: ${{ fromJSON(env.MAINTENANCE_BRANCHES) }}
+        branch: ${{ fromJSON(needs.get-maintenance-branches.outputs.branches) }}
     uses: ./.github/workflows/backport-workflow.yml
     with:
       label-to-check-for: '["backport to all versions"]'
@@ -21,10 +24,11 @@ jobs:
     secrets: inherit
 
   backport-to-specified-branch:
+    needs: get-maintenance-branches
     strategy:
       fail-fast: false
       matrix:
-        branch: ${{ fromJSON(env.MAINTENANCE_BRANCHES) }}
+        branch: ${{ fromJSON(needs.get-maintenance-branches.outputs.branches) }}
     uses: ./.github/workflows/backport-workflow.yml
     with:
       label-to-check-for: '["backport to ${{ matrix.branch }}"]'


### PR DESCRIPTION
Reverts hazelcast/hz-docs#1403

[`env` is only available in workflow _`steps`_, so isn't accessible for matrix specification](https://stackoverflow.com/a/74073435).

Fixes: https://github.com/hazelcast/hazelcast-platform-operator-docs/pull/277