### PR TITLE
Add note about classpath for custom EPs in pipelines [HZG-287]

### DIFF
--- a/docs/modules/integrate/pages/map-connector.adoc
+++ b/docs/modules/integrate/pages/map-connector.adoc
@@ -191,7 +191,7 @@ from the map.
 NOTE: Custom classes, such as an `EntryProcessor`, must be available to all members
 of the cluster. This can be done by adding the classes to each member's classpath
 directly, or by using {ucn}. If using {ucn}, ensure that the Job and underlying IMap
-are both associated with the correct namespace.
+are both associated with a namespace that contains the same `EntryProcessor` implementation.
 
 == Predicates and Projections
 


### PR DESCRIPTION
With the recently added support for UCN in Jet (available in next minor release), it is useful to mention this in documentation, particularly for the commonly used `EntryProcessor`. Even without UCN, the custom classes need to be on the classpath, so it's good to be explicit about this.

Only relevant for next minor release (5.6.0?)

Fixes https://hazelcast.atlassian.net/browse/HZG-287