### PR TITLE
Update RoutingMode package [HZG-251]

### DIFF
--- a/docs/modules/ROOT/examples/clients/ExampleClientConfiguration.java
+++ b/docs/modules/ROOT/examples/clients/ExampleClientConfiguration.java
@@ -2,7 +2,7 @@ package com.hazelcast.client.config;
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClusterRoutingConfig;
-import com.hazelcast.client.impl.connection.tcp.RoutingMode;
+import com.hazelcast.client.config.RoutingMode;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.core.HazelcastInstance;
 


### PR DESCRIPTION
Following on from https://github.com/hazelcast/hazelcast-mono/pull/3781 the example client configuration needs to be updated with the new location of `RoutingMode`.

This should only be applied to live docs with the release of the next major/minor version, as this change is not backported to `5.5`.