### PR TITLE
Vale integration [DOC-95]

### DIFF
--- a/.github/workflows/vale-pr-builder.yaml
+++ b/.github/workflows/vale-pr-builder.yaml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - run: ls vale
       - name: Install Asciidoctor
         run: sudo apt-get install -y asciidoctor
       - uses: errata-ai/vale-action@v2
+        with:
+          files: docs

--- a/.github/workflows/vale-pr-builder.yaml
+++ b/.github/workflows/vale-pr-builder.yaml
@@ -1,0 +1,16 @@
+name: Vale PR linter
+
+on:
+  pull_request:
+    branches:
+      - main
+     
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Asciidoctor
+        run: sudo apt-get install -y asciidoctor
+      - uses: errata-ai/vale-action@v2

--- a/.github/workflows/vale-pr-builder.yaml
+++ b/.github/workflows/vale-pr-builder.yaml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
       - run: ls vale
       - name: Install Asciidoctor
         run: sudo apt-get install -y asciidoctor
       - uses: errata-ai/vale-action@v2
-        with:
-          files: docs

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .vscode/settings.json
 /target/
 .classpath
+/styles/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vale"]
+	path = vale
+	url = https://github.com/hazelcast/vale.git

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,1 @@
+Packages = vale

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "chrischinchilla.vale-vscode"
+    ]
+}


### PR DESCRIPTION
Make getting started with [Vale](https://vale.sh/) easier by:
- adding suggested extension to VSCode
- adding [shared config](https://github.com/hazelcast/vale.git) as a submodule
   - note this is currently an `internal` repo!

Out of scope:
- updating the `README`

_Partially addresses_ [DOC-95](https://hazelcast.atlassian.net/browse/DOC-95)

[DOC-95]: https://hazelcast.atlassian.net/browse/DOC-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ