### PR TITLE
Fix `forwardport` action parameter naming

### DIFF
--- a/.github/workflows/forwardport.yml
+++ b/.github/workflows/forwardport.yml
@@ -7,6 +7,6 @@ jobs:
   forwardport:
     uses: ./.github/workflows/backport-workflow.yml
     with:
-      label: '["forwardport to snapshot"]'
+      label-to-check-for: '["forwardport to snapshot"]'
       target-branch: main
     secrets: inherit


### PR DESCRIPTION
The name of the parameter is wrong.