### PR TITLE
Improve `test-external-links` failure Slack notifications

### DIFF
--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -87,8 +87,9 @@ runs:
         uses: 8398a7/action-slack@v3
         if: failure()
         with:
-          fields: repo,message,action,workflow
-          status: ${{ job.status }}
+          status: failure
+          fields: repo,job,workflow
+          text: "👎 Test external links failed - ⛓️‍💥 dead link(s) found ⛓️‍💥."
           channel: "#docs"
         env:
           SLACK_WEBHOOK_URL: ${{ inputs.SLACK_WEBHOOK }}


### PR DESCRIPTION
The [initial message](https://hazelcast.slack.com/archives/C035HQET5/p1733762495778609) (introduced in https://github.com/hazelcast/hz-docs/pull/1382) wasn't very communicative of the problem.