### PR TITLE
Fix Backport workflow action branch specification

### DIFF
--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - if: ${{ steps.check_pr_labels.outputs.result == 'true' }}
-        uses: hazelcast/backport/.github/actions/backport@main
+        uses: hazelcast/backport/.github/actions/backport@master
         with:
           GITHUB_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}


### PR DESCRIPTION
Backport’s default branch is master, not main.

[Slack discussion](https://hazelcast.slack.com/archives/C035HQET5/p1733245920694469).