### PR TITLE
Add note about limit indirectly impacting quality [AI-269]

### DIFF
--- a/docs/modules/data-structures/pages/vector-collections.adoc
+++ b/docs/modules/data-structures/pages/vector-collections.adoc
@@ -611,9 +611,9 @@ By default, the vector values are not included. To include the vector values, se
 
 |===
 
-NOTE: Larger `limit` makes it more likely to find better results which are not found with smaller `limit`. Even the truly closest neighbour may be found only with sufficiently large `limit`.
-This can be unexpected if you try to compare the search results with different `limit`: one is not guaranteed to be the subset of another.
-The precision, especially with smaller `limit` values can be fine-tuned using hints.
+NOTE: Using a larger `limit` may yield better results than with a smaller `limit` — for example, the nearest neighbor may only be found with a sufficiently large `limit`. 
+This can be unexpected if you are trying to compare search results that use a different `limit`, since one is not guaranteed to be a subset of another. 
+For precision, especially with smaller `limit` values, use hints as a means of fine-tuning.
 
 .Available hints
 [cols="1,2",options="header"]

--- a/docs/modules/data-structures/pages/vector-collections.adoc
+++ b/docs/modules/data-structures/pages/vector-collections.adoc
@@ -609,6 +609,10 @@ By default, the vector values are not included. To include the vector values, se
 |Extra hints for the search.
 |`NULL`
 
+NOTE: Larger `limit` makes it more likely to find better results which are not found with smaller `limit`. Even the truly closest neighbour may be found only with sufficiently large `limit`.
+This can be unexpected if you try to compare the search results with different `limit`: one is not guaranteed to be the subset of another.
+The precision, especially with smaller `limit` values can be fine-tuned using hints.
+
 |===
 
 
@@ -645,7 +649,7 @@ var options = SearchOptions.builder()
 --
 ====
 
-INFORMATION: Hints allow fine-tuning for some aspects of search execution but are subject to change and may be removed in future versions.
+NOTE: Hints allow fine-tuning for some aspects of search execution but are subject to change and may be removed in future versions.
 
 == Manage collection
 

--- a/docs/modules/data-structures/pages/vector-collections.adoc
+++ b/docs/modules/data-structures/pages/vector-collections.adoc
@@ -613,7 +613,7 @@ By default, the vector values are not included. To include the vector values, se
 
 NOTE: Using a larger `limit` may yield better results than with a smaller `limit` — for example, the nearest neighbor may only be found with a sufficiently large `limit`. 
 This can be unexpected if you are trying to compare search results that use a different `limit`, since one is not guaranteed to be a subset of another. 
-For precision, especially with smaller `limit` values, use hints as a means of fine-tuning.
+You can use hints to fine-tune search precision, especially with smaller `limit` values.
 
 .Available hints
 [cols="1,2",options="header"]

--- a/docs/modules/data-structures/pages/vector-collections.adoc
+++ b/docs/modules/data-structures/pages/vector-collections.adoc
@@ -609,12 +609,11 @@ By default, the vector values are not included. To include the vector values, se
 |Extra hints for the search.
 |`NULL`
 
+|===
+
 NOTE: Larger `limit` makes it more likely to find better results which are not found with smaller `limit`. Even the truly closest neighbour may be found only with sufficiently large `limit`.
 This can be unexpected if you try to compare the search results with different `limit`: one is not guaranteed to be the subset of another.
 The precision, especially with smaller `limit` values can be fine-tuned using hints.
-
-|===
-
 
 .Available hints
 [cols="1,2",options="header"]


### PR DESCRIPTION
During investigation of https://hazelcast.atlassian.net/browse/AI-269 it was uncovered that `limit` impact on search quality is nonintuitive and unexpected.

More detailed description will follow later, as part of 6.0 changes, in particular `efSearch` hint and `paritionLimit` heuristics. The part described in this PR applies equally to 5.5 and 6.0 although in a slightly different way under the hood.