### PR TITLE
Clarify MapLoader interaction behaviour [HZG-289]

### DIFF
--- a/docs/modules/mapstore/pages/mapstore-triggers.adoc
+++ b/docs/modules/mapstore/pages/mapstore-triggers.adoc
@@ -14,6 +14,9 @@ is called, it triggers the `MapLoader.loadAllKeys()` method.
 |Flush all the local dirty entries by calling the `MapStore.storeAll(Map)` or `MapStore.deleteAll(Collection)` methods with the elements marked as dirty.
 
 |get()
+
+getAsync()
+
 |Retrieve an entry from the map. If the entry does not exist in memory the `MapLoader.load(Object)` method is called to retrieve
 the entry from the external system if it exists.
 

--- a/docs/modules/mapstore/pages/mapstore-triggers.adoc
+++ b/docs/modules/mapstore/pages/mapstore-triggers.adoc
@@ -13,6 +13,13 @@ is called, it triggers the `MapLoader.loadAllKeys()` method.
 |flush()
 |Flush all the local dirty entries by calling the `MapStore.storeAll(Map)` or `MapStore.deleteAll(Collection)` methods with the elements marked as dirty.
 
+|get()
+|Retrieve an entry from the map. If the entry does not exist in memory the `MapLoader.load(Object)` method is called to retrieve
+the entry from the external system if it exists.
+
+|getAll()
+|Fetches all entries from the map that match the provided key set. If any keys are not found in memory then this method calls the `MapLoader.loadAll(Collection)` method with the missing keys.
+
 |put()
 
 putAll()
@@ -66,3 +73,6 @@ executeOnAllEntries()
 
 |Apply the user-defined entry processors to one or more entries. These methods call the `MapLoader.load(Object)` method if the value with key is not found in the memory, to load the value from the external system. If the entry processor updates the entry, these methods call the `MapStore.store(Object, Object)` method to write the value into the external system. If the entry processor updates the entry's value to null value, they call the `MapStore.delete(Object)` method to delete the value from the external system.
 |===
+
+More information about the behaviour of IMap method calls and their relationship to `MapStore` methods can be found in the
+https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/map/IMap.html[IMap Javadocs].

--- a/docs/modules/mapstore/pages/mapstore-triggers.adoc
+++ b/docs/modules/mapstore/pages/mapstore-triggers.adoc
@@ -74,5 +74,5 @@ executeOnAllEntries()
 |Apply the user-defined entry processors to one or more entries. These methods call the `MapLoader.load(Object)` method if the value with key is not found in the memory, to load the value from the external system. If the entry processor updates the entry, these methods call the `MapStore.store(Object, Object)` method to write the value into the external system. If the entry processor updates the entry's value to null value, they call the `MapStore.delete(Object)` method to delete the value from the external system.
 |===
 
-More information about the behaviour of IMap method calls and their relationship to `MapStore` methods can be found in the
+More information about the behavior of IMap method calls and their relationship to `MapStore` methods can be found in the
 https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/map/IMap.html[IMap Javadocs].


### PR DESCRIPTION
Adds additional clarity about `#get` and `#getAll` behaviour on `IMap` when a `MapLoader` is provided. Since the `MapStore` is an extension of the `MapLoader`, and some behaviour is already documented in the `mapstore-triggers` page, I've added it to the existing table.

I've also added a line to the bottom of the page directing users to the javadocs for more detailed information about interactions as this is well documented in javadocs.

Fixes https://hazelcast.atlassian.net/browse/HZG-289