### PR TITLE
Fix required parameters for name of index in Vector Collections

### DIFF
--- a/docs/modules/data-structures/pages/vector-collections.adoc
+++ b/docs/modules/data-structures/pages/vector-collections.adoc
@@ -82,7 +82,7 @@ See the <<split-brain-protection>> section.
 |name
 |The name of the vector index.
 Can include letters, numbers, and the symbols `-` and `_`.
-|Required for single-index vector collections. Optional for multi-index collection
+|Required for multi-index vector collections. Optional for single-index collection
 |`NULL`
 
 |dimension


### PR DESCRIPTION
Current documentation is incorrect since index name is required for multi-index vector collections.