### PR TITLE
Some clarifications about data persistence [HZG-257]

### DIFF
--- a/docs/modules/storage/pages/persistence.adoc
+++ b/docs/modules/storage/pages/persistence.adoc
@@ -1,5 +1,5 @@
 = Persisting Data on Disk
-:description: Persistence allows individual members and whole clusters to recover data by persisting map entries, JCache data, and streaming job snapshots on disk. Members can use persisted data to recover from planned cluster-wide shutdowns, unplanned cluster-wide failures and speed up individual member restarts by reducing the volume of data sent over the network.
+:description: Persistence allows individual members and whole clusters to recover data by persisting map entries, JCache data, and streaming job snapshots on disk. Members can use persisted data to recover from planned cluster-wide shutdowns, unplanned cluster-wide failures, and to accelerate individual member restarts by reducing the volume of data sent over the network.
 :toc-levels: 3
 :page-enterprise: true
 
@@ -11,7 +11,7 @@ Data in Hazelcast is usually stored in-memory (RAM) so that it's faster to acces
 
 Clusters can use persisted data for the following scenarios:
 
-- **Persisting data across cluster-wide shutdowns**:
+- **Cluster-wide shutdowns**:
 
 ** **Planned**: A whole cluster is shut down and restarted with the same configuration, state, and data as before the restart. 
 +
@@ -21,10 +21,10 @@ In order for persistence to function correctly for planned cluster shutdowns you
 ====
 ** **Unplanned**: A cluster is restarted after all its members crash at the same time due an event such as a power outage. Note that some data loss is expected unless `fsync` is set to `true`. For more information, see xref:storage:configuring-persistence.adoc#data-structures[Data structure options].
 
-- **Speeding up single member restarts**: 
+- **Accelerating single member restarts**: 
 
 ** **Planned**: During a rolling restart each cluster member is restarted one by one for scenarios such as installing an operating system patch or new hardware. xref:maintain-cluster:rolling-upgrades.adoc[Rolling upgrades] are an example of a rolling restart.
-** **Unplanned**: A member may crash or terminate unexpectedly at any time, using persistence allows faster recovery.
+** **Unplanned**: A single member may crash or terminate unexpectedly at any time, using persistence allows faster recovery by using the data on disk where possible. In some cases a member can recover entirely using the data on disk removing the need to transfer data over the network.
 
 
 == Supported Features

--- a/docs/modules/storage/pages/persistence.adoc
+++ b/docs/modules/storage/pages/persistence.adoc
@@ -1,5 +1,5 @@
 = Persisting Data on Disk
-:description: Persistence allows individual members and whole clusters to recover data by persisting map entries, JCache data, and streaming job snapshots on disk. Members can use persisted data to recover from cluster-wide shutdowns and speed up individual member restarts by reducing the volume of data sent over the network.
+:description: Persistence allows individual members and whole clusters to recover data by persisting map entries, JCache data, and streaming job snapshots on disk. Members can use persisted data to recover from planned cluster-wide shutdowns, unplanned cluster-wide failures and speed up individual member restarts by reducing the volume of data sent over the network.
 :toc-levels: 3
 :page-enterprise: true
 
@@ -7,7 +7,7 @@
 
 == Why Persist Data
 
-Data in Hazelcast is usually stored in-memory (RAM) so that it's faster to access. However, data in RAM is volatile, meaning that when a member shuts down, its data is lost. In-memory partition backups are still the primary method for data resilience in Hazelcast but additionally persisting data to disk can be useful in certain situations. When you persist data on disk, members can load it upon a restart back into memory directly instead of relying on other active members sending it over the network.
+Data in Hazelcast is usually stored in-memory (RAM) so that it's faster to access. However, data in RAM is volatile, meaning that when a member shuts down, its data is lost. In-memory partition backups are the primary method for data resilience in Hazelcast but additionally persisting data to disk can be useful in certain situations. When you persist data on disk, members can load it upon a restart instead of relying on other active members sending it over the network. In the case of cluster-wide failure - e.g. due to data centre power outage - where we cannot rely on receiving the data from other active members, persistence means that we can recover data that would otherwise be irreversibly lost.
 
 Clusters can use persisted data for the following scenarios:
 
@@ -17,7 +17,7 @@ Clusters can use persisted data for the following scenarios:
 +
 [IMPORTANT]
 ====
-In order for persistence to function correctly for planned cluster shutdowns you must xref:maintain-cluster:shutdown.adoc[shutdown the entire cluster at once].
+In order for persistence to function correctly for planned cluster shutdowns you must first put the cluster into `PASSIVE` state before shutting down members. A list of methods for gracefully shutting down a cluster can be found in the xref:maintain-cluster:shutdown.adoc[shutdown] docs.
 ====
 ** **Unplanned**: A cluster is restarted after all its members crash at the same time due an event such as a power outage. Note that some data loss is expected unless `fsync` is set to `true`. For more information, see xref:storage:configuring-persistence.adoc#data-structures[Data structure options].
 

--- a/docs/modules/storage/pages/persistence.adoc
+++ b/docs/modules/storage/pages/persistence.adoc
@@ -7,7 +7,9 @@
 
 == Why Persist Data
 
-Data in Hazelcast is usually stored in-memory (RAM) so that it's faster to access. However, data in RAM is volatile, meaning that when a member shuts down, its data is lost. In-memory partition backups are the primary method for data resilience in Hazelcast but additionally persisting data to disk can be useful in certain situations. When you persist data on disk, members can load it upon a restart instead of relying on other active members sending it over the network. In the case of cluster-wide failure - e.g. due to data centre power outage - where we cannot rely on receiving the data from other active members, persistence means that we can recover data that would otherwise be irreversibly lost.
+Data in Hazelcast is usually stored in-memory (RAM) so that it's faster to access. However, data in RAM is volatile, meaning that when a member shuts down, its data is lost. In-memory partition backups are the primary method for data resilience in Hazelcast, but additionally persisting data to disk can reduce downtime and data loss in certain scenarios.
+
+When you persist data on disk, members can load it on restart, instead of waiting for other active members to send it over the network. In a cluster-wide failure - e.g. due to a data center power outage - there are no active members to receive data from, so persistence means that we can recover data that would otherwise be lost.
 
 Clusters can use persisted data for the following scenarios:
 
@@ -17,11 +19,11 @@ Clusters can use persisted data for the following scenarios:
 +
 [IMPORTANT]
 ====
-In order for persistence to function correctly for planned cluster shutdowns you must first put the cluster into `PASSIVE` state before shutting down members. A list of methods for gracefully shutting down a cluster can be found in the xref:maintain-cluster:shutdown.adoc[shutdown] docs.
+In order for persistence to function correctly for planned cluster shutdowns you must first put the cluster into `PASSIVE` state before shutting down members. A list of methods for gracefully shutting down a cluster can be found in the xref:maintain-cluster:shutdown.adoc[shutdown] documentation.
 ====
-** **Unplanned**: A cluster is restarted after all its members crash at the same time due an event such as a power outage. Note that some data loss is expected unless `fsync` is set to `true`. For more information, see xref:storage:configuring-persistence.adoc#data-structures[Data structure options].
+** **Unplanned**: A cluster is restarted after all its members crash at the same time due to an event such as a power outage. Note that some data loss is expected unless `fsync` is set to `true`. For more information, see xref:storage:configuring-persistence.adoc#data-structures[Data structure options].
 
-- **Accelerating single member restarts**: 
+- **Single member restarts**: 
 
 ** **Planned**: During a rolling restart each cluster member is restarted one by one for scenarios such as installing an operating system patch or new hardware. xref:maintain-cluster:rolling-upgrades.adoc[Rolling upgrades] are an example of a rolling restart.
 ** **Unplanned**: A single member may crash or terminate unexpectedly at any time, using persistence allows faster recovery by using the data on disk where possible. In some cases a member can recover entirely using the data on disk removing the need to transfer data over the network.

--- a/docs/modules/storage/pages/persistence.adoc
+++ b/docs/modules/storage/pages/persistence.adoc
@@ -1,5 +1,5 @@
 = Persisting Data on Disk
-:description: Persistence allows individual members and whole clusters to recover data by persisting map entries, JCache data, and streaming job snapshots on disk. Members can use persisted data to recover from a planned shutdown (including rolling upgrades), a sudden cluster-wide crash, or a single member failure.
+:description: Persistence allows individual members and whole clusters to recover data by persisting map entries, JCache data, and streaming job snapshots on disk. Members can use persisted data to recover from cluster-wide shutdowns and speed up individual member restarts by reducing the volume of data sent over the network.
 :toc-levels: 3
 :page-enterprise: true
 
@@ -7,15 +7,25 @@
 
 == Why Persist Data
 
-Data in Hazelcast is usually stored in-memory (RAM) so that it's faster to access. However, data in RAM is volatile, meaning that when one or more members shut down, their data is lost. When you persist data on disk, members can load it upon a restart and continue to operate as usual.
+Data in Hazelcast is usually stored in-memory (RAM) so that it's faster to access. However, data in RAM is volatile, meaning that when a member shuts down, its data is lost. In-memory partition backups are still the primary method for data resilience in Hazelcast but additionally persisting data to disk can be useful in certain situations. When you persist data on disk, members can load it upon a restart back into memory directly instead of relying on other active members sending it over the network.
 
-Clusters can use persisted data to recover from the following scenarios:
+Clusters can use persisted data for the following scenarios:
 
-- **Cluster-wide shutdown**:
+- **Persisting data across cluster-wide shutdowns**:
 
-** **Planned**: A whole cluster is shut down and restarted with the same configuration, state, and data as before the restart. A planned shutdown includes rolling restarts, where the cluster is restarted member by member for scenarios such as installing an operating system patch or new hardware. xref:maintain-cluster:rolling-upgrades.adoc[Rolling upgrades] are an example of a rolling restart.
+** **Planned**: A whole cluster is shut down and restarted with the same configuration, state, and data as before the restart. 
++
+[IMPORTANT]
+====
+In order for persistence to function correctly for planned cluster shutdowns you must xref:maintain-cluster:shutdown.adoc[shutdown the entire cluster at once].
+====
 ** **Unplanned**: A cluster is restarted after all its members crash at the same time due an event such as a power outage. Note that some data loss is expected unless `fsync` is set to `true`. For more information, see xref:storage:configuring-persistence.adoc#data-structures[Data structure options].
-- **A single member restart**: A single member is restarted for whatever reason.
+
+- **Speeding up single member restarts**: 
+
+** **Planned**: During a rolling restart each cluster member is restarted one by one for scenarios such as installing an operating system patch or new hardware. xref:maintain-cluster:rolling-upgrades.adoc[Rolling upgrades] are an example of a rolling restart.
+** **Unplanned**: A member may crash or terminate unexpectedly at any time, using persistence allows faster recovery.
+
 
 == Supported Features
 


### PR DESCRIPTION
Some clarifications that data persistence is there to augment in-memory partition backups and that planned cluster shutdowns must be done cluster-wide. A rolling restart is not the same as a cluster shutdown, it is a sequence of individual member restarts and so is more appropriate to categorize as a speed improvement instead of a resiliency one.