### PR TITLE
Fix typo in VectorCollection example

### DIFF
--- a/docs/modules/data-structures/pages/vector-collections.adoc
+++ b/docs/modules/data-structures/pages/vector-collections.adoc
@@ -338,7 +338,7 @@ VectorCollectionConfig collectionConfig = new VectorCollectionConfig("books")
                 .setDimension(6)
                 .setMetric(Metric.DOT)
     );
-VectorCollection vectorCollection = VectorCollection.getCollection(hazelcastInstance, vectorCollectionConfig);
+VectorCollection vectorCollection = VectorCollection.getCollection(hazelcastInstance, collectionConfig);
 ----
 --
 Python::


### PR DESCRIPTION
Fix typo - previously created `VectorCollectionConfig` has name `collectionConfig` and not `vectorCollectionConfig` in example.