### PR TITLE
Document expensive IMap reporting threshold & property

### DIFF
--- a/docs/modules/cluster-performance/pages/imap-bulk-read-operations.adoc
+++ b/docs/modules/cluster-performance/pages/imap-bulk-read-operations.adoc
@@ -19,6 +19,13 @@ Methods like `IMap#entrySet()` and `IMap#values()` can trigger an OOME, dependin
 on the size of your map and the available memory on each member.
 To mitigate this risk, you should follow these best practices.
 
+NOTE: Client invocations of certain `IMap` methods such as those described above
+are logged on the member side when their results meet or exceed a threshold defined
+by the Hazelcast property `hazelcast.expensive.imap.invocation.reporting.threshold`,
+which has a default value of `100` results.
+See the https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/spi/properties/ClusterProperty.html#EXPENSIVE_IMAP_INVOCATION_REPORTING_THRESHOLD[relevant Javadocs^]
+for details on which `IMap` methods are logged.
+
 == Plan capacity
 Proper capacity planning is crucial for providing
 sufficient system resources to the Hazelcast cluster. This

--- a/docs/modules/cluster-performance/pages/imap-bulk-read-operations.adoc
+++ b/docs/modules/cluster-performance/pages/imap-bulk-read-operations.adoc
@@ -19,12 +19,11 @@ Methods like `IMap#entrySet()` and `IMap#values()` can trigger an OOME, dependin
 on the size of your map and the available memory on each member.
 To mitigate this risk, you should follow these best practices.
 
-NOTE: Client invocations of certain `IMap` methods such as those described above
-are logged on the member side when their results meet or exceed a threshold defined
+NOTE: To help you to monitor this potential problem, client invocations of certain `IMap` methods are logged on the member side when their results meet or exceed a threshold.
+The threshold for logging large results is defined
 by the Hazelcast property `hazelcast.expensive.imap.invocation.reporting.threshold`,
 which has a default value of `100` results.
-See the https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/spi/properties/ClusterProperty.html#EXPENSIVE_IMAP_INVOCATION_REPORTING_THRESHOLD[relevant Javadocs^]
-for details on which `IMap` methods are logged.
+The relevant methods are listed in the https://docs.hazelcast.org/docs/{full-version}/javadoc/com/hazelcast/spi/properties/ClusterProperty.html#EXPENSIVE_IMAP_INVOCATION_REPORTING_THRESHOLD[Javadocs^].
 
 == Plan capacity
 Proper capacity planning is crucial for providing


### PR DESCRIPTION
Adds documentation about the expensive IMap client invocations logging, including the property used to control this threshold and guidance on which methods utilize this reporting.

Related PR: https://github.com/hazelcast/hazelcast-mono/pull/3856