### PR TITLE
Fix more dead links

### DIFF
--- a/docs/modules/deploy/pages/deploying-in-cloud.adoc
+++ b/docs/modules/deploy/pages/deploying-in-cloud.adoc
@@ -27,7 +27,7 @@ To deploy a cluster on Amazon EKS/Fargate or EKS/EC2, see xref:kubernetes:deploy
 [[hazelcast-cloud-discovery-plugins-azure]]
 == Hazelcast Azure
 
-Deploy a Hazelcast application on https://azure.microsoft.com/en-us/[Microsoft Azure^]:
+Deploy a Hazelcast application on https://azure.microsoft.com/[Microsoft Azure^]:
 
 * xref:deploy:deploying-on-azure.adoc[Deploying a cluster on Azure Virtual Machines]
 * xref:kubernetes:deploying-in-kubernetes.adoc#discovering-members-in-kubernetes-automatically[Deploying a cluster on Azure Kubernetes Service] (AKS)

--- a/docs/modules/deploy/pages/deploying-on-azure.adoc
+++ b/docs/modules/deploy/pages/deploying-on-azure.adoc
@@ -101,14 +101,14 @@ Caused by: com.hazelcast.azure.RestClientException: Failure executing: GET at: h
  
 If you have Hazelcast clients running outside an Azure VM, the Azure Instance Metadata service unavailable. In this case, Hazelcast client instances should be configured with the following properties:
 
-NOTE: You will need to setup link:https://azure.microsoft.com/documentation/articles/resource-group-create-service-principal-portal/[Azure Active Directory Service Principal credentials] for your Azure Subscription to be able to use these properties.
+NOTE: You will need to setup link:https://learn.microsoft.com/en-gb/entra/identity-platform/howto-create-service-principal-portal/[Microsoft Entra Service Principal credentials] for your Azure Subscription to be able to use these properties.
 
 - `instance-metadata-available` - This property should be configured as `false` in order to be able to use the following properties. It is `true` by default.
-- `client-id` - The Azure Active Directory Service Principal client ID.
-- `client-secret` - The Azure Active Directory Service Principal client secret.
-- `tenant-id` - The Azure Active Directory tenant ID.
+- `client-id` - The Microsoft Entra Service Principal client ID.
+- `client-secret` - The Microsoft Entra Service Principal client secret.
+- `tenant-id` - The Microsoft Entra tenant ID.
 - `subscription-id` - The Azure subscription ID.
-- `resource-group` - The name of Azure link:https://azure.microsoft.com/documentation/articles/resource-group-portal/[resource group] which the Hazelcast instance is running in.
+- `resource-group` - The name of Azure link:https://learn.microsoft.com/azure/azure-resource-manager/management/manage-resources-portal/[resource group] which the Hazelcast instance is running in.
 - `scale-set` - *(Optional)* The name of Azure link:https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/overview[VM scale set]. If this setting is configured, the plugin will search for instances over the resources only within this scale set.
 - `use-public-ip` - Enables the discovery joiner to use public IPs. It should be set to `true` in client instances running outside the Azure environment.
 
@@ -174,12 +174,12 @@ clientConfig.getNetworkConfig().getAzureConfig()
 
 Hazelcast allows you to configure xref:wan:wan.adoc[WAN replication] to work with the clusters in Azure and determine the endpoint IP addresses at runtime. If one Hazelcast cluster is running outside Azure and another is running inside Azure, then you should configure your WAN batch publisher as below:
 
-NOTE: You will need to setup link:https://azure.microsoft.com/documentation/articles/resource-group-create-service-principal-portal/[Azure Active Directory Service Principal credentials] for your Azure Subscription to be able to use these properties.
+NOTE: You will need to setup link:https://learn.microsoft.com/entra/identity-platform/howto-create-service-principal-portal/[Microsoft Entra Service Principal credentials] for your Azure Subscription to be able to use these properties.
 
 - `instance-metadata-available` - This property should be configured as `false` in order to be able to use the following properties. It is `true` by default.
-- `client-id` - The Azure Active Directory Service Principal client ID.
-- `client-secret` - The Azure Active Directory Service Principal client secret.
-- `tenant-id` - The Azure Active Directory tenant ID.
+- `client-id` - The Microsoft Entra Service Principal client ID.
+- `client-secret` - The Microsoft Entra Service Principal client secret.
+- `tenant-id` - The Microsoft Entra tenant ID.
 - `subscription-id` - The Azure subscription ID.
 - `resource-group` - The name of Azure link:https://azure.microsoft.com/documentation/articles/resource-group-portal/[resource group] which the Hazelcast instance is running in.
 - `scale-set` - *(Optional)* The name of Azure link:https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/overview[VM scale set]. If this setting is configured, the plugin will search for instances over the resources only within this scale set.

--- a/docs/modules/deploy/pages/deploying-on-azure.adoc
+++ b/docs/modules/deploy/pages/deploying-on-azure.adoc
@@ -101,14 +101,14 @@ Caused by: com.hazelcast.azure.RestClientException: Failure executing: GET at: h
  
 If you have Hazelcast clients running outside an Azure VM, the Azure Instance Metadata service unavailable. In this case, Hazelcast client instances should be configured with the following properties:
 
-NOTE: You will need to setup link:https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/[Azure Active Directory Service Principal credentials] for your Azure Subscription to be able to use these properties.
+NOTE: You will need to setup link:https://azure.microsoft.com/documentation/articles/resource-group-create-service-principal-portal/[Azure Active Directory Service Principal credentials] for your Azure Subscription to be able to use these properties.
 
 - `instance-metadata-available` - This property should be configured as `false` in order to be able to use the following properties. It is `true` by default.
 - `client-id` - The Azure Active Directory Service Principal client ID.
 - `client-secret` - The Azure Active Directory Service Principal client secret.
 - `tenant-id` - The Azure Active Directory tenant ID.
 - `subscription-id` - The Azure subscription ID.
-- `resource-group` - The name of Azure link:https://azure.microsoft.com/en-us/documentation/articles/resource-group-portal/[resource group] which the Hazelcast instance is running in.
+- `resource-group` - The name of Azure link:https://azure.microsoft.com/documentation/articles/resource-group-portal/[resource group] which the Hazelcast instance is running in.
 - `scale-set` - *(Optional)* The name of Azure link:https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/overview[VM scale set]. If this setting is configured, the plugin will search for instances over the resources only within this scale set.
 - `use-public-ip` - Enables the discovery joiner to use public IPs. It should be set to `true` in client instances running outside the Azure environment.
 
@@ -174,14 +174,14 @@ clientConfig.getNetworkConfig().getAzureConfig()
 
 Hazelcast allows you to configure xref:wan:wan.adoc[WAN replication] to work with the clusters in Azure and determine the endpoint IP addresses at runtime. If one Hazelcast cluster is running outside Azure and another is running inside Azure, then you should configure your WAN batch publisher as below:
 
-NOTE: You will need to setup link:https://azure.microsoft.com/en-us/documentation/articles/resource-group-create-service-principal-portal/[Azure Active Directory Service Principal credentials] for your Azure Subscription to be able to use these properties.
+NOTE: You will need to setup link:https://azure.microsoft.com/documentation/articles/resource-group-create-service-principal-portal/[Azure Active Directory Service Principal credentials] for your Azure Subscription to be able to use these properties.
 
 - `instance-metadata-available` - This property should be configured as `false` in order to be able to use the following properties. It is `true` by default.
 - `client-id` - The Azure Active Directory Service Principal client ID.
 - `client-secret` - The Azure Active Directory Service Principal client secret.
 - `tenant-id` - The Azure Active Directory tenant ID.
 - `subscription-id` - The Azure subscription ID.
-- `resource-group` - The name of Azure link:https://azure.microsoft.com/en-us/documentation/articles/resource-group-portal/[resource group] which the Hazelcast instance is running in.
+- `resource-group` - The name of Azure link:https://azure.microsoft.com/documentation/articles/resource-group-portal/[resource group] which the Hazelcast instance is running in.
 - `scale-set` - *(Optional)* The name of Azure link:https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/overview[VM scale set]. If this setting is configured, the plugin will search for instances over the resources only within this scale set.
 - `use-public-ip` - Enables the discovery joiner to use public IPs. It should be set to `true` in client instances running outside the Azure environment.
 
@@ -250,7 +250,7 @@ WanBatchPublisherConfig batchPublisherConfig = new WanBatchPublisherConfig()
 
 == Azure App Services Support
 
-link:https://azure.microsoft.com/en-gb/services/app-service/[Azure App Services] is a platform as a service (PaaS) which allows publishing applications running on multiple frameworks and written in different programming languages. If you would like to use Hazelcast in your App Service applications, you can <<discovering-members-from-hazelcast-clients, connect a Hazelcast client>> to a Hazelcast cluster running in Azure environment.
+link:https://azure.microsoft.com/services/app-service/[Azure App Services] is a platform as a service (PaaS) which allows publishing applications running on multiple frameworks and written in different programming languages. If you would like to use Hazelcast in your App Service applications, you can <<discovering-members-from-hazelcast-clients, connect a Hazelcast client>> to a Hazelcast cluster running in Azure environment.
 
 Azure App Services are unaware of the underlying VMs' network interfaces so it is not available to communicate among App Services using TCP/IP. Because of this reason, it is not possible to deploy a Hazelcast cluster on Azure App Services.  
 

--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -60,7 +60,7 @@ Windows::
 +
 --
 ifdef::snapshot[]
-Download and extract the Hazelcast ZIP file from link:https://hazelcast.jfrog.io/ui/native/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{full-version}[the repository].
+Download and extract the Hazelcast ZIP file from link:https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{full-version}[the repository].
 endif::[]
 ifndef::snapshot[]
 Download and extract the link:https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-{full-version}.zip[Hazelcast ZIP file].

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -195,7 +195,7 @@ The Java package includes both a member API and a Java client API. The member AP
 If you aren't using a build tool:
 
 ifdef::snapshot[]
-* link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{os-version}/hazelcast-{os-version}/[download the Hazelcast JAR file]
+* link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{os-version}/hazelcast-{os-version}.jar/[download the Hazelcast JAR file]
 endif::[]
 ifndef::snapshot[]
 * link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{full-version}/hazelcast-{full-version}.jar[download the Hazelcast JAR file]

--- a/docs/modules/pipelines/pages/cdc.adoc
+++ b/docs/modules/pipelines/pages/cdc.adoc
@@ -153,11 +153,11 @@ mysql> SELECT * FROM customers;
 If you already have Hazelcast and you skipped the above steps, make sure to
 follow from here on.
 ifdef::snapshot[]
-Download and extract the Hazelcast ZIP file from link:https://hazelcast.jfrog.io/ui/native/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{full-version}[the repository].
-. Make sure the MySQL CDC plugin is in the `lib/` directory. You must manually download the MySQL CDC plugin's `jar-with-dependencies` from link:https://hazelcast.jfrog.io/artifactory/snapshot/com/hazelcast/jet/hazelcast-enterprise-cdc-mysql/{full-version}[Hazelcast's Maven repository, window=_blank] and then copy it to the `lib/` directory.
+Download and extract the Hazelcast ZIP file from link:https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{full-version}[the repository].
+. Make sure the MySQL CDC plugin is in the `lib/` directory. You must manually download the MySQL CDC plugin's `jar-with-dependencies` from link:https://repository.hazelcast.com/snapshot/com/hazelcast/jet/hazelcast-enterprise-cdc-mysql/{full-version}[Hazelcast's Maven repository, window=_blank] and then copy it to the `lib/` directory.
 endif::[]
 ifndef::snapshot[]
-. Make sure the MySQL CDC plugin is in the `lib/` directory. You must manually download the MySQL CDC plugin from link:https://hazelcast.jfrog.io/artifactory/release/com/hazelcast/jet/hazelcast-enterprise-cdc-mysql/{full-version}/hazelcast-enterprise-cdc-mysql-{full-version}-jar-with-dependencies.jar[Hazelcast's Maven repository, window=_blank] and then copy it to the `lib/` directory.
+. Make sure the MySQL CDC plugin is in the `lib/` directory. You must manually download the MySQL CDC plugin from link:https://repository.hazelcast.com/release/com/hazelcast/jet/hazelcast-enterprise-cdc-mysql/{full-version}/hazelcast-enterprise-cdc-mysql-{full-version}-jar-with-dependencies.jar[Hazelcast's Maven repository, window=_blank] and then copy it to the `lib/` directory.
 endif::[]
 +
 [source,bash]

--- a/docs/modules/pipelines/pages/cdc.adoc
+++ b/docs/modules/pipelines/pages/cdc.adoc
@@ -153,7 +153,7 @@ mysql> SELECT * FROM customers;
 If you already have Hazelcast and you skipped the above steps, make sure to
 follow from here on.
 ifdef::snapshot[]
-Download and extract the link:https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise/hazelcast-enterprise-{full-version}.zip[Hazelcast ZIP file].
+Download and extract the Hazelcast ZIP file from link:https://hazelcast.jfrog.io/ui/native/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{full-version}[the repository].
 . Make sure the MySQL CDC plugin is in the `lib/` directory. You must manually download the MySQL CDC plugin's `jar-with-dependencies` from link:https://hazelcast.jfrog.io/artifactory/snapshot/com/hazelcast/jet/hazelcast-enterprise-cdc-mysql/{full-version}[Hazelcast's Maven repository, window=_blank] and then copy it to the `lib/` directory.
 endif::[]
 ifndef::snapshot[]
@@ -171,7 +171,7 @@ You should see the following jars:
 * hazelcast-enterprise-cdc-mysql-{full-version}-jar-with-dependencies.jar
 * hazelcast-enterprise-cdc-postgres-{full-version}-jar-with-dependencies.jar
 +
-WARNING: If you have Hazelcast {enterprise-product-name}, you need to manually download the MySQL CDC plugin from https://repo1.maven.org/maven2/com/hazelcast/jet/hazelcast-jet-cdc-mysql/{full-version}/hazelcast-jet-cdc-mysql-{full-version}-jar-with-dependencies.jar[Hazelcast's Maven repository] and then copy it to the `lib/` directory.
+WARNING: If you have Hazelcast {enterprise-product-name}, you need to manually download the MySQL CDC plugin from https://repo1.maven.org/maven2/com/hazelcast/jet/hazelcast-jet-cdc-mysql/{os-version}/hazelcast-jet-cdc-mysql-{os-version}-jar-with-dependencies.jar[Hazelcast's Maven repository] and then copy it to the `lib/` directory.
 
 . Start Hazelcast.
 +

--- a/docs/modules/spring/pages/configuration.adoc
+++ b/docs/modules/spring/pages/configuration.adoc
@@ -1,6 +1,6 @@
 = Configuring Hazelcast in Spring
 
-*Code Sample*: See our https://github.com/hazelcast/hazelcast-code-samples/tree/master/hazelcast-integration/spring-configuration[sample application^]
+*Code Sample*: See our https://github.com/hazelcast/hazelcast-code-samples/tree/master/spring/spring-configuration[sample application^]
 for Spring Configuration.
 
 == Enabling Spring Integration

--- a/docs/modules/spring/pages/hibernate.adoc
+++ b/docs/modules/spring/pages/hibernate.adoc
@@ -1,6 +1,6 @@
 = Configuring Hibernate Second-Level Cache
 
-**Code Sample**: See the https://github.com/hazelcast/hazelcast-code-samples/tree/master/hazelcast-integration/spring-hibernate-2ndlevel-cache[sample application^]
+**Code Sample**: See the https://github.com/hazelcast/hazelcast-code-samples/tree/master/spring/spring-hibernate-2ndlevel-cache[sample application^]
 for Hibernate 2nd Level Cache configuration.
 
 If you are using Hibernate with Hazelcast as a second level cache provider, you can easily configure your


### PR DESCRIPTION
Fix more links identified in by the [new dead link check](https://github.com/hazelcast/hz-docs/actions/runs/12235124537/job/34125742776).

Specifically:
- Fix code samples links following https://github.com/hazelcast/hazelcast-code-samples/pull/688
- Fix JFrog repository links
- Normalise all repositories to use `repository.hazelcast.com` over `hazelcast.jfrog.io` (which it silently redirects to anyway)
- Update Azure pages with new Entra naming / links ([Azure Active Directory has been renamed](https://learn.microsoft.com/en-us/entra/fundamentals/new-name))
- Make all Azure URLs non-regionalised (i.e. not `us` or `gb`) and instead let them be redirected as required