### PR TITLE
Doc-319: add boomerang backup note

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -1114,6 +1114,8 @@ When an operation with sync backup is sent by a client to the Hazelcast member(s
 the acknowledgment of the operation's backup is sent to the client by the backup
 replica member(s). This improves the performance of the client operations.
 
+NOTE: Backup acknowledgement is sometimes referred to as _boomerang backups_.
+
 If using the `ALL_MEMBERS` cluster routing mode, backup acknowledgement to the client is enabled by default.
 However, neither the `MULTI_MEMBER` nor the `SINGLE_MEMBER` cluster routing modes support backup acknowledgement to the client.
 


### PR DESCRIPTION
Add a brief note “Backup acknowledgement is sometimes referred to as boomerang backups” to enable the search to pick this up.

Note that JamesH and Burak confirmed this is a term sometimes used by customers and HZC for backup acknowledgement, and have OK'd this note