### PR TITLE
Add warning about WAN sync ignores WAN filters

### DIFF
--- a/docs/modules/wan/pages/advanced-features.adoc
+++ b/docs/modules/wan/pages/advanced-features.adoc
@@ -891,6 +891,16 @@ WAN event replication queues by providing a filtering API.
 Using this API, you can monitor WAN replication events of each data structure
 separately.
 
+WAN replication adheres strictly to the filtering rules defined, ensuring that only the
+specified data flows between clusters. Filters can be configured to include or exclude
+specific map entries based on criteria such as keys, values, or custom rules. This allows
+for precise control over where the data is transferred and can be configured for compliance,
+regulatory, or other business requirements.
+
+WARNING: WAN synchronization is designed to synchronize entire data sets between clusters
+without applying any filtering rules. It aims to recover or reestablish consistency across
+clusters by replicating all entries, regardless of existing filters.
+
 You can attach filters to your data structures using the `filter` element of
 `wan-replication-ref` configuration inside `hazelcast.xml` as shown below.
 You can also configure it using the programmatic configuration.


### PR DESCRIPTION
This PR updates the WAN event filtering API documentation to: A) sell the feature a bit more by expanding on its uses, and B) warn that WAN synchronizations ignore WAN filters.

Fixes https://hazelcast.atlassian.net/browse/HZG-269