### PR TITLE
Improve `test-external-links`

### DIFF
--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -85,7 +85,7 @@ runs:
 
         - name: Slack notification
           uses: 8398a7/action-slack@v3
-          if: failure()
+          if: failure() && github.event_name == 'schedule'
           with:
             status: failure
             fields: repo,job,workflow

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -68,7 +68,8 @@ runs:
                     fi
 
                     if [[ "${status}" -eq 404 ]]; then
-                        locations=$(grep -rl "${url}")
+                        # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
+                        locations=$(grep -rl "${url}" || true)
                         echo "::error::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
                         found_error=1
                     else


### PR DESCRIPTION
The action should:
- only post a Slack message on a scheduled failure - a manually triggered run will _already_ notify the initiator via email of the action failure, and is probably only being done for debugging purposes anyway.

- more gracefully handle the unicode issue addressed in https://github.com/hazelcast/hz-docs/pull/1462 so that it doesn't crash (but exact behaviour irrelevant as long as _an_ error is logged)