### PR TITLE
Update DMT download location

### DIFF
--- a/docs/modules/migrate/pages/data-migration-tool.adoc
+++ b/docs/modules/migrate/pages/data-migration-tool.adoc
@@ -43,7 +43,7 @@ At a high-level, the migration process is as follows:
 
 == Get the DMT
 
-You can download the DMT from https://cloud.hazelcast.com/[Hazelcast {hazelcast-cloud}^] or the https://hazelcast.com/[Hazelcast web site^].
+You can download the DMT from the https://hazelcast.com/get-started/download/#data-migration-tool[Hazelcast download page^].
 
 Once downloaded, extract the DMT package to a location in your folder structure. The DMT package includes the following:
 


### PR DESCRIPTION
Updates the DMT download link to point directly at the correct section, and also removes the cloud reference.

Fixes https://hazelcast.atlassian.net/browse/SUP-723