### PR TITLE
Update 'hazelcast.diagnostics.memberinfo.period.seconds' Property To Use 'seconds' In Plural

### DIFF
--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -216,7 +216,7 @@ along with this and the following diagnostic related system properties, see the 
 0 means this plugin is disabled.
 
 
-|`hazelcast.diagnostics.memberinfo.period.second`
+|`hazelcast.diagnostics.memberinfo.period.seconds`
 |60
 |long
 |Frequency, in seconds, at which the cluster information is dumped to the diagnostics log file.

--- a/docs/modules/maintain-cluster/pages/monitoring.adoc
+++ b/docs/modules/maintain-cluster/pages/monitoring.adoc
@@ -1815,7 +1815,7 @@ It is useful to get a fast impression of the cluster without needing to analyze 
 
 You can configure the frequency at which the cluster information is dumped to the log file using the following property:
 
-* `hazelcast.diagnostics.memberinfo.period.second`: Set a value in seconds. Its default value is `60` seconds.
+* `hazelcast.diagnostics.memberinfo.period.seconds`: Set a value in seconds. Its default value is `60` seconds.
 
 ==== EventQueue
 


### PR DESCRIPTION
In the current documentation, the name of the property in question is as follows:

```bash
hazelcast.diagnostics.memberinfo.period.second
```

This name exists in two places:
* [Configuration of the `HazelcastInstance` diagnostics plugin](https://docs.hazelcast.com/hazelcast/5.5/maintain-cluster/monitoring#hazelcastinstance)
* [System properties reference](https://docs.hazelcast.com/hazelcast/5.5/system-properties#hide-nav)

In Hazelcast Platform's source code, however, it's called `hazelcast.diagnostics.memberinfo.period.seconds`, see [MemberHazelcastInstanceInfoPlugin.java](https://github.com/hazelcast/hazelcast/blob/7b365b48eea173c322e895da552517e693f29134/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPlugin.java#L43).

This PR updates the two aforementioned occurrences, so they correspond to the name of the property in the source code.