### PR TITLE
Fix `id assigned to anchor already in use: columns` warning [DOC-260]

### DIFF
--- a/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
+++ b/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
@@ -394,7 +394,7 @@ mapConfig.setMapStoreConfig(mapStoreConfig);
 --
 ====
 
-|[[columns]]`type-name`
+|[[type-name]]`type-name`
 |The type name of the compact GenericRecord. Use this property to map your record to an existing domain class.
 
 |


### PR DESCRIPTION
Fix [warning during build](https://github.com/hazelcast/hz-docs/pull/1399/checks)

_Partially_ addresses: [DOC-260](https://hazelcast.atlassian.net/browse/DOC-260)

[DOC-260]: https://hazelcast.atlassian.net/browse/DOC-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ