### PR TITLE
Fix Debezium/PostgreSQL dead `docker` image links

### DIFF
--- a/docs/modules/pipelines/pages/cdc-database-setup.adoc
+++ b/docs/modules/pipelines/pages/cdc-database-setup.adoc
@@ -109,8 +109,8 @@ The `pgoutput` plug-in is always present and requires no explicit
 installation, for the other two follow the instructions provided by
 their maintainers.
 
-Note: for simplicity Debezium also provides a Docker image based on a
-vanilla link:https://github.com/debezium/docker-images/tree/master/postgres/9.6[PostgreSQL server image]
+Note: for simplicity Debezium also provide Docker images based on
+vanilla link:https://github.com/debezium/docker-images/tree/master/postgres[PostgreSQL server images]
 on top of which it compiles and installs all above-mentioned plugins.
 
 === Configure the Database Server


### PR DESCRIPTION
The `9.6` link [is dead](https://github.com/hazelcast/hz-docs/runs/35872592372) - updated.