### PR TITLE
Remove dead Hazelcast/Optane Intel blog link

### DIFF
--- a/docs/modules/storage/pages/persistence-on-intel.adoc
+++ b/docs/modules/storage/pages/persistence-on-intel.adoc
@@ -177,7 +177,3 @@ In Hazelcast, you must configure Persistence to tell your cluster where to save 
     <parallelism>12</parallelism>
 </persistence>
 ----
-
-== Next Steps
-For test results, which show why increasing parallelism improves performance, see our blog on link:https://builders.intel.com/datacenter/blog/hazelcast-fast-restart-optane-dc-persistent-memory[https://builders.intel.com/datacenter/blog/hazelcast-fast-restart-optane-dc-persistent-memory^].
-For details about persistence configuration, see xref:configuring-persistence.adoc[].


### PR DESCRIPTION
Removed `Next Steps` section as functionality is deprecated and adds no value.