### PR TITLE
Ensure docker versions are correct for OS/EE [DOC-238]

### DIFF
--- a/docs/modules/deploy/pages/deploying-with-docker.adoc
+++ b/docs/modules/deploy/pages/deploying-with-docker.adoc
@@ -26,8 +26,8 @@ Members will discover and connect to each other automatically only if your local
 --
 [source,bash,subs="attributes+"]
 ----
-docker run --rm --network host --name member1 hazelcast/hazelcast:{full-version}
-docker run --rm --network host --name member2 hazelcast/hazelcast:{full-version}
+docker run --rm --network host --name member1 hazelcast/hazelcast:{os-version}
+docker run --rm --network host --name member2 hazelcast/hazelcast:{os-version}
 ----
 --
 {enterprise-product-name}:: 
@@ -35,8 +35,8 @@ docker run --rm --network host --name member2 hazelcast/hazelcast:{full-version}
 --
 [source,bash,subs="attributes+"]
 ----
-docker run --rm --network host --name member1 hazelcast/hazelcast-enterprise:{full-version}
-docker run --rm --network host --name member2 hazelcast/hazelcast-enterprise:{full-version}
+docker run --rm --network host --name member1 hazelcast/hazelcast-enterprise:{ee-version}
+docker run --rm --network host --name member2 hazelcast/hazelcast-enterprise:{ee-version}
 ----
 --
 ====
@@ -104,7 +104,7 @@ hazelcast:
 [source,bash,subs="attributes+"]
 ----
 docker run --rm --name member1 \
-  -e HZ_NETWORK_PUBLICADDRESS=192.168.1.12:5701 -p 5701:5701 hazelcast/hazelcast:{full-version}
+  -e HZ_NETWORK_PUBLICADDRESS=192.168.1.12:5701 -p 5701:5701 hazelcast/hazelcast:{os-version}
 ----
 
 . Start another member on the second host.
@@ -112,7 +112,7 @@ docker run --rm --name member1 \
 [source,bash,subs="attributes+"]
 ----
 docker run --rm --name member1 \
-  -e HZ_NETWORK_PUBLICADDRESS=192.168.1.13:5701 -p 5701:5701 hazelcast/hazelcast:{full-version}
+  -e HZ_NETWORK_PUBLICADDRESS=192.168.1.13:5701 -p 5701:5701 hazelcast/hazelcast:{os-version}
 ----
 
 In the member logs, you should see that your members connected to each other:
@@ -147,7 +147,7 @@ GB assigned to the JVM:
 
 [source,bash,subs="attributes+"]
 ----
-docker run --memory 2g --rm hazelcast/hazelcast:{full-version}
+docker run --memory 2g --rm hazelcast/hazelcast:{os-version}
 ----
 
 === JAVA_OPTS
@@ -157,7 +157,7 @@ variable. Hazelcast passes it to the JVM when starting. For example:
 
 [source,bash,subs="attributes+"]
 ----
-docker run --memory 2g -e JAVA_OPTS="-XX:MaxRAMPercentage=85.0" --rm hazelcast/hazelcast:{full-version}
+docker run --memory 2g -e JAVA_OPTS="-XX:MaxRAMPercentage=85.0" --rm hazelcast/hazelcast:{os-version}
 ----
 
 Make sure to leave enough free RAM for metaspace and other overheads.
@@ -170,7 +170,7 @@ by replacing the default ones in the container at
 
 [source,bash,subs="attributes+"]
 ----
-docker run --rm hazelcast/hazelcast:{full-version} \
+docker run --rm hazelcast/hazelcast:{os-version} \
 cat /opt/hazelcast/config/examples/hazelcast-docker.yaml \
 > hazelcast.yml
 ----
@@ -182,7 +182,7 @@ Now edit the file and apply it when starting Hazelcast:
 docker run \
 -v "$(pwd)"/hazelcast.yml:/opt/hazelcast/hazelcast.yml \
 -e HAZELCAST_CONFIG=hazelcast.yml \
--p:5701:5701 hazelcast/hazelcast:{full-version}
+-p:5701:5701 hazelcast/hazelcast:{os-version}
 ----
 
 === Extend Hazelcast's CLASSPATH with Custom JARS and Files
@@ -196,7 +196,7 @@ container, and set the `CLASSPATH` environment variable:
 docker run \
 -v /path/to/ext:/opt/hazelcast/ext \
 -e CLASSPATH="/opt/hazelcast/ext/" \
--p:5701:5701 hazelcast/hazelcast:{full-version}
+-p:5701:5701 hazelcast/hazelcast:{os-version}
 ----
 
 If you have just one file to add, it's simpler to mount it directly to the
@@ -206,7 +206,7 @@ Hazelcast `lib` directory:
 ----
 docker run \
 -v /path/to/my.jar:/opt/hazelcast-jet/lib/my.jar \
--p:5701:5701 hazelcast/hazelcast:{full-version}
+-p:5701:5701 hazelcast/hazelcast:{os-version}
 
 ----
 
@@ -217,7 +217,7 @@ variable:
 
 [source,bash,subs="attributes+"]
 ----
-docker run -e LOGGING_LEVEL=DEBUG hazelcast/hazelcast:{full-version}
+docker run -e LOGGING_LEVEL=DEBUG hazelcast/hazelcast:{os-version}
 ----
 
 Available logging levels are (from highest to lowest): `FATAL`, `ERROR`,
@@ -228,14 +228,14 @@ If you need more control over logging, you can supply your own
 
 [source,bash,subs="attributes+"]
 ----
-docker run --rm hazelcast/hazelcast:{full-version} cat /opt/hazelcast/log4j2.properties > log4j2.properties
+docker run --rm hazelcast/hazelcast:{os-version} cat /opt/hazelcast/log4j2.properties > log4j2.properties
 ----
 
 Edit the file and mount it when starting Hazelcast:
 
 [source,bash,subs="attributes+"]
 ----
-docker run -v /path/to/log4j2.properties:/opt/hazelcast/log4j2.properties hazelcast/hazelcast:{full-version}
+docker run -v /path/to/log4j2.properties:/opt/hazelcast/log4j2.properties hazelcast/hazelcast:{os-version}
 ----
 
 == Building a Custom Image from the Slim Image

--- a/docs/modules/getting-started/pages/authenticate-clients.adoc
+++ b/docs/modules/getting-started/pages/authenticate-clients.adoc
@@ -92,7 +92,7 @@ Run the following command.
 ----
 docker run \
     -p 5701:5701 \
-    -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.yaml" -v ~/config:/opt/hazelcast/config_ext hazelcast/hazelcast-enterprise:{full-version}
+    -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.yaml" -v ~/config:/opt/hazelcast/config_ext hazelcast/hazelcast-enterprise:{ee-version}
 ----
 
 This command starts the member and configures it, using your configuration file.

--- a/docs/modules/getting-started/pages/blue-green.adoc
+++ b/docs/modules/getting-started/pages/blue-green.adoc
@@ -54,7 +54,7 @@ docker run \
     -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5701 \ <1>
     -e HZ_CLUSTERNAME=blue \
     -e HZ_LICENSEKEY=<your license key> \ <2>
-    -p 5701:5701 hazelcast/hazelcast-enterprise:{full-version}
+    -p 5701:5701 hazelcast/hazelcast-enterprise:{ee-version}
 ----
 <1> Replace the `<host_ip>` placeholder with the IP address of your Docker host.
 <2> Replace the `<your license key>` placeholder with your Hazelcast {enterprise-product-name} license key.
@@ -84,7 +84,7 @@ docker run \
     -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5702 \ <1>
     -e HZ_CLUSTERNAME=green \
     -e HZ_LICENSEKEY=<your license key> \ <2>
-    -p 5702:5701 hazelcast/hazelcast-enterprise:{full-version}
+    -p 5702:5701 hazelcast/hazelcast-enterprise:{ee-version}
 ----
 <1> Replace the `<host_ip>` placeholder with the IP address of your Docker host.
 <2> Replace the `<your license key>` placeholder with your Hazelcast {enterprise-product-name} license key.

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -38,7 +38,7 @@ docker run \
     --rm \
     -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5701 \
     -e HZ_CLUSTERNAME=hello-world \
-    -p 5701:5701 hazelcast/hazelcast:{full-version}
+    -p 5701:5701 hazelcast/hazelcast:{os-version}
 ----
 +
 Hazelcast environment variables:
@@ -72,7 +72,7 @@ Replace the `<host_ip>` placeholder with the IP address of your Docker host.
 +
 [source,shell,subs="attributes+"]
 ----
-docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{full-version} hz-cli --targets hello-world@<host_ip> sql
+docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{os-version} hz-cli --targets hello-world@<host_ip> sql
 ----
 +
 The `--targets` parameter tells the SQL shell to connect to the member at the given IP address in a cluster called `hello-world`.
@@ -366,7 +366,7 @@ Replace the `<host_ip>` placeholder with the IP address of your Docker host.
 +
 [source,shell,subs="attributes+"]
 ----
-docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{full-version} hz-cli --targets hello-world@<host_ip> sql
+docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{os-version} hz-cli --targets hello-world@<host_ip> sql
 ----
 
 . Query all data in the map.
@@ -660,7 +660,7 @@ docker run \
     --name my-second-member --network hazelcast-network \
     -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5702 \
     -e HZ_CLUSTERNAME=hello-world \
-    -p 5702:5701 hazelcast/hazelcast:{full-version}
+    -p 5702:5701 hazelcast/hazelcast:{os-version}
 ----
 
 . Start another member.
@@ -673,7 +673,7 @@ docker run \
     --name my-third-member --network hazelcast-network \
     -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5703 \
     -e HZ_CLUSTERNAME=hello-world \
-    -p 5703:5701 hazelcast/hazelcast:{full-version}
+    -p 5703:5701 hazelcast/hazelcast:{os-version}
 ----
 +
 You should see that your members find and connect to each other automatically to form your `hello-world` cluster. You can learn more about how members do this in xref:clusters:discovery-mechanisms.adoc[].

--- a/docs/modules/getting-started/pages/get-started-rest-api-with-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-rest-api-with-docker.adoc
@@ -92,7 +92,7 @@ Using XML Config::
 ----
 docker run \
     -p 5701:5701 -p 8443:8443\
-    -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.xml" -v ~/config:/opt/hazelcast/config_ext hazelcast/hazelcast-enterprise:{full-version}
+    -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.xml" -v ~/config:/opt/hazelcast/config_ext hazelcast/hazelcast-enterprise:{ee-version}
 ----
 --
 
@@ -102,7 +102,7 @@ Using YAML Config::
 ----
 docker run \
     -p 5701:5701 -p 8443:8443\
-    -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.yaml" -v ~/config:/opt/hazelcast/config_ext hazelcast/hazelcast-enterprise:{full-version}
+    -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.yaml" -v ~/config:/opt/hazelcast/config_ext hazelcast/hazelcast-enterprise:{ee-version}
 ----
 ====
 

--- a/docs/modules/getting-started/pages/persistence.adoc
+++ b/docs/modules/getting-started/pages/persistence.adoc
@@ -47,7 +47,7 @@ docker run \
     -e HZ_PERSISTENCE_ENABLED=true \ <3>
     -e HZ_MAP_MYDISTRIBUTEDMAP_DATAPERSISTENCE_ENABLED=true \ <4>
     -v ~/persist:/opt/hazelcast/persistence \ <5>
-    -p 5701:5701 hazelcast/hazelcast-enterprise:{full-version}
+    -p 5701:5701 hazelcast/hazelcast-enterprise:{ee-version}
 ----
 <1> Replace the `<host_ip>` placeholder with the IP address of your Docker host.
 <2> Replace the `<your license key>` placeholder with your Hazelcast {enterprise-product-name} license key.
@@ -91,7 +91,7 @@ docker run \
     -e HZ_PERSISTENCE_ENABLED=true \
     -e HZ_MAP_MYDISTRIBUTEDMAP_DATAPERSISTENCE_ENABLED=true \
     -v ~/persist:/opt/hazelcast/persistence \
-    -p 5702:5701 hazelcast/hazelcast-enterprise:{full-version}
+    -p 5702:5701 hazelcast/hazelcast-enterprise:{ee-version}
 ----
 
 .Command to start a third member.
@@ -107,7 +107,7 @@ docker run \
     -e HZ_PERSISTENCE_ENABLED=true \
     -e HZ_MAP_MYDISTRIBUTEDMAP_DATAPERSISTENCE_ENABLED=true \
     -v ~/persist:/opt/hazelcast/persistence \
-    -p 5703:5701 hazelcast/hazelcast-enterprise:{full-version}
+    -p 5703:5701 hazelcast/hazelcast-enterprise:{ee-version}
 ----
 
 You can now see all three members are started on the terminal forming a cluster:
@@ -131,7 +131,7 @@ In this step, you'll create a map called `mydistributedmap` with three entries.
 +
 [source,shell]
 ----
-docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{full-version} hz-cli --targets hello-world@<IP address of one of the members> sql
+docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{os-version} hz-cli --targets hello-world@<IP address of one of the members> sql
 ----
 . Create the map.
 +

--- a/docs/modules/getting-started/pages/wan.adoc
+++ b/docs/modules/getting-started/pages/wan.adoc
@@ -46,7 +46,7 @@ docker run \
     -e HZ_NETWORK_PUBLICADDRESS=<host_ip>:5701 \ <1>
     -e HZ_LICENSEKEY=<your license key> \ <2>
     -e HZ_CLUSTERNAME=london \
-    hazelcast/hazelcast-enterprise:{full-version}
+    hazelcast/hazelcast-enterprise:{ee-version}
 ----
 <1> Replace the `<host_ip>` placeholder with the IP address of your Docker host.
 <2> Replace the `<your license key>` placeholder with your Hazelcast {enterprise-product-name} license key.
@@ -123,7 +123,7 @@ XML::
 ----
 docker run \
      --network hazelcast-network \
-     -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.yaml" -v ~/config-tokyo:/opt/hazelcast/config_ext hazelcast/hazelcast-enterprise:{full-version}
+     -e JAVA_OPTS="-Dhazelcast.config=/opt/hazelcast/config_ext/hazelcast.yaml" -v ~/config-tokyo:/opt/hazelcast/config_ext hazelcast/hazelcast-enterprise:{ee-version}
 ----
 
 Here is your other single-member cluster:
@@ -175,7 +175,7 @@ In this step you switch to the SQL shell in a terminal, create a map called `cit
 +
 [source,shell,subs="attributes+"]
 ----
-docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{full-version} hz-cli --targets tokyo@172.18.0.4:5701 sql
+docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{os-version} hz-cli --targets tokyo@172.18.0.4:5701 sql
 ----
 . Once you see the SQL shell (`sql>`), type the following command and press kbd:[Enter] to create the map.
 +

--- a/docs/modules/kubernetes/pages/deploying-in-kubernetes.adoc
+++ b/docs/modules/kubernetes/pages/deploying-in-kubernetes.adoc
@@ -50,9 +50,9 @@ Kubectl::
 ----
 kubectl apply -f https://raw.githubusercontent.com/hazelcast/hazelcast-kubernetes/master/rbac.yaml
 
-kubectl run hazelcast-0 --image=hazelcast/hazelcast:{full-version} -l "role=hazelcast"
-kubectl run hazelcast-1 --image=hazelcast/hazelcast:{full-version} -l "role=hazelcast"
-kubectl run hazelcast-2 --image=hazelcast/hazelcast:{full-version} -l "role=hazelcast"
+kubectl run hazelcast-0 --image=hazelcast/hazelcast:{os-version} -l "role=hazelcast"
+kubectl run hazelcast-1 --image=hazelcast/hazelcast:{os-version} -l "role=hazelcast"
+kubectl run hazelcast-2 --image=hazelcast/hazelcast:{os-version} -l "role=hazelcast"
 
 kubectl create service clusterip hz-hazelcast --tcp=5701 -o yaml --dry-run=client | kubectl set selector --local -f - "role=hazelcast" -o yaml | kubectl create -f -
 ----

--- a/docs/modules/maintain-cluster/pages/logging.adoc
+++ b/docs/modules/maintain-cluster/pages/logging.adoc
@@ -121,7 +121,7 @@ Docker::
 ----
 docker run \
     -e LOGGING_PATTERN='{"time":"%date\{ISO8601\}", "logger": "%logger\{36\}", "level": "%level", "msg": "%enc{%m %xEx}\{JSON\}"}%n' \
-    hazelcast/hazelcast:{full-version}
+    hazelcast/hazelcast:{os-version}
 ----
 ====
 
@@ -157,7 +157,7 @@ Provide the file's relative or absolute path.
 ----
 docker run \
     -e LOGGING_CONFIG=config/myHzConfig.properties \
-    hazelcast/hazelcast:{full-version}
+    hazelcast/hazelcast:{os-version}
 ----
 --
 ====
@@ -224,7 +224,7 @@ Docker::
 docker run \
     -e LOGGING_CONFIG=config/log4j2-json.properties \
     -e LOGGING_JSON_TEMPLATE="classpath:EcsLayout.json" \
-    hazelcast/hazelcast:{full-version}
+    hazelcast/hazelcast:{os-version}
 ----
 ====
 
@@ -248,7 +248,7 @@ Docker::
 ----
 docker run \
     -e LOGGING_LEVEL=FINE \
-    hazelcast/hazelcast:{full-version}
+    hazelcast/hazelcast:{os-version}
 ----
 --
 

--- a/docs/modules/pipelines/pages/stream-processing-client.adoc
+++ b/docs/modules/pipelines/pages/stream-processing-client.adoc
@@ -210,7 +210,7 @@ docker run \
     -it \
     --network hazelcast-network \
     --rm \
-    -p 5701:5701 hazelcast/hazelcast:{full-version}
+    -p 5701:5701 hazelcast/hazelcast:{os-version}
 ----
 +
 Docker parameters:
@@ -261,7 +261,7 @@ Replace the following placeholders:
 +
 [source,bash,subs="attributes+"]
 ----
-docker run -it --network hazelcast-network -v $PATH_TO_TARGET:/jars --rm hazelcast/hazelcast:{full-version} hz-cli -t $MEMBER_IP submit -c org.example.EvenNumberStream /jars/hz-example-0.1.0.jar
+docker run -it --network hazelcast-network -v $PATH_TO_TARGET:/jars --rm hazelcast/hazelcast:{os-version} hz-cli -t $MEMBER_IP submit -c org.example.EvenNumberStream /jars/hz-example-0.1.0.jar
 ----
 
 In the console of your Hazelcast member, you should see that a new job has been submitted and it's running on your cluster.

--- a/docs/modules/pipelines/pages/submitting-jobs.adoc
+++ b/docs/modules/pipelines/pages/submitting-jobs.adoc
@@ -190,7 +190,7 @@ Create a Dockerfile as follows:
 
 [source,dockerfile,subs="attributes+"]
 ----
-FROM hazelcast/hazelcast:{full-version}
+FROM hazelcast/hazelcast:{os-version}
 ADD examples/hello-world.jar /examples/
 ENV HAZELCAST_MEMBER_ADDRESS 172.17.0.2
 CMD ["sh", "-c", "hz-cli -t $HAZELCAST_MEMBER_ADDRESS submit /examples/hello-world.jar"]

--- a/docs/modules/sql/pages/sql-overview.adoc
+++ b/docs/modules/sql/pages/sql-overview.adoc
@@ -58,7 +58,7 @@ Replace the `<cluster-name>` placeholder with the name of your cluster and the `
 
 [source,shell,subs="attributes+"]
 ----
-docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{full-version} hz-cli --targets <cluster-name>@<address> sql
+docker run --network hazelcast-network -it --rm hazelcast/hazelcast:{os-version} hz-cli --targets <cluster-name>@<address> sql
 ----
 --
 ====


### PR DESCRIPTION
Following on from https://github.com/hazelcast/hz-docs/pull/1355#issuecomment-2465223876, ensure the versions of referenced Docker images are correctly differentiating between OS & EE.

Note - not backporting to `v/5.5` as [doesn't contain these properties](https://github.com/hazelcast/hz-docs/blob/v/5.5/docs/antora.yml).

[Slack discussion](https://hazelcast.slack.com/archives/C035HQET5/p1733424118024969)

_Partially_ addresses:
- [DOC-238](https://hazelcast.atlassian.net/browse/DOC-238)
- [DEX-304](https://hazelcast.atlassian.net/browse/DEX-304)

[DOC-238]: https://hazelcast.atlassian.net/browse/DOC-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEX-304]: https://hazelcast.atlassian.net/browse/DEX-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ