### PR TITLE
Doc 369 tutorials

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -8,8 +8,8 @@ site:
     docsearch_api: 'ef7bd9485eafbd75d6e8425949eda1f5'
     docsearch_index: 'prod_hazelcast_docs'
     ai_search_id: '6b326171-dd1e-40c6-a948-1f9bb6c0ed52'
-urls:
-  html_extension_style: drop
+# urls:
+#  html_extension_style: drop
 content:
   sources:
   - url: .

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -522,6 +522,7 @@
 *** xref:maintain-cluster:dynamic-config-via-rest.adoc[Dynamic configuration tutorial]
 ** xref:clients:memcache.adoc[Memcache]
 * Client tutorials
+** xref:clients:client-tutorial-landing.adoc[About the client tutorials]
 ** xref:clients:java-client-getting-started.adoc[Get started with Java]
 ** xref:clients:csharp-client-getting-started.adoc[Get started with .NET]
 ** xref:clients:python-client-getting-started.adoc[Get started with Python]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -521,6 +521,13 @@
 *** xref:maintain-cluster:rest-api-swagger.adoc[]
 *** xref:maintain-cluster:dynamic-config-via-rest.adoc[Dynamic configuration tutorial]
 ** xref:clients:memcache.adoc[Memcache]
+* Client tutorials
+** xref:clients:java-client-getting-started.adoc[Get started with Java]
+** xref:clients:csharp-client-getting-started.adoc[Get started with .NET]
+** xref:clients:python-client-getting-started.adoc[Get started with Python]
+** xref:clients:cpp-client-getting-started.adoc[Get started with C++]
+** xref:clients:go-client-getting-started.adoc[Get started with Go]
+** xref:clients:nodejs-client-getting-started.adoc[Get started with Node.js]
 
 .Frameworks and plugins
 // Spring

--- a/docs/modules/clients/pages/client-overview.adoc
+++ b/docs/modules/clients/pages/client-overview.adoc
@@ -78,5 +78,7 @@ For detailed information and code samples for each client, see:
 * xref:go.adoc[Go]
 * xref:nodejs.adoc[Node.js]
 
+For help getting started with the Hazelcast clients, see the xref:clients:client-tutorial-landing.adoc[client tutorials].
+
 For details about using Memcache to communicate directly with a Hazelcast cluster, see xref:memcache.adoc[Memcache].
 For information about using the REST API for simple operations, see: xref:rest.adoc[REST].

--- a/docs/modules/clients/pages/client-tutorial-landing.adoc
+++ b/docs/modules/clients/pages/client-tutorial-landing.adoc
@@ -1,0 +1,10 @@
+= Client tutorials overview
+:description: Landing page for the Hazelcast client tutorials
+
+Learn how to get started quickly with the Hazelcast clients by following our simple tutorials. 
+
+Hazelcast client tutorials are practical, step-by-step guides to help you get started with using Hazelcast clients in various programming languages. The tutorials are ideal for developers new to Hazelcast, to learn how to integrate Hazelcast's distributed computing capabilities into their applications. These tutorials typically cover the following aspects:
+
+1. Setting up a Hazelcast client.
+2. Connecting to a Hazelcast cluster (usually a Viridian cloud instance).
+3. Performing basic operations like putting data into a distributed map.

--- a/docs/modules/clients/pages/cpp-client-getting-started.adoc
+++ b/docs/modules/clients/pages/cpp-client-getting-started.adoc
@@ -1,0 +1,415 @@
+= Get started with the Hazelcast C++ Client
+
+:description: This tutorial will get you started with the Hazelcast C++ client and show you how to manipulate a map.
+
+== What you'll learn
+
+{description}
+
+== Prerequisites
+
+Before you begin, make sure you have the following:
+
+* C++ 11 or above
+* https://hazelcast.com/products/viridian/[Hazelcast Viridian Cloud Account]
+* A text editor or IDE
+
+== Start a Hazelcast Viridian Cloud Cluster
+
+1. Sign up for a Hazelcast Viridian Cloud account (free trial is available).
+2. Log in to your Hazelcast Viridian Cloud account and start your trial by filling in the welcome questionnaire.
+3. A Viridian cluster will be created automatically when you start your trial.
+4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
+5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.
+
+== Set up a Hazelcast Client
+
+Create a new folder and navigate to it:
+
+[source]
+----
+mkdir hazelcast-cpp-example
+cd hazelcast-cpp-example
+----
+
+Download and install Vcpkg: +
+
+for Windows;
+[source,bash]
+----
+git clone https://github.com/microsoft/vcpkg
+.\vcpkg\bootstrap-vcpkg.bat
+----
+
+for non-Windows;
+[source,bash]
+----
+git clone https://github.com/microsoft/vcpkg
+./vcpkg/bootstrap-vcpkg.sh
+----
+
+Download and install hazelcast-cpp-client: +
+
+for Windows;
+[source,bash]
+----
+.\vcpkg\vcpkg.exe install "hazelcast-cpp-client[openssl]" --recurse
+----
+
+for non-Windows;
+[source,bash]
+----
+./vcpkg/vcpkg install "hazelcast-cpp-client[openssl]" --recurse
+----
+
+NOTE: Avoid directory names in your path that contain spaces or other non-standard characters.
+
+Extract the keystore files you downloaded from Viridian into this directory. The files you need for this tutorial are:
+
+[source,bash]
+----
+ca.pem
+cert.pem
+key.pem
+----
+
+Create a CMake file in this directory, named "CMakeLists.txt" as follows:
+
+[source,bash]
+----
+cmake_minimum_required(VERSION 3.10)
+
+project(HazelcastCloud)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(hazelcast-cpp-client CONFIG REQUIRED)
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/example.cpp)
+    add_executable(example example.cpp)
+    target_link_libraries(example PRIVATE hazelcast-cpp-client::hazelcast-cpp-client)
+endif()
+----
+
+You should have the following entries in the directory:
+[source,bash]
+----
+CMakeLists.txt
+ca.pem
+cert.pem
+key.pem
+vcpkg
+----
+
+== Understand the C++ Client
+
+The following section creates and starts a Hazelcast client with default configuration, and connects to your Viridian cluster before finally shutting down the client.
+
+Create a C++ file named “example.cpp” and insert the following code in it:
+
+[source,cpp]
+----
+#include <string>
+#include <hazelcast/client/hazelcast_client.h>
+
+int
+main(int argc, char** argv)
+{
+    hazelcast::client::client_config config;
+
+    // Viridian Cluster Name and Token
+    config.set_cluster_name("<YOUR_CLUSTER_ID>");
+    auto& cloud_configuration = config.get_network_config().get_cloud_config();
+    cloud_configuration.enabled = true;
+    cloud_configuration.discovery_token = "<YOUR_DISCOVERY_TOKEN>";
+
+    // configure SSL
+    boost::asio::ssl::context ctx(boost::asio::ssl::context::tlsv12);
+
+    try {
+        ctx.load_verify_file("ca.pem");
+        ctx.use_certificate_file("cert.pem", boost::asio::ssl::context::pem);
+        ctx.set_password_callback(
+          [&](std::size_t max_length,
+              boost::asio::ssl::context::password_purpose purpose) {
+              return "<YOUR_CERTIFICATE_PASSWORD>";
+          });
+        ctx.use_private_key_file("key.pem", boost::asio::ssl::context::pem);
+    } catch (std::exception& e) {
+        std::cerr << "You should copy ca.pem, cert.pem and key.pem files to "
+                     "the working directory, exception cause "
+                  << e.what() << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    config.get_network_config().get_ssl_config().set_context(std::move(ctx));
+
+    // Connect to your Hazelcast Cluster
+    auto client = hazelcast::new_client(std::move(config)).get();
+
+    // take actions
+    std::cout << "Welcome to your Hazelcast Viridian Cluster!" << std::endl;
+
+    // Shutdown the client connection
+    client.shutdown().get();
+}
+----
+
+Compile using CMake as follows:
+
+[source,bash]
+----
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
+cmake --build build
+----
+
+Once complete, run the example:
+
+[source,bash]
+----
+./build/example
+----
+
+For more information about Vcpkg installation check https://github.com/hazelcast/hazelcast-cpp-client/blob/master/Reference_Manual.md#112-vcpkg-users[here].
+In this tutorial we use CMake for compilation; for other options you can check https://github.com/hazelcast/hazelcast-cpp-client/blob/master/Reference_Manual.md#13-compiling-your-project[here].
+
+To understand and use the client, review the https://hazelcast.github.io/hazelcast-cpp-client/api-index.html[C++ API documentation] to discover what is possible.
+
+== Understand the Hazelcast SQL API
+
+Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
+
+In the following example, we will create a map and insert entries into it where the keys are ids and the values are defined as an object representing a city.
+
+[source,cpp]
+----
+#include <string>
+#include <hazelcast/client/hazelcast_client.h>
+
+void
+create_mapping(hazelcast::client::hazelcast_client client);
+void
+insert_cities(hazelcast::client::hazelcast_client client);
+void
+fetch_cities(hazelcast::client::hazelcast_client client);
+
+struct CityDTO
+{
+    std::string cityName;
+    std::string country;
+    int population;
+};
+
+// CityDTO serializer
+namespace hazelcast {
+namespace client {
+namespace serialization {
+
+template<>
+struct hz_serializer<CityDTO> : compact::compact_serializer
+{
+    static void write(const CityDTO& object, compact::compact_writer& out)
+    {
+        out.write_int32("population", object.population);
+        out.write_string("city", object.cityName);
+        out.write_string("country", object.country);
+    }
+
+    static CityDTO read(compact::compact_reader& in)
+    {
+        CityDTO c;
+
+        c.population = in.read_int32("population");
+        boost::optional<std::string> city = in.read_string("city");
+
+        if (city) {
+            c.cityName = *city;
+        }
+
+        boost::optional<std::string> country = in.read_string("country");
+
+        if (country) {
+            c.country = *country;
+        }
+
+        return c;
+    }
+
+    static std::string type_name() { return "CityDTO"; }
+};
+
+} // namespace serialization
+} // namespace client
+} // namespace hazelcast
+
+int
+main(int argc, char** argv)
+{
+    hazelcast::client::client_config config;
+
+    // Viridian Cluster Name and Token
+    config.set_cluster_name("<YOUR_CLUSTER_ID>");
+    auto& cloud_configuration = config.get_network_config().get_cloud_config();
+    cloud_configuration.enabled = true;
+    cloud_configuration.discovery_token = "<YOUR_DISCOVERY_TOKEN>";
+
+    // configure SSL
+    boost::asio::ssl::context ctx(boost::asio::ssl::context::tlsv12);
+
+    try {
+        ctx.load_verify_file("ca.pem");
+        ctx.use_certificate_file("cert.pem", boost::asio::ssl::context::pem);
+        ctx.set_password_callback(
+          [&](std::size_t max_length,
+              boost::asio::ssl::context::password_purpose purpose) {
+            return "<YOUR_CERTIFICATE_PASSWORD>";
+          });
+        ctx.use_private_key_file("key.pem", boost::asio::ssl::context::pem);
+    } catch (std::exception& e) {
+        std::cerr << "You should copy ca.pem, cert.pem and key.pem files to "
+                     "the working directory, exception cause "
+                  << e.what() << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    config.get_network_config().get_ssl_config().set_context(std::move(ctx));
+
+    // Connect to your Hazelcast Cluster
+    auto client = hazelcast::new_client(std::move(config)).get();
+
+    // take actions
+    create_mapping(client);
+    insert_cities(client);
+    fetch_cities(client);
+
+    // Shutdown the client connection
+    client.shutdown().get();
+}
+
+void
+create_mapping(hazelcast::client::hazelcast_client client)
+{
+    // Mapping is required for your distributed map to be queried over SQL.
+    // See: https://docs.hazelcast.com/hazelcast/latest/sql/mapping-to-maps
+
+    std::cout << "Creating the mapping...";
+
+    auto sql = client.get_sql();
+
+    auto result = sql
+                    .execute(R"(CREATE OR REPLACE MAPPING
+                                    cities (
+                                        __key INT,
+                                        country VARCHAR,
+                                        city VARCHAR,
+                                        population INT) TYPE IMAP
+                                    OPTIONS (
+                                        'keyFormat' = 'int',
+                                        'valueFormat' = 'compact',
+                                        'valueCompactTypeName' = 'CityDTO'))")
+                    .get();
+
+    std::cout << "OK." << std::endl;
+}
+
+void
+insert_cities(hazelcast::client::hazelcast_client client)
+{
+    auto sql = client.get_sql();
+
+    try {
+        sql.execute("DELETE FROM cities").get();
+
+        std::cout << "Inserting data...";
+
+        // Create mapping for the integers. This needs to be done only once per
+        // map.
+        auto result = sql
+                        .execute(R"(INSERT INTO cities
+                    (__key, city, country, population) VALUES
+                    (1, 'London', 'United Kingdom', 9540576),
+                    (2, 'Manchester', 'United Kingdom', 2770434),
+                    (3, 'New York', 'United States', 19223191),
+                    (4, 'Los Angeles', 'United States', 3985520),
+                    (5, 'Istanbul', 'Türkiye', 15636243),
+                    (6, 'Ankara', 'Türkiye', 5309690),
+                    (7, 'Sao Paulo ', 'Brazil', 22429800))")
+                        .get();
+
+        std::cout << "OK." << std::endl;
+    } catch (hazelcast::client::exception::iexception& e) {
+        // don't panic for duplicated keys.
+        std::cerr << "FAILED, duplicated keys " << e.what() << std::endl;
+    }
+}
+
+void
+fetch_cities(hazelcast::client::hazelcast_client client)
+{
+    std::cout << "Fetching cities...";
+
+    auto result =
+      client.get_sql().execute("SELECT __key, this FROM cities").get();
+
+    std::cout << "OK." << std::endl;
+    std::cout << "--Results of 'SELECT __key, this FROM cities'" << std::endl;
+
+    std::printf("| %-4s | %-20s | %-20s | %-15s |\n",
+                "id",
+                "country",
+                "city",
+                "population");
+
+    for (auto itr = result->iterator(); itr.has_next();) {
+        auto page = itr.next().get();
+
+        for (auto const& row : page->rows()) {
+
+            auto id = row.get_object<int32_t>("__key");
+            auto city = row.get_object<CityDTO>("this");
+            std::printf("| %-4d | %-20s | %-20s | %-15d |\n",
+                        *id,
+                        city->country.c_str(),
+                        city->cityName.c_str(),
+                        city->population);
+        }
+    }
+
+    std::cout
+      << "\n!! Hint !! You can execute your SQL queries on your Viridian "
+         "cluster over the management center. \n 1. Go to 'Management Center' "
+         "of your Hazelcast Viridian cluster. \n 2. Open the 'SQL Browser'. \n "
+         "3. Try to execute 'SELECT * FROM cities'.\n";
+}
+----
+
+The output of this code is given below:
+
+[source,bash]
+----
+Creating the mapping...OK.
+Inserting data...OK.
+Fetching cities...OK.
+--Results of 'SELECT __key, this FROM cities'
+|   id | country              | city                 | population      |
+|    2 | United Kingdom       | Manchester           | 2770434         |
+|    6 | Turkiye              | Ankara               | 5309690         |
+|    1 | United Kingdom       | London               | 9540576         |
+|    7 | Brazil               | Sao Paulo            | 22429800        |
+|    4 | United States        | Los Angeles          | 3985520         |
+|    5 | Turkiye              | Istanbul             | 15636243        |
+|    3 | United States        | New York             | 19223191        |
+----
+
+NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to insertion order.
+
+== Summary
+
+In this tutorial, you learned how to get started with the Hazelcast C++ Client, connect to a Viridian instance and put data into a distributed map.
+
+== See also
+
+There are many things you can do with the C++ Client. For more information, such as how you can query a map with predicates and SQL,
+check out the https://github.com/hazelcast/hazelcast-cpp-client[C++ Client repository] and the https://hazelcast.github.io/hazelcast-cpp-client/api-index.html[C++ API documentation] to better understand what is possible.
+
+If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
+To contribute to the client, take a look at https://github.com/hazelcast/hazelcast-cpp-client/issues[the issue list].

--- a/docs/modules/clients/pages/csharp-client-getting-started.adoc
+++ b/docs/modules/clients/pages/csharp-client-getting-started.adoc
@@ -1,13 +1,8 @@
-= Getting Started with the Hazelcast .NET Client
-:page-layout: tutorial
-:page-product: platform
-:page-categories: Get Started
-:page-lang: csharp
-:page-enterprise:
-:page-est-time: 5-10 mins
+= Get started with the Hazelcast .NET Client
+
 :description: In this tutorial you will see how to connect with the Hazelcast .NET client and manipulate a map.
 
-== What You'll Learn
+== What you'll learn
 
 {description}
 
@@ -27,7 +22,7 @@ Before you begin, make sure you have the following:
 4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.
 
-== Setup a Hazelcast Client
+== Set up a Hazelcast Client
 
 Create a new folder and navigate to it:
 
@@ -60,7 +55,7 @@ client.pfx
 
 To understand and use the client, review the https://hazelcast.github.io/hazelcast-csharp-client/versions.html[.NET API documentation] to discover what is possible.
 
-== Understanding the .NET Client
+== Understand the .NET Client
 
 The following section creates and starts a Hazelcast client with default configuration, and connects to your Viridian cluster before finally shutting the client down.
 
@@ -104,7 +99,7 @@ namespace Client
 }
 ----
 
-== Understanding the Hazelcast SQL API
+== Understand the Hazelcast SQL API
 
 Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
 
@@ -281,7 +276,7 @@ Fetching cities...OK.
 
 NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to insertion order.
 
-== Understanding the Hazelcast Map API
+== Understand the Hazelcast Map API
 
 A Hazelcast Map is a distributed key-value store, similar to C# dictionary. You can store key-value pairs in a Hazelcast Map.
 
@@ -386,10 +381,10 @@ NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to ent
 
 In this tutorial, you learned how to get started with the Hazelcast .NET Client and put data into a distributed map. 
 
-== See Also
+== See also
 
 There are many things you can do with the .NET Client. For more information, such as how you can query a map with predicates and SQL,
-check out our https://github.com/hazelcast/hazelcast-csharp-client[.NET Client repository] and our https://hazelcast.github.io/hazelcast-csharp-client/versions.html[.NET API documentation] to better understand what is possible.
+check out the https://github.com/hazelcast/hazelcast-csharp-client[.NET Client repository] and the https://hazelcast.github.io/hazelcast-csharp-client/versions.html[.NET API documentation] to better understand what is possible.
 
 If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
 To contribute to the client, take a look at https://github.com/hazelcast/hazelcast-csharp-client/issues[the issue list].

--- a/docs/modules/clients/pages/csharp-client-getting-started.adoc
+++ b/docs/modules/clients/pages/csharp-client-getting-started.adoc
@@ -1,0 +1,394 @@
+= Getting Started with the Hazelcast .NET Client
+:page-layout: tutorial
+:page-product: platform
+:page-categories: Get Started
+:page-lang: csharp
+:page-enterprise:
+:page-est-time: 5-10 mins
+:description: In this tutorial you will see how to connect with the Hazelcast .NET client and manipulate a map.
+
+== What You'll Learn
+
+{description}
+
+== Prerequisites
+
+* .NET SDK 6.0 or above
+* https://hazelcast.com/products/viridian/[Hazelcast Viridian Cloud Account]
+* An IDE
+
+== Start a Hazelcast Viridian Cloud Cluster
+
+1. Sign up for a Hazelcast Viridian Cloud account (free trial is available).
+2. Log in to your Hazelcast Viridian Cloud account and start your trial by filling in the welcome questionnaire.
+3. A Viridian cluster will be created automatically when you start your trial.
+4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
+5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.
+
+== Setup a Hazelcast Client
+
+Create a new folder and navigate to it:
+
+[source]
+----
+mkdir hazelcast-csharp-example
+cd hazelcast-csharp-example
+----
+
+Create a new .NET Console project using the command-line tool:
+
+[source]
+----
+dotnet new console
+----
+
+Add the Hazelcast.NET Client as a dependency:
+
+[source]
+----
+dotnet add Hazelcast.Net
+----
+
+Extract the keystore files you downloaded from Viridian into this directory. The files you need for this tutorial are:
+
+[source,bash]
+----
+client.pfx
+----
+
+To understand and use the client, review the https://hazelcast.github.io/hazelcast-csharp-client/versions.html[.NET API documentation] to discover what is possible.
+
+== Understanding the .NET Client
+
+The following section creates and starts a Hazelcast client with default configuration, and connects to your Viridian cluster before finally shutting the client down.
+
+Create a C# file named “Program.cs” and include the following code in it:
+
+[source,cs]
+----
+using Hazelcast;
+
+using System;
+
+namespace Client
+{
+    internal static class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            // Create a client connection            
+            var options = new HazelcastOptionsBuilder()
+                .With(config =>
+                {
+                    // Your Viridian cluster name.
+                    config.ClusterName = "<YOUR_CLUSTER_ID>";
+
+                    // Your discovery token to connect Viridian cluster.
+                    config.Networking.Cloud.DiscoveryToken = "<YOUR_DISCOVERY_TOKEN>";
+
+                    // Configure SSL.
+                    config.Networking.Ssl.Enabled = true;
+                    config.Networking.Ssl.ValidateCertificateChain = false;
+                    config.Networking.Ssl.CertificatePath = "client.pfx";
+                    config.Networking.Ssl.CertificatePassword = "<YOUR_CERTIFICATE_PASSWORD>";
+                })
+                .With(args) // Pass command line args to the client
+                .Build();
+
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
+
+            // take actions
+        }
+}
+----
+
+== Understanding the Hazelcast SQL API
+
+Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
+
+In the following example, we will create a map and insert entries into it where the keys are ids and the values are defined as an object representing a city.
+
+[source,cs]
+----
+using Hazelcast;
+using Hazelcast.Serialization.Compact;
+
+namespace Client
+{
+    internal class CityDTO
+    {
+        public string City { get; set; }
+        public string Country { get; set; }
+        public int Population { get; set; }
+    }
+
+    internal class CitySerializer : ICompactSerializer<CityDTO>
+    {
+        public string TypeName => "CityDTO";
+
+        public CityDTO Read(ICompactReader reader)
+        {
+            return new CityDTO()
+            {
+                City = reader.ReadString("city"),
+                Country = reader.ReadString("country"),
+                Population = reader.ReadInt32("population")
+            };
+        }
+
+        public void Write(ICompactWriter writer, CityDTO value)
+        {
+            writer.WriteString("city", value.City);
+            writer.WriteString("country", value.Country);
+            writer.WriteInt32("population", value.Population);
+        }
+    }
+
+    internal static class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            // Create a client connection
+            var options = new HazelcastOptionsBuilder()
+                .With(config =>
+                {
+                    // Your Viridian cluster name.
+                    config.ClusterName = "<YOUR_CLUSTER_ID>";
+
+                    // Your discovery token to connect Viridian cluster.
+                    config.Networking.Cloud.DiscoveryToken = "<YOUR_DISCOVERY_TOKEN>";
+
+                    // Configure SSL.
+                    config.Networking.Ssl.Enabled = true;
+                    config.Networking.Ssl.ValidateCertificateChain = false;
+                    config.Networking.Ssl.CertificatePath = "client.pfx";
+                    config.Networking.Ssl.CertificatePassword = "<YOUR_CERTIFICATE_PASSWORD>";
+
+                    // Register Compact serializer of City class.
+                    config.Serialization.Compact.AddSerializer(new CitySerializer());
+                })
+                .With(args) // Pass command line args to the client
+                .Build();
+
+            // Connect to your Hazelcast Cluster
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
+
+            // Create a map on the cluster
+            await CreateMapping(client);
+
+            // Add some data
+            await PopulateCities(client);
+
+            // Output the data
+            await FetchCities(client);
+        }
+
+        private static async Task CreateMapping(IHazelcastClient client)
+        {
+            // Mapping is required for your distributed map to be queried over SQL.
+            // See: https://docs.hazelcast.com/hazelcast/latest/sql/mapping-to-maps
+
+            Console.Write("\nCreating the mapping...");
+
+            var mappingCommand = @"CREATE OR REPLACE MAPPING
+                                    cities (
+                                        __key INT,
+                                        country VARCHAR,
+                                        city VARCHAR,
+                                        population INT) TYPE IMAP
+                                    OPTIONS (
+                                        'keyFormat' = 'int',
+                                        'valueFormat' = 'compact',
+                                        'valueCompactTypeName' = 'CityDTO')";
+
+            await client.Sql.ExecuteCommandAsync(mappingCommand);
+
+            Console.Write("OK.");
+        }
+
+        private static async Task PopulateCities(IHazelcastClient client)
+        {
+            var deleteQuery = @"DELETE FROM cities";
+
+            var insertQuery = @"INSERT INTO cities
+                                (__key, city, country, population) VALUES
+                                (1, 'London', 'United Kingdom', 9540576),
+                                (2, 'Manchester', 'United Kingdom', 2770434),
+                                (3, 'New York', 'United States', 19223191),
+                                (4, 'Los Angeles', 'United States', 3985520),
+                                (5, 'Istanbul', 'Türkiye', 15636243),
+                                (6, 'Ankara', 'Türkiye', 5309690),
+                                (7, 'Sao Paulo ', 'Brazil', 22429800)";
+
+            try
+            {
+                Console.Write("\nInserting data...");
+                await client.Sql.ExecuteCommandAsync(deleteQuery);
+                await client.Sql.ExecuteCommandAsync(insertQuery);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("FAILED. "+ex.ToString());
+            }
+
+            Console.Write("OK.");
+        }
+
+        private static async Task FetchCities(IHazelcastClient client)
+        {
+            Console.Write("\nFetching cities...");
+
+            await using var result = await client.Sql.ExecuteQueryAsync("SELECT __key, this FROM cities");
+            Console.Write("OK.");
+            Console.WriteLine("\n--Results of 'SELECT __key, this FROM cities'");
+            Console.WriteLine(String.Format("| {0,4} | {1,20} | {2,20} | {3,15} |","id", "country", "city", "population"));
+
+            await foreach (var row in result)
+            {
+                var id = row.GetKey<int>();      // Corresponds to '__key'
+                var c = row.GetValue<CityDTO>(); // Corresponds to 'this'
+
+                Console.WriteLine(string.Format("| {0,4} | {1,20} | {2,20} | {3,15} |",
+                                    id,
+                                    c.Country,
+                                    c.City,
+                                    c.Population));
+            }
+        }
+    }
+}
+----
+
+The output of this code is given below:
+
+[source,bash]
+----
+Creating the mapping...OK.
+Inserting data...OK.
+Fetching cities...OK.
+--Results of 'SELECT __key, this FROM cities'
+|   id | country              | city                 | population      |
+|    2 | United Kingdom       | Manchester           | 2770434         |
+|    6 | Türkiye              | Ankara               | 5309690         |
+|    1 | United Kingdom       | London               | 9540576         |
+|    7 | Brazil               | Sao Paulo            | 22429800        |
+|    4 | United States        | Los Angeles          | 3985520         |
+|    5 | Türkiye              | Istanbul             | 15636243        |
+|    3 | United States        | New York             | 19223191        |
+----
+
+NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to insertion order.
+
+== Understanding the Hazelcast Map API
+
+A Hazelcast Map is a distributed key-value store, similar to C# dictionary. You can store key-value pairs in a Hazelcast Map.
+
+In the following example, we will work with map entries where the keys are ids and the values are defined as an object representing a city.
+
+[source,cs]
+----
+using Hazelcast;
+
+namespace Client
+{
+    internal static class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            // Create a client connection
+            var options = new HazelcastOptionsBuilder()
+                .With(config =>
+                {
+                    // Your Viridian cluster name.
+                    config.ClusterName = "<YOUR_CLUSTER_ID>";
+
+                    // Your discovery token to connect Viridian cluster.
+                    config.Networking.Cloud.DiscoveryToken = "<YOUR_DISCOVERY_TOKEN>";
+
+                    // Configure SSL.
+                    config.Networking.Ssl.Enabled = true;
+                    config.Networking.Ssl.ValidateCertificateChain = false;
+                    config.Networking.Ssl.CertificatePath = "client.pfx";
+                    config.Networking.Ssl.CertificatePassword = "<YOUR_CERTIFICATE_PASSWORD>";
+                })
+                .With(args) // Pass command line args to the client
+                .Build();
+
+            await using var client = await HazelcastClientFactory.StartNewClientAsync(options);
+
+            // Create a map on the cluster
+            await using var citiesMap = await client.GetMapAsync<int, string>("cities");
+
+            // Add some data
+            await citiesMap.PutAsync(1, "London");
+            await citiesMap.PutAsync(2, "New York");
+            await citiesMap.PutAsync(3, "Tokyo");
+
+            // Output the data
+            var entries = citiesMap.GetEntriesAsync();
+
+            foreach (var entry in entries.Result)
+            {
+                Console.WriteLine($"{entry.Key} -> {entry.Value}");
+            }
+        }
+}
+----
+
+The following line returns a map proxy object for the `cities` map:
+
+[source,cs]
+----
+            // Create a map on the cluster
+            await using var citiesMap = await client.GetMapAsync<int, string>("cities");
+----
+
+If `cities` doesn't exist, it will be automatically created. All the clients connected to the same cluster will have access to the same map.
+
+With these lines, the client adds data to the `cities` map. The first parameter is the key of the entry, the second one is the value.
+
+[source,cs]
+----
+            // Add some data
+            await citiesMap.PutAsync(1, "London");
+            await citiesMap.PutAsync(2, "New York");
+            await citiesMap.PutAsync(3, "Tokyo");
+----
+
+Then, we get the data using the `GetEntriesAsync()` method and iterate over the results.
+
+[source,cs]
+----
+            // Output the data
+            var entries = citiesMap.GetEntriesAsync();
+
+            foreach (var entry in entries.Result)
+            {
+                Console.WriteLine($"{entry.Key} -> {entry.Value}");
+            }
+----
+
+The output of this code is given below:
+
+[source,bash]
+----
+2 -> New York
+1 -> London
+3 -> Tokyo
+----
+
+NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to entry order.
+
+
+== Summary
+
+In this tutorial, you learned how to get started with the Hazelcast .NET Client and put data into a distributed map. 
+
+== See Also
+
+There are many things you can do with the .NET Client. For more information, such as how you can query a map with predicates and SQL,
+check out our https://github.com/hazelcast/hazelcast-csharp-client[.NET Client repository] and our https://hazelcast.github.io/hazelcast-csharp-client/versions.html[.NET API documentation] to better understand what is possible.
+
+If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
+To contribute to the client, take a look at https://github.com/hazelcast/hazelcast-csharp-client/issues[the issue list].
+

--- a/docs/modules/clients/pages/csharp-client-getting-started.adoc
+++ b/docs/modules/clients/pages/csharp-client-getting-started.adoc
@@ -13,6 +13,8 @@
 
 == Prerequisites
 
+Before you begin, make sure you have the following:
+
 * .NET SDK 6.0 or above
 * https://hazelcast.com/products/viridian/[Hazelcast Viridian Cloud Account]
 * An IDE

--- a/docs/modules/clients/pages/go-client-getting-started.adoc
+++ b/docs/modules/clients/pages/go-client-getting-started.adoc
@@ -1,13 +1,8 @@
-= Getting Started with the Hazelcast Go Client
-:page-layout: tutorial
-:page-product: platform
-:page-categories: Get Started
-:page-lang: go
-:page-enterprise:
-:page-est-time: 5-10 mins
+= Get started with the Hazelcast Go Client
+
 :description: This tutorial will get you started with the Hazelcast Go client and show you how to manipulate a map.
 
-== What You'll Learn
+== What you'll learn
 
 {description}
 
@@ -27,7 +22,7 @@ Before you begin, make sure you have the following:
 4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later. 
 
-== Setup a Hazelcast Client
+== Set up a Hazelcast Client
 
 Create a new folder and navigate to it:
 
@@ -60,7 +55,7 @@ cert.pem
 key.pem
 ----
 
-== Understanding the Go Client
+== Understand the Go Client
 
 The following section creates and starts a Hazelcast client with default configuration, and connects to your Viridian cluster before finally shutting down the client.
 
@@ -110,7 +105,7 @@ To run this Go script, use the following command:
 go run example.go
 ----
 
-== Understanding the Hazelcast SQL API
+== Understand the Hazelcast SQL API
 
 Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
 
@@ -316,10 +311,10 @@ Fetching cities...OK.
 
 In this tutorial, you learned how to get started with the Hazelcast Go Client, connect to a Viridian instance and put data into a distributed map.
 
-== See Also
+== See also
 
 There are many things you can do with the Go Client. For more information, such as how you can query a map with predicates and SQL,
-check out our https://github.com/hazelcast/hazelcast-go-client[Go Client repository] and our https://pkg.go.dev/github.com/hazelcast/hazelcast-go-client[Go API documentation] to better understand what is possible.
+check out the https://github.com/hazelcast/hazelcast-go-client[Go Client repository] and the https://pkg.go.dev/github.com/hazelcast/hazelcast-go-client[Go API documentation] to better understand what's possible.
 
 If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
 To contribute to the client, take a look at https://github.com/hazelcast/hazelcast-go-client/issues[the issue list].

--- a/docs/modules/clients/pages/go-client-getting-started.adoc
+++ b/docs/modules/clients/pages/go-client-getting-started.adoc
@@ -1,0 +1,325 @@
+= Getting Started with the Hazelcast Go Client
+:page-layout: tutorial
+:page-product: platform
+:page-categories: Get Started
+:page-lang: go
+:page-enterprise:
+:page-est-time: 5-10 mins
+:description: This tutorial will get you started with the Hazelcast Go client and show you how to manipulate a map.
+
+== What You'll Learn
+
+{description}
+
+== Prerequisites
+
+Before you begin, make sure you have the following:
+
+* Go 1.15 or above
+* https://hazelcast.com/products/viridian/[Hazelcast Viridian Cloud Account]
+* A text editor or IDE
+
+== Start a Hazelcast Viridian Cloud Cluster
+
+1. Sign up for a Hazelcast Viridian Cloud account (free trial is available).
+2. Log in to your Hazelcast Viridian Cloud account and start your trial by filling in the welcome questionnaire.
+3. A Viridian cluster will be created automatically when you start your trial.
+4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
+5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later. 
+
+== Setup a Hazelcast Client
+
+Create a new folder and navigate to it:
+
+[source]
+----
+mkdir hazelcast-go-example
+cd hazelcast-go-example
+----
+
+Initialize a new go module:
+
+[source,bash]
+----
+go mod init example
+----
+
+Install Hazelcast Go client's latest version as a dependency:
+
+[source,bash]
+----
+go get github.com/hazelcast/hazelcast-go-client@latest
+----
+
+Extract the keystore files you downloaded from Viridian into this directory. The files you need for this tutorial are:
+
+[source,bash]
+----
+ca.pem
+cert.pem
+key.pem
+----
+
+== Understanding the Go Client
+
+The following section creates and starts a Hazelcast client with default configuration, and connects to your Viridian cluster before finally shutting down the client.
+
+Create a Go file named “example.go” and insert the following code in it:
+
+[source,go]
+----
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hazelcast/hazelcast-go-client"
+)
+
+func main() {
+
+	// Connection details for cluster
+	config := hazelcast.Config{}
+	config.Cluster.Name = "<YOUR_CLUSTER_ID>"
+
+	config.Cluster.Cloud.Enabled = true
+	config.Cluster.Cloud.Token = "<YOUR_DISCOVERY_TOKEN>"
+
+	config.Cluster.Network.SSL.SetCAPath("ca.pem")
+	config.Cluster.Network.SSL.AddClientCertAndEncryptedKeyPath("cert.pem", "key.pem", "<YOUR_CERTIFICATE_PASSWORD>")
+
+	// create the client and connect to the cluster
+	client, err := hazelcast.StartNewClientWithConfig(context.TODO(), config)
+	// error checking is omitted for brevity
+
+	fmt.Println("Welcome to your Hazelcast Viridian Cluster!")
+
+	defer client.Shutdown(context.TODO())
+
+	if err != nil {
+		panic(err)
+	}
+}
+----
+
+To run this Go script, use the following command:
+
+[source,bash]
+----
+go run example.go
+----
+
+== Understanding the Hazelcast SQL API
+
+Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
+
+In the following example, we will create a map and insert entries into it where the keys are ids and the values are defined as an object representing a city.
+
+[source,go]
+----
+package main
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/logger"
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+type CityDTO struct {
+	city       string
+	country    string
+	population int32
+}
+
+type CitySerializer struct{}
+
+func (s CitySerializer) Type() reflect.Type {
+	return reflect.TypeOf(CityDTO{})
+}
+
+func (s CitySerializer) TypeName() string {
+	return "CityDTO"
+}
+
+func (s CitySerializer) Write(writer serialization.CompactWriter, value interface{}) {
+	city := value.(CityDTO)
+
+	writer.WriteString("City", &city.city)
+	writer.WriteString("Country", &city.country)
+	writer.WriteInt32("Population", city.population)
+}
+
+func (s CitySerializer) Read(reader serialization.CompactReader) interface{} {
+	return CityDTO{
+		city:       *reader.ReadString("city"),
+		country:    *reader.ReadString("country"),
+		population: reader.ReadInt32("population"),
+	}
+}
+
+func createMapping(ctx context.Context, client hazelcast.Client) error {
+	fmt.Println("Creating the mapping...")
+
+	// Mapping is required for your distributed map to be queried over SQL.
+	// See: https://docs.hazelcast.com/hazelcast/latest/sql/mapping-to-maps
+	mappingQuery := `
+        CREATE OR REPLACE MAPPING
+        cities (
+            __key INT,
+            country VARCHAR,
+            city VARCHAR,
+            population INT) TYPE IMAP
+        OPTIONS (
+            'keyFormat' = 'int',
+            'valueFormat' = 'compact',
+            'valueCompactTypeName' = 'CityDTO')
+    `
+
+	_, err := client.SQL().Execute(ctx, mappingQuery)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("OK.\n")
+	return nil
+}
+
+func populateCities(ctx context.Context, client hazelcast.Client) error {
+	fmt.Println("Inserting data...")
+
+	// Mapping is required for your distributed map to be queried over SQL.
+	// See: https://docs.hazelcast.com/hazelcast/latest/sql/mapping-to-maps
+	insertQuery := `
+		INSERT INTO cities
+		(__key, city, country, population) VALUES
+		(1, 'London', 'United Kingdom', 9540576),
+		(2, 'Manchester', 'United Kingdom', 2770434),
+		(3, 'New York', 'United States', 19223191),
+		(4, 'Los Angeles', 'United States', 3985520),
+		(5, 'Istanbul', 'Türkiye', 15636243),
+		(6, 'Ankara', 'Türkiye', 5309690),
+		(7, 'Sao Paulo ', 'Brazil', 22429800)
+    `
+
+	_, err := client.SQL().Execute(ctx, "DELETE from cities")
+	if err != nil {
+		return err
+	}
+	_, err = client.SQL().Execute(ctx, insertQuery)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("OK.\n")
+	return nil
+}
+
+func fetchCities(ctx context.Context, client hazelcast.Client) error {
+	fmt.Println("Fetching cities...")
+
+	result, err := client.SQL().Execute(ctx, "SELECT __key, this FROM cities")
+	if err != nil {
+		return err
+	}
+	defer result.Close()
+
+	fmt.Println("OK.")
+	fmt.Println("--Results of SELECT __key, this FROM cities")
+	fmt.Printf("| %4s | %20s | %20s | %15s |\n", "id", "country", "city", "population")
+
+	iter, err := result.Iterator()
+	for iter.HasNext() {
+		row, err := iter.Next()
+
+		key, err := row.Get(0)
+		cityDTO, err := row.Get(1)
+
+		fmt.Printf("| %4d | %20s | %20s | %15d |\n", key.(int32), cityDTO.(CityDTO).country, cityDTO.(CityDTO).city, cityDTO.(CityDTO).population)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("\n!! Hint !! You can execute your SQL queries on your Viridian cluster over the management center. \n 1. Go to 'Management Center' of your Hazelcast Viridian cluster. \n 2. Open the 'SQL Browser'. \n 3. Try to execute 'SELECT * FROM cities'.")
+	return nil
+}
+
+///////////////////////////////////////////////////////
+
+func main() {
+
+	// Connection details for cluster
+	config := hazelcast.Config{}
+	config.Cluster.Name = "<YOUR_CLUSTER_ID>"
+
+	config.Cluster.Cloud.Enabled = true
+	config.Cluster.Cloud.Token = "<YOUR_DISCOVERY_TOKEN>"
+
+	config.Cluster.Network.SSL.SetCAPath("ca.pem")
+	config.Cluster.Network.SSL.AddClientCertAndEncryptedKeyPath("cert.pem", "key.pem", "<YOUR_CERTIFICATE_PASSWORD>")
+
+	// Register Compact Serializers
+	config.Serialization.Compact.SetSerializers(CitySerializer{})
+
+	// Other environment propreties
+	config.Logger.Level = logger.FatalLevel
+
+	ctx := context.TODO()
+	// create the client and connect to the cluster
+	client, err := hazelcast.StartNewClientWithConfig(ctx, config)
+	if err != nil {
+		panic(err)
+	}
+
+	//
+	if err := createMapping(ctx, *client); err != nil {
+		panic(fmt.Errorf("creating mapping: %w", err))
+	}
+	if err := populateCities(ctx, *client); err != nil {
+		panic(fmt.Errorf("populating cities: %w", err))
+	}
+	if err := fetchCities(ctx, *client); err != nil {
+		panic(fmt.Errorf("fetching cities: %w", err))
+	}
+
+	if err := client.Shutdown(ctx); err != nil {
+		panic(err)
+	}
+}
+----
+
+The output of this code is given below:
+
+[source,bash]
+----
+Creating the mapping...OK.
+Inserting data...OK.
+Fetching cities...OK.
+--Results of 'SELECT __key, this FROM cities'
+|   id | country              | city                 | population      |
+|    2 | United Kingdom       | Manchester           | 2770434         |
+|    6 | Türkiye              | Ankara               | 5309690         |
+|    1 | United Kingdom       | London               | 9540576         |
+|    7 | Brazil               | Sao Paulo            | 22429800        |
+|    4 | United States        | Los Angeles          | 3985520         |
+|    5 | Türkiye              | Istanbul             | 15636243        |
+|    3 | United States        | New York             | 19223191        |
+----
+
+== Summary
+
+In this tutorial, you learned how to get started with the Hazelcast Go Client, connect to a Viridian instance and put data into a distributed map.
+
+== See Also
+
+There are many things you can do with the Go Client. For more information, such as how you can query a map with predicates and SQL,
+check out our https://github.com/hazelcast/hazelcast-go-client[Go Client repository] and our https://pkg.go.dev/github.com/hazelcast/hazelcast-go-client[Go API documentation] to better understand what is possible.
+
+If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
+To contribute to the client, take a look at https://github.com/hazelcast/hazelcast-go-client/issues[the issue list].

--- a/docs/modules/clients/pages/java-client-getting-started.adoc
+++ b/docs/modules/clients/pages/java-client-getting-started.adoc
@@ -1,13 +1,8 @@
-= Getting Started with the Hazelcast Java Client
-:page-layout: tutorial
-:page-product: platform
-:page-categories: Get Started
-:page-lang: java
-:page-enterprise:
-:page-est-time: 5-10 mins
+= Get started with the Hazelcast Java Client
+
 :description: This tutorial will get you started with the Hazelcast Java client and show you how to manipulate a map.
 
-== What You'll Learn
+== What you'll learn
 
 {description}
 
@@ -27,7 +22,7 @@ Before you begin, make sure you have the following:
 4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.
 
-== Setup a Hazelcast Client
+== Set up a Hazelcast Client
 
 Create a new folder and navigate to it:
 
@@ -55,7 +50,7 @@ client.truststore
 
 To understand and use the client, review the https://docs.hazelcast.com/hazelcast/5.3/clients/java#hide-nav[Java client documentation] to discover what is possible.
 
-== Understanding the Java Client
+== Understand the Java Client
 
 The following section creates and starts a Hazelcast client with default configuration, connects to your Viridian cluster before finally shutting down the client.
 
@@ -103,7 +98,7 @@ public class Example {
 }
 ----
 
-== Understanding the Hazelcast SQL API
+== Understand the Hazelcast SQL API
 
 Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
 
@@ -312,7 +307,7 @@ Fetching cities...OK.
 
 NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to insertion order.
 
-== Understanding the Hazelcast IMap API
+== Understand the Hazelcast IMap API
 
 A Hazelcast Map is a distributed key-value store, similar to Python dictionary. You can store key-value pairs in a Hazelcast Map.
 
@@ -429,12 +424,10 @@ NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to ent
 
 In this tutorial, you learned how to get started with the Hazelcast Java Client, connect to a Viridian instance and put data into a distributed map.
 
-== See Also
+== See also
 
 There are many things  you can do with the Java Client. For more information, such as how you can query a map with predicates and SQL,
-check out our https://github.com/hazelcast/hazelcast[Hazelcast repository] and our https://docs.hazelcast.com/hazelcast/5.3/clients/java#hide-nav[Java client documentation] to better understand what is possible.
+check out the https://github.com/hazelcast/hazelcast[Hazelcast repository] and the https://docs.hazelcast.com/hazelcast/5.3/clients/java#hide-nav[Java client documentation] to better understand what's possible.
 
 If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
 To contribute to the client, take a look at https://github.com/hazelcast/hazelcast/issues[the issue list].
-
-

--- a/docs/modules/clients/pages/java-client-getting-started.adoc
+++ b/docs/modules/clients/pages/java-client-getting-started.adoc
@@ -1,0 +1,440 @@
+= Getting Started with the Hazelcast Java Client
+:page-layout: tutorial
+:page-product: platform
+:page-categories: Get Started
+:page-lang: java
+:page-enterprise:
+:page-est-time: 5-10 mins
+:description: This tutorial will get you started with the Hazelcast Java client and show you how to manipulate a map.
+
+== What You'll Learn
+
+{description}
+
+== Prerequisites
+
+Before you begin, make sure you have the following:
+
+* JDK 11.0 or above
+* https://hazelcast.com/products/viridian/[Hazelcast Viridian Cloud Account]
+* An IDE
+
+== Start a Hazelcast Viridian Cloud Cluster
+
+1. Sign up for a Hazelcast Viridian Cloud account (free trial is available).
+2. Log in to your Hazelcast Viridian Cloud account and start your trial by filling in the welcome questionnaire.
+3. A Viridian cluster will be created automatically when you start your trial.
+4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
+5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.
+
+== Setup a Hazelcast Client
+
+Create a new folder and navigate to it:
+
+[source]
+----
+mkdir hazelcast-java-example
+cd hazelcast-java-example
+----
+
+Download the latest version of Hazelcast Enterprise zip slim from https://hazelcast.com/get-started/download/[here] and extract the Hazelcast Enterprise jar into this directory:
+
+[source]
+----
+hazelcast-enterprise-5.3.1.jar
+----
+
+Extract the keystore files you downloaded from Viridian into this directory. The files you need for this tutorial are:
+
+[source,bash]
+----
+client.keystore
+client.pfx
+client.truststore
+----
+
+To understand and use the client, review the https://docs.hazelcast.com/hazelcast/5.3/clients/java#hide-nav[Java client documentation] to discover what is possible.
+
+== Understanding the Java Client
+
+The following section creates and starts a Hazelcast client with default configuration, connects to your Viridian cluster before finally shutting down the client.
+
+Create a Java file named “Example.java” and insert the following code in it:
+
+[source,java]
+----
+import java.util.Properties;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.SSLConfig;
+import com.hazelcast.core.HazelcastInstance;
+
+public class Example {
+
+    public static void main(String[] args) throws Exception {
+        ClientConfig config = new ClientConfig();
+
+        // Your Viridian cluster name.
+        config.setClusterName("<YOUR_CLUSTER_ID>");
+
+        // Your discovery token to connect Viridian cluster.
+        config.getNetworkConfig().getCloudConfig()
+                .setDiscoveryToken("<YOUR_DISCOVERY_TOKEN>")
+                .setEnabled(true);
+
+        // Configure SSL
+        ClassLoader classLoader = ClientWithSsl.class.getClassLoader();
+        Properties props = new Properties();
+        props.setProperty("javax.net.ssl.keyStore", classLoader.getResource("client.keystore").toURI().getPath());
+        props.setProperty("javax.net.ssl.keyStorePassword", "<YOUR_CERTIFICATE_PASSWORD>");
+        props.setProperty("javax.net.ssl.trustStore",
+                classLoader.getResource("client.truststore").toURI().getPath());
+        props.setProperty("javax.net.ssl.trustStorePassword", "<YOUR_CERTIFICATE_PASSWORD>");
+        config.getNetworkConfig().setSSLConfig(new SSLConfig().setEnabled(true).setProperties(props));
+
+        // Create client
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
+
+        System.out.println("Welcome to your Hazelcast Viridian Cluster!")
+
+        client.shutdown();
+    }
+}
+----
+
+== Understanding the Hazelcast SQL API
+
+Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
+
+In the following example, we will create a map and insert entries into it where the keys are ids and the values are defined as an object representing a city.
+
+[source,java]
+----
+import java.util.Properties;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.SSLConfig;
+import com.hazelcast.core.HazelcastInstance;
+
+import com.hazelcast.nio.serialization.compact.CompactReader;
+import com.hazelcast.nio.serialization.compact.CompactSerializer;
+import com.hazelcast.nio.serialization.compact.CompactWriter;
+import com.hazelcast.sql.SqlResult;
+import com.hazelcast.sql.SqlRow;
+import com.hazelcast.sql.SqlService;
+
+public class Example {
+
+    public final class CityDTO {
+
+        private final String country;
+
+        private final String city;
+
+        private final int population;
+
+        public CityDTO(String country, String city, int population) {
+            this.country = country;
+            this.city = city;
+            this.population = population;
+        }
+
+        public String getCountry() {
+            return country;
+        }
+
+        public String getCity() {
+            return city;
+        }
+
+        public int getPopulation() {
+            return population;
+        }
+    }
+
+    public final class CitySerializer implements CompactSerializer<CityDTO> {
+        @Override
+        public CityDTO read(CompactReader compactReader) {
+            return new CityDTO(compactReader.readString("country"),
+                            compactReader.readString("city"),
+                            compactReader.readInt32("population"));
+        }
+
+        @Override
+        public void write(CompactWriter compactWriter, CityDTO city) {
+            compactWriter.writeString("country", city.getCountry());
+            compactWriter.writeString("city", city.getCity());
+            compactWriter.writeInt32("population", city.getPopulation());
+        }
+
+        @Override
+        public String getTypeName() {
+            return "CityDTO";
+        }
+
+        @Override
+        public Class<CityDTO> getCompactClass() {
+            return CityDTO.class;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        ClientConfig config = new ClientConfig();
+
+        // Connection details for cluster
+        config.setClusterName("<YOUR_CLUSTER_ID>");
+
+        config.getNetworkConfig().getCloudConfig()
+                .setDiscoveryToken("<YOUR_DISCOVERY_TOKEN>")
+                .setEnabled(true);
+
+        ClassLoader classLoader = Example.class.getClassLoader();
+        Properties props = new Properties();
+        props.setProperty("javax.net.ssl.keyStore", classLoader.getResource("client.keystore").toURI().getPath());
+        props.setProperty("javax.net.ssl.keyStorePassword", "<YOUR_CERTIFICATE_PASSWORD>");
+        props.setProperty("javax.net.ssl.trustStore", classLoader.getResource("client.truststore").toURI().getPath());
+        props.setProperty("javax.net.ssl.trustStorePassword", "<YOUR_CERTIFICATE_PASSWORD>");
+        config.getNetworkConfig().setSSLConfig(new SSLConfig().setEnabled(true).setProperties(props));
+
+        // Register Compact Serializers
+        config.getSerializationConfig().getCompactSerializationConfig()
+            .addSerializer(new Example().new CitySerializer());
+
+        // Connect to your Hazelcast Cluster
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
+
+        try {
+            // Create a map on the cluster
+            createMapping(client.getSql());
+
+            // Add some data
+            insertCities(client);
+
+            // Output the data
+            fetchCities(client.getSql());
+
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    private static void createMapping(SqlService sqlService) {
+        // See: https://docs.hazelcast.com/hazelcast/latest/sql/mapping-to-maps#compact-objects
+        System.out.print("\nCreating mapping...");
+
+        String mappingSql = ""
+                + "CREATE OR REPLACE MAPPING cities("
+                + "     __key INT,"
+                + "     country VARCHAR,"
+                + "     city VARCHAR,"
+                + "     population INT"
+                + ") TYPE IMap"
+                + " OPTIONS ("
+                + "     'keyFormat' = 'int',"
+                + "     'valueFormat' = 'compact',"
+                + "     'valueCompactTypeName' = 'Example$CityDTO'"
+                + " )";
+
+        try (SqlResult ignored = sqlService.execute(mappingSql)) {
+            System.out.print("OK.");
+        } catch (Exception ex) {
+            System.out.print("FAILED. " + ex.getMessage());
+        }
+    }
+
+    private static void insertCities(HazelcastInstance client) {
+        try {
+            String deleteQuery = "DELETE from cities";
+
+            String insertQuery = "INSERT INTO cities "
+                + "(__key, city, country, population) VALUES"
+                + "(1, 'London', 'United Kingdom', 9540576),"
+                + "(2, 'Manchester', 'United Kingdom', 2770434),"
+                + "(3, 'New York', 'United States', 19223191),"
+                + "(4, 'Los Angeles', 'United States', 3985520),"
+                + "(5, 'Istanbul', 'Türkiye', 15636243),"
+                + "(6, 'Ankara', 'Türkiye', 5309690),"
+                + "(7, 'Sao Paulo ', 'Brazil', 22429800)";
+
+            System.out.print("\nInserting data...");
+            client.getSql().execute(deleteQuery);
+            client.getSql().execute(insertQuery);
+            System.out.print("OK.");
+        } catch (Exception ex) {
+            System.out.print("FAILED. " + ex.getMessage());
+        }
+    }
+
+    private static void fetchCities(SqlService sqlService) {
+        System.out.print("\nFetching cities...");
+
+        try (SqlResult result = sqlService.execute("SELECT __key, this FROM cities")) {
+            System.out.print("OK.\n");
+            System.out.println("--Results of 'SELECT __key, this FROM cities'");
+
+            System.out.printf("%4s | %20s | %20s | %15s |%n", "id", "country", "city", "population");
+            for (SqlRow row : result) {
+                int id = row.getObject("__key");
+                CityDTO cityDTO = row.getObject("this");
+                System.out.printf("%4s | %20s | %20s | %15s |%n",
+                        id,
+                        cityDTO.getCountry(),
+                        cityDTO.getCity(),
+                        cityDTO.getPopulation()
+                );
+            }
+        } catch (Exception ex) {
+            System.out.print("FAILED. " + ex.getMessage());
+        }
+    }
+}
+----
+
+The output of this code is given below:
+
+[source,bash]
+----
+Creating the mapping...OK.
+Inserting data...OK.
+Fetching cities...OK.
+--Results of 'SELECT __key, this FROM cities'
+|   id | country              | city                 | population      |
+|    2 | United Kingdom       | Manchester           | 2770434         |
+|    6 | Türkiye              | Ankara               | 5309690         |
+|    1 | United Kingdom       | London               | 9540576         |
+|    7 | Brazil               | Sao Paulo            | 22429800        |
+|    4 | United States        | Los Angeles          | 3985520         |
+|    5 | Türkiye              | Istanbul             | 15636243        |
+|    3 | United States        | New York             | 19223191        |
+----
+
+NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to insertion order.
+
+== Understanding the Hazelcast IMap API
+
+A Hazelcast Map is a distributed key-value store, similar to Python dictionary. You can store key-value pairs in a Hazelcast Map.
+
+In the following example, we will work with map entries where the keys are ids and the values are defined as a string representing a city name.
+
+[source,java]
+----
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.SSLConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+
+public class Example {
+
+    public static void main(String[] args) throws Exception {
+        ClientConfig config = new ClientConfig();
+
+        // Your Viridian cluster name.
+        config.setClusterName("<YOUR_CLUSTER_ID>");
+
+        // Your discovery token to connect Viridian cluster.
+        config.getNetworkConfig().getCloudConfig()
+                .setDiscoveryToken("<YOUR_DISCOVERY_TOKEN>")
+                .setEnabled(true);
+
+        // Configure SSL
+        ClassLoader classLoader = ClientWithSsl.class.getClassLoader();
+        Properties props = new Properties();
+        props.setProperty("javax.net.ssl.keyStore", classLoader.getResource("client.keystore").toURI().getPath());
+        props.setProperty("javax.net.ssl.keyStorePassword", "<YOUR_CERTIFICATE_PASSWORD>");
+        props.setProperty("javax.net.ssl.trustStore", classLoader.getResource("client.truststore").toURI().getPath());
+        props.setProperty("javax.net.ssl.trustStorePassword", "<YOUR_CERTIFICATE_PASSWORD>");
+        config.getNetworkConfig().setSSLConfig(new SSLConfig().setEnabled(true).setProperties(props));
+
+        // Create client
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
+
+        try {
+            // Create a map on the cluster
+            IMap<Integer, String> citiesMap = client.getMap("cities");
+
+            // Clear the map
+            citiesMap.clear();
+
+            // Add some data
+            citiesMap.put(1, "London");
+            citiesMap.put(2, "New York");
+            citiesMap.put(3, "Tokyo");
+
+            // Output the data
+            Set<Map.Entry<Integer, String>> entries = citiesMap.entrySet();
+
+            for (Map.Entry<Integer, String> entry : entries)
+            {
+                System.out.println(entry.getKey() + " -> " + entry.getValue() );
+            }
+        } finally {
+            client.shutdown();
+        }
+    }
+}
+----
+
+The following line returns a map proxy object for the `cities` map:
+
+[source,java]
+----
+            // Create a map on the cluster
+            IMap<Integer, String> citiesMap = client.getMap("cities");
+----
+
+If `cities` doesn't exist, it will be automatically created. All the clients connected to the same cluster will have access to the same map.
+
+With these lines, the client adds data to the `cities` map. The first parameter is the key of the entry, the second one is the value.
+
+[source,java]
+----
+            // Add some data
+            citiesMap.put(1, "London");
+            citiesMap.put(2, "New York");
+            citiesMap.put(3, "Tokyo");
+----
+
+Then, we get the data using the `entrySet()` method and iterate over the results.
+
+[source,java]
+----
+            // Output the data
+            Set<Map.Entry<Integer, String>> entries = citiesMap.entrySet();
+
+            for (Map.Entry<Integer, String> entry : entries)
+            {
+                System.out.println(entry.getKey() + " -> " + entry.getValue() );
+            }
+----
+
+The output of this code is given below:
+
+[source,bash]
+----
+2 -> New York
+1 -> London
+3 -> Tokyo
+----
+
+NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to entry order.
+
+== Summary
+
+In this tutorial, you learned how to get started with the Hazelcast Java Client, connect to a Viridian instance and put data into a distributed map.
+
+== See Also
+
+There are many things  you can do with the Java Client. For more information, such as how you can query a map with predicates and SQL,
+check out our https://github.com/hazelcast/hazelcast[Hazelcast repository] and our https://docs.hazelcast.com/hazelcast/5.3/clients/java#hide-nav[Java client documentation] to better understand what is possible.
+
+If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
+To contribute to the client, take a look at https://github.com/hazelcast/hazelcast/issues[the issue list].
+
+

--- a/docs/modules/clients/pages/nodejs-client-getting-started.adoc
+++ b/docs/modules/clients/pages/nodejs-client-getting-started.adoc
@@ -1,13 +1,8 @@
-= Getting Started with the Hazelcast Node.js Client
-:page-layout: tutorial
-:page-product: platform
-:page-categories: Get Started
-:page-lang: node
-:page-enterprise:
-:page-est-time: 5-10 mins
+= Get started with the Hazelcast Node.js Client
+
 :description: This tutorial will get you started with the Hazelcast Node.js client and show you how to manipulate a map.
 
-== What You'll Learn
+== What you'll learn
 
 {description}
 
@@ -27,7 +22,7 @@ Before you begin, make sure you have the following:
 4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.
 
-== Setup a Hazelcast Client
+== Set up a Hazelcast Client
 
 Create a new folder and navigate to it:
 
@@ -60,7 +55,7 @@ cert.pem
 key.pem
 ----
 
-== Understanding the Node.js Client
+== Understand the Node.js Client
 
 The following section creates and starts a Hazelcast client with default configuration, and connects to your Viridian cluster before finally shutting down the client.
 
@@ -125,7 +120,7 @@ The majority of the client methods return promises using the https://developer.m
 but you can use the regular https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then[then] / https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch[catch]
 syntax, too.
 
-== Understanding the Hazelcast SQL API
+== Understand the Hazelcast SQL API
 
 Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
 
@@ -319,7 +314,7 @@ Fetching cities...OK.
 
 NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to insertion order.
 
-== Understanding the Hazelcast Map API
+== Understand the Hazelcast Map API
 
 A Hazelcast Map is a distributed key-value store, similar to Node map. You can store key-value pairs in a Hazelcast Map.
 
@@ -564,10 +559,10 @@ The value of the first entry becomes "null" since it is removed.
 
 In this tutorial, you learned how to get started with the Hazelcast Node.js Client, connect to a Viridian instance and put data into a distributed map.
 
-== See Also
+== See also
 
 There are many things that you can do with the Node.js Client. For more information, such as how you can query a map with predicates and SQL,
-check out our https://github.com/hazelcast/hazelcast-nodejs-client[Node.js Client repository] and our http://hazelcast.github.io/hazelcast-nodejs-client/[Node.js API documentation] to better understand what is possible.
+check out the https://github.com/hazelcast/hazelcast-nodejs-client[Node.js Client repository] and the http://hazelcast.github.io/hazelcast-nodejs-client/[Node.js API documentation] to better understand what's is possible.
 
 If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
 To contribute to the client, take a look at https://github.com/hazelcast/hazelcast-nodejs-client/issues[the issue list].

--- a/docs/modules/clients/pages/nodejs-client-getting-started.adoc
+++ b/docs/modules/clients/pages/nodejs-client-getting-started.adoc
@@ -1,0 +1,573 @@
+= Getting Started with the Hazelcast Node.js Client
+:page-layout: tutorial
+:page-product: platform
+:page-categories: Get Started
+:page-lang: node
+:page-enterprise:
+:page-est-time: 5-10 mins
+:description: This tutorial will get you started with the Hazelcast Node.js client and show you how to manipulate a map.
+
+== What You'll Learn
+
+{description}
+
+== Prerequisites
+
+Before you begin, make sure you have the following:
+
+* Node.js 10.4 or above
+* https://hazelcast.com/products/viridian/[Hazelcast Viridian Cloud Account]
+* A text editor or IDE
+
+== Start a Hazelcast Viridian Cloud Cluster
+
+1. Sign up for a Hazelcast Viridian Cloud account (free trial is available).
+2. Log in to your Hazelcast Viridian Cloud account and start your trial by filling in the welcome questionnaire.
+3. A Viridian cluster will be created automatically when you start your trial.
+4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
+5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.
+
+== Setup a Hazelcast Client
+
+Create a new folder and navigate to it:
+
+[source]
+----
+mkdir hazelcast-nodejs-example
+cd hazelcast-nodejs-example
+----
+
+Initialize a new npm package and choose default values when asked:
+
+[source,bash]
+----
+npm init
+----
+
+Install Hazelcast Node.js client's latest version:
+
+[source,bash]
+----
+npm install --save hazelcast-client
+----
+
+Extract the keystore files you downloaded from Viridian into this directory. The files you need for this tutorial are:
+
+[source,bash]
+----
+ca.pem
+cert.pem
+key.pem
+----
+
+== Understanding the Node.js Client
+
+The following section creates and starts a Hazelcast client with default configuration, and connects to your Viridian cluster before finally shutting down the client.
+
+Create a JavaScript file named “index.js” and put the following code inside it:
+
+[source,javascript]
+----
+'use strict';
+
+const { Client } = require('hazelcast-client');
+const fs = require('fs');
+const path = require('path');
+const process = require('process');
+const sprintf= require('sprintf-js').sprintf;
+
+(async () => {
+
+    const client = await Client.newHazelcastClient({
+        clusterName: '<YOUR_CLUSTER_ID>',
+
+        // Connection details for cluster
+        network: {
+            hazelcastCloud: {
+                discoveryToken: '<YOUR_DISCOVERY_TOKEN>',
+            },
+
+            ssl: {
+                enabled: true,
+                sslOptions: {
+                    ca: [fs.readFileSync(path.resolve(path.join(__dirname, 'ca.pem')))],
+                    cert: [fs.readFileSync(path.resolve(path.join(__dirname, 'cert.pem')))],
+                    key: [fs.readFileSync(path.resolve(path.join(__dirname, 'key.pem')))],
+                    passphrase: '<YOUR_CERTIFICATE_PASSWORD>',
+                    checkServerIdentity: () => null
+                },
+            },
+        },
+
+        // Other environment propreties
+        properties: {
+            'hazelcast.logging.level': 'WARN' // this property value is case-insensitive
+        },
+    });
+
+    process.stdout.write('Welcome to your Hazelcast Viridian Cluster!');
+
+    await client.shutdown();
+
+})().catch(err => {
+    process.stderr.write(`An error occured: ${err}\n`);
+});
+----
+
+To run this Node.js script, use the following command:
+
+[source,bash]
+----
+node index.js
+----
+
+The majority of the client methods return promises using the https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function[async/await] syntax,
+but you can use the regular https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then[then] / https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch[catch]
+syntax, too.
+
+== Understanding the Hazelcast SQL API
+
+Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
+
+In the following example, we will create a map and insert entries into it where the keys are ids and the values are defined as an object representing a city.
+
+NOTE: SSL certificate files are available from the Python client download available from Viridian.
+
+[source,javascript]
+----
+'use strict';
+
+const { Client } = require('hazelcast-client');
+const fs = require('fs');
+const path = require('path');
+const process = require('process');
+const sprintf= require('sprintf-js').sprintf;
+
+class CityDTO {
+    constructor(city, country, population) {
+        this.city = city;
+        this.country = country;
+        this.population = population;
+    }
+}
+
+class CitySerializer {
+
+    getClass() {
+        return CityDTO;
+    }
+
+    getTypeName() {
+        return 'CityDTO'
+    }
+
+    write(writer, cityDTO) {
+        writer.writeString('city', cityDTO.city);
+        writer.writeString('country', cityDTO.country);
+        writer.writeInt32('population', cityDTO.population);
+    }
+
+    read(reader) {
+        const city = reader.readString('city');
+        const country = reader.readString('country');
+        const population = reader.readInt32('population');
+
+        return new CityDTO(city, country, population);
+    }
+}
+
+async function createMapping(client) {
+    process.stdout.write('Creating the mapping...');
+
+    // Mapping is required for your distributed map to be queried over SQL.
+    // See: https://docs.hazelcast.com/hazelcast/latest/sql/mapping-to-maps
+    const mappingQuery = `
+        CREATE OR REPLACE MAPPING
+        cities (
+            __key INT,
+            country VARCHAR,
+            city VARCHAR,
+            population INT) TYPE IMAP
+        OPTIONS (
+            'keyFormat' = 'int',
+            'valueFormat' = 'compact',
+            'valueCompactTypeName' = 'CityDTO')
+    `;
+
+    await client.getSql().execute(mappingQuery);
+    process.stdout.write('OK.\n');
+}
+
+async function populateCities(client) {
+    process.stdout.write('Inserting data...');
+
+    // Mapping is required for your distributed map to be queried over SQL.
+    // See: https://docs.hazelcast.com/hazelcast/latest/sql/mapping-to-maps
+    const insertQuery = `
+        INSERT INTO cities
+        (__key, city, country, population) VALUES
+        (1, 'London', 'United Kingdom', 9540576),
+        (2, 'Manchester', 'United Kingdom', 2770434),
+        (3, 'New York', 'United States', 19223191),
+        (4, 'Los Angeles', 'United States', 3985520),
+        (5, 'Istanbul', 'Türkiye', 15636243),
+        (6, 'Ankara', 'Türkiye', 5309690),
+        (7, 'Sao Paulo ', 'Brazil', 22429800)
+    `;
+
+    try {
+        await client.getSql().execute('DELETE from cities');
+        await client.getSql().execute(insertQuery);
+
+        process.stdout.write('OK.\n');
+    } catch (error) {
+        process.stderr.write('FAILED.\n', error)
+    }
+}
+
+async function fetchCities(client) {
+    process.stdout.write('Fetching cities...');
+
+    const sqlResultAll = await client.sqlService.execute('SELECT __key, this FROM cities', [], { returnRawResult: true });
+
+    process.stdout.write('OK.\n');
+    process.stdout.write('--Results of SELECT __key, this FROM cities\n');
+    process.stdout.write(sprintf('| %4s | %20s | %20s | %15s |\n', 'id', 'country', 'city', 'population'));
+
+    // NodeJS client does lazy deserialization. In order to update schema table on the client,
+    // it's required to get a map value.
+    const cities = await client.getMap('cities');
+    await cities.get(1);
+
+    for await (const row of sqlResultAll) {
+        const id = row.getObject('__key');
+        const cityDTO = row.getObject('this');
+        process.stdout.write(sprintf('| %4d | %20s | %20s | %15d |\n', id, cityDTO.country, cityDTO.city, cityDTO.population));
+    }
+
+    process.stdout.write('\n!! Hint !! You can execute your SQL queries on your Viridian cluster over the management center. \n 1. Go to "Management Center" of your Hazelcast Viridian cluster. \n 2. Open the "SQL Browser". \n 3. Try to execute "SELECT * FROM cities".\n');
+}
+
+///////////////////////////////////////////////////////
+
+(async () => {
+
+    const client = await Client.newHazelcastClient({
+        clusterName: '<YOUR_CLUSTER_ID>',
+
+        // Connection details for cluster
+        network: {
+            hazelcastCloud: {
+                discoveryToken: '<YOUR_DISCOVERY_TOKEN>',
+            },
+
+            ssl: {
+                enabled: true,
+                sslOptions: {
+                    ca: [fs.readFileSync(path.resolve(path.join(__dirname, 'ca.pem')))],
+                    cert: [fs.readFileSync(path.resolve(path.join(__dirname, 'cert.pem')))],
+                    key: [fs.readFileSync(path.resolve(path.join(__dirname, 'key.pem')))],
+                    passphrase: '<YOUR_CERTIFICATE_PASSWORD>',
+                    checkServerIdentity: () => null
+                },
+            },
+        },
+
+        // Register Compact Serializers
+        serialization: {
+            compact: {
+                serializers: [new CitySerializer()],
+            },
+            defaultNumberType:"integer",
+        },
+
+        // Other environment propreties
+        properties: {
+            'hazelcast.logging.level': 'WARN' // this property value is case-insensitive
+        },
+    });
+
+    await createMapping(client);
+    await populateCities(client);
+    await fetchCities(client);
+
+    await client.shutdown();
+
+})().catch(err => {
+    process.stderr.write(`An error occured: ${err}\n`);
+});
+----
+
+The output of this code is given below:
+
+[source,bash]
+----
+Connection Successful!
+Creating the mapping...OK.
+Inserting data...OK.
+Fetching cities...OK.
+--Results of 'SELECT __key, this FROM cities'
+|   id | country              | city                 | population      |
+|    2 | United Kingdom       | Manchester           | 2770434         |
+|    6 | Türkiye              | Ankara               | 5309690         |
+|    1 | United Kingdom       | London               | 9540576         |
+|    7 | Brazil               | Sao Paulo            | 22429800        |
+|    4 | United States        | Los Angeles          | 3985520         |
+|    5 | Türkiye              | Istanbul             | 15636243        |
+|    3 | United States        | New York             | 19223191        |
+----
+
+NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to insertion order.
+
+== Understanding the Hazelcast Map API
+
+A Hazelcast Map is a distributed key-value store, similar to Node map. You can store key-value pairs in a Hazelcast Map.
+
+In the following example, we will work with map entries where the keys are ids and the values are defined as a string representing a city name.
+
+[source,javascript]
+----
+'use strict';
+
+const { Client } = require('hazelcast-client');
+const fs = require('fs');
+const path = require('path');
+const process = require('process');
+const sprintf= require('sprintf-js').sprintf;
+
+####################################
+
+(async () => {
+
+    const client = await Client.newHazelcastClient({
+        clusterName: '<YOUR_CLUSTER_ID>',
+
+        // Connection details for cluster
+        network: {
+            hazelcastCloud: {
+                discoveryToken: '<YOUR_DISCOVERY_TOKEN>',
+            },
+
+            ssl: {
+                enabled: true,
+                sslOptions: {
+                    ca: [fs.readFileSync(path.resolve(path.join(__dirname, 'ca.pem')))],
+                    cert: [fs.readFileSync(path.resolve(path.join(__dirname, 'cert.pem')))],
+                    key: [fs.readFileSync(path.resolve(path.join(__dirname, 'key.pem')))],
+                    passphrase: '<YOUR_CERTIFICATE_PASSWORD>',
+                    checkServerIdentity: () => null
+                },
+            },
+        },
+
+        // Register Compact Serializers
+        serialization: {
+            compact: {
+                serializers: [new CitySerializer()],
+            },
+            defaultNumberType:"integer",
+        },
+
+        // Other environment propreties
+        properties: {
+            'hazelcast.logging.level': 'WARN' // this property value is case-insensitive
+        },
+    });
+
+    //
+    var citiesMap = await client.getMap('cities');
+
+    // Clear the map
+    await citiesMap.clear();
+
+    // Add some data
+    await citiesMap.put(1, 'London');
+    await citiesMap.put(2, 'New York');
+    await citiesMap.put(3, 'Tokyo');
+
+    // Output the data
+    const entries = await citiesMap.entrySet();
+
+    for (const [key, value] of entries) {
+        process.stdout.write(`${key} -> ${value}\n`);
+    }
+
+    await client.shutdown();
+
+})().catch(err => {
+    process.stderr.write(`An error occured: ${err}\n`);
+});
+----
+
+The following line returns a map proxy object for the `cities` map:
+
+[source, javascript]
+----
+var citiesMap = await client.getMap('cities');
+----
+
+If `cities` doesn't exist, it will be automatically created. All the clients connected to the same cluster will have access to the same map.
+
+With these lines, the client adds data to the `cities` map. The first parameter is the key of the entry, the second one is the value.
+
+[source, python]
+----
+await citiesMap.put(1, 'London');
+await citiesMap.put(2, 'New York');
+await citiesMap.put(3, 'Tokyo');
+----
+
+Then, we get the data using the `entrySet()` method and iterate over the results.
+
+[source, javascript]
+----
+const entries = await citiesMap.entrySet();
+
+for (const [key, value] of entries) {
+    process.stdout.write(`${key} -> ${value}\n`);
+}
+----
+
+Finally, `client.shutdown()` terminates our client and release its resources.
+
+The output of this code is given below:
+
+[source,bash]
+----
+2 -> New York
+1 -> London
+3 -> Tokyo
+----
+
+NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to entry order.
+
+== Adding a Listener to the Map
+
+You can add an entry listener using the `addEntryListener()` method available on the map proxy object.
+This will allow you to listen to certain events that happen in the map across the cluster.
+
+The first argument to the `addEntryListener()` method is an object that is used to define listeners.
+In this example, we register listeners for the `added`, `removed` and `updated` events.
+
+The second argument to the `addEntryListener()` method is `includeValue`.
+This boolean parameter, if set to true, ensures the entry event contains the entry value.
+
+This enables your code to listen to map events of that particular map.
+
+[source, javascript]
+----
+'use strict';
+
+const { Client } = require('hazelcast-client');
+const fs = require('fs');
+const path = require('path');
+const process = require('process');
+const sprintf= require('sprintf-js').sprintf;
+
+####################################
+
+(async () => {
+
+    const client = await Client.newHazelcastClient({
+        clusterName: '<YOUR_CLUSTER_ID>',
+
+        // Connection details for cluster
+        network: {
+            hazelcastCloud: {
+                discoveryToken: '<YOUR_DISCOVERY_TOKEN>',
+            },
+
+            ssl: {
+                enabled: true,
+                sslOptions: {
+                    ca: [fs.readFileSync(path.resolve(path.join(__dirname, 'ca.pem')))],
+                    cert: [fs.readFileSync(path.resolve(path.join(__dirname, 'cert.pem')))],
+                    key: [fs.readFileSync(path.resolve(path.join(__dirname, 'key.pem')))],
+                    passphrase: '<YOUR_CERTIFICATE_PASSWORD>',
+                    checkServerIdentity: () => null
+                },
+            },
+        },
+
+        // Register Compact Serializers
+        serialization: {
+            compact: {
+                serializers: [new CitySerializer()],
+            },
+            defaultNumberType:"integer",
+        },
+
+        // Other environment propreties
+        properties: {
+            'hazelcast.logging.level': 'WARN' // this property value is case-insensitive
+        },
+    });
+
+    //
+    var citiesMap = await client.getMap('cities');
+
+    citiesMap.addEntryListener({
+        added: (event) => {
+            process.stdout.write(`Entry added with key: ${event.key}, value: ${event.value}\n`)
+        },
+        removed: (event) => {
+            process.stdout.write(`Entry removed with key: ${event.key}\n`);
+        },
+        updated: (event) => {
+            process.stdout.write(`Entry updated with key: ${event.key}, old value: ${event.oldValue}, new value: ${event.value}\n`)
+        },
+    }, undefined, true);
+
+    // Clear the map
+    await citiesMap.clear();
+
+    // Add some data
+    await citiesMap.put(1, 'London');
+    await citiesMap.put(2, 'New York');
+    await citiesMap.put(3, 'Tokyo');
+
+    await citiesMap.remove(1);
+    await citiesMap.replace(2, 'Paris');
+
+    // Output the data
+    const entries = await citiesMap.entrySet();
+
+    for (const [key, value] of entries) {
+        process.stdout.write(`${key} -> ${value}\n`);
+    }
+
+    await client.shutdown();
+
+})().catch(err => {
+    process.stderr.write(`An error occured: ${err}\n`);
+});
+----
+
+First, the map is cleared, which will trigger removed events if there are some entries in the map. Then, entries are added, and they are logged. After that, we remove one of the entries and update the other one. Then, we log the entries again.
+
+The output is as follows.
+
+[source, bash]
+----
+Entry added with key: 1, value: London
+Entry added with key: 2, value: New York
+Entry added with key: 3, value: Tokyo
+Entry removed with key: 1
+Entry updated with key: 2, old value: New York, new value: Paris
+2 -> Paris
+3 -> Tokyo
+----
+
+The value of the first entry becomes "null" since it is removed.
+
+== Summary
+
+In this tutorial, you learned how to get started with the Hazelcast Node.js Client, connect to a Viridian instance and put data into a distributed map.
+
+== See Also
+
+There are many things that you can do with the Node.js Client. For more information, such as how you can query a map with predicates and SQL,
+check out our https://github.com/hazelcast/hazelcast-nodejs-client[Node.js Client repository] and our http://hazelcast.github.io/hazelcast-nodejs-client/[Node.js API documentation] to better understand what is possible.
+
+If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
+To contribute to the client, take a look at https://github.com/hazelcast/hazelcast-nodejs-client/issues[the issue list].

--- a/docs/modules/clients/pages/python-client-getting-started.adoc
+++ b/docs/modules/clients/pages/python-client-getting-started.adoc
@@ -5,13 +5,15 @@
 :page-lang: python3
 :page-enterprise:
 :page-est-time: 5-10 mins
-:description: This tutorial will get you started with the Hazelcast Python client and show how to manipulate a map.
+:description: This tutorial will get you started with the Hazelcast Python client and show you how to manipulate a map.
 
 == What You'll Learn
 
 {description}
 
 == Prerequisites
+
+Before you begin, make sure you have the following:
 
 * Python 3.6 or above
 * https://hazelcast.com/products/viridian/[Hazelcast Viridian Cloud Account]
@@ -53,7 +55,7 @@ key.pem
 
 == Understanding the Python Client
 
-The following section creates and starts a Hazelcast client with default configuration, connects to your Viridian cluster before finally shutting down the client.
+The following section creates and starts a Hazelcast client with default configuration, and connects to your Viridian cluster before finally shutting down the client.
 
 Create a Python file named “example.py” and put the following code inside it:
 
@@ -291,7 +293,7 @@ If `cities` doesn't exist, it will be automatically created. All the clients con
 You may wonder why we have used `blocking()` method over the `get_map()`. This returns a version of this proxy with only blocking
 (sync) method calls, which is better for getting started. For async calls, please check our https://hazelcast.readthedocs.io/en/stable/#usage[API documentation].
 
-With these lines, client adds data to the `cities` map. The first parameter is the key of the entry, the second one is the value.
+With these lines, the client adds data to the `cities` map. The first parameter is the key of the entry, the second one is the value.
 
 [source, python]
 ----

--- a/docs/modules/clients/pages/python-client-getting-started.adoc
+++ b/docs/modules/clients/pages/python-client-getting-started.adoc
@@ -1,5 +1,5 @@
-= Getting Started with the Hazelcast Python Client
-:page-layout: tutorial
+= Get started with the Hazelcast Python Client
+// :page-layout: tutorial
 :page-product: platform
 :page-categories: Get Started
 :page-lang: python3
@@ -7,7 +7,7 @@
 :page-est-time: 5-10 mins
 :description: This tutorial will get you started with the Hazelcast Python client and show you how to manipulate a map.
 
-== What You'll Learn
+== What you'll learn
 
 {description}
 
@@ -27,7 +27,7 @@ Before you begin, make sure you have the following:
 4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.
 
-== Setup a Hazelcast Client
+== Set up a Hazelcast Client
 
 Create a new folder and navigate to it:
 
@@ -53,7 +53,7 @@ cert.pem
 key.pem
 ----
 
-== Understanding the Python Client
+== Understand the Python Client
 
 The following section creates and starts a Hazelcast client with default configuration, and connects to your Viridian cluster before finally shutting down the client.
 
@@ -89,7 +89,7 @@ client.shutdown()
 
 To understand and use the client, review the https://hazelcast.readthedocs.io/en/stable/client.html#hazelcast.client.HazelcastClient[Python API documentation] to discover what is possible.
 
-== Understanding the Hazelcast SQL API
+== Understand the Hazelcast SQL API
 
 Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
 
@@ -233,7 +233,7 @@ Fetching cities...OK.
 
 NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to insertion order.
 
-== Understanding the Hazelcast Map API
+== Understand the Hazelcast Map API
 
 A Hazelcast Map is a distributed key-value store, similar to Python dictionary. You can store key-value pairs in a Hazelcast Map.
 
@@ -281,7 +281,7 @@ for key, value in entries:
 client.shutdown()
 ----
 
-Following line returns a map proxy object for the `cities` map:
+The following line returns a map proxy object for the `cities` map:
 
 [source, python]
 ----
@@ -325,7 +325,7 @@ The output of this code is given below:
 
 NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to entry order.
 
-== Adding a Listener to the Map
+== Add a Listener to the Map
 
 You can add an entry listener using the `add_entry_listener()` method available on the map proxy object.
 This will allow you to listen to certain events that happen in the map across the cluster.
@@ -418,10 +418,10 @@ The value of the first entry becomes `None` since it is removed.
 
 In this tutorial, you learned how to get started with the Hazelcast Python Client, connect to a Viridian instance and put data into a distributed map.
 
-== See Also
+== See also
 
 There are many things you can do with the Python Client. For more information, such as how you can query a map with predicates and SQL,
-check out our https://github.com/hazelcast/hazelcast-python-client[Python Client repository] and our https://hazelcast.readthedocs.io/en/stable/client.html#hazelcast.client.HazelcastClient[Python API documentation] to better understand what is possible.
+check out the https://github.com/hazelcast/hazelcast-python-client[Python Client repository] and the https://hazelcast.readthedocs.io/en/stable/client.html#hazelcast.client.HazelcastClient[Python API documentation] to better understand what's possible.
 
 If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
 To contribute to the client, take a look at https://github.com/hazelcast/hazelcast-python-client/issues[the issue list].

--- a/docs/modules/clients/pages/python-client-getting-started.adoc
+++ b/docs/modules/clients/pages/python-client-getting-started.adoc
@@ -1,0 +1,425 @@
+= Getting Started with the Hazelcast Python Client
+:page-layout: tutorial
+:page-product: platform
+:page-categories: Get Started
+:page-lang: python3
+:page-enterprise:
+:page-est-time: 5-10 mins
+:description: This tutorial will get you started with the Hazelcast Python client and show how to manipulate a map.
+
+== What You'll Learn
+
+{description}
+
+== Prerequisites
+
+* Python 3.6 or above
+* https://hazelcast.com/products/viridian/[Hazelcast Viridian Cloud Account]
+* A text editor or IDE
+
+== Start a Hazelcast Viridian Cloud Cluster
+
+1. Sign up for a Hazelcast Viridian Cloud account (free trial is available).
+2. Log in to your Hazelcast Viridian Cloud account and start your trial by filling in the welcome questionnaire.
+3. A Viridian cluster will be created automatically when you start your trial.
+4. Press the Connect Cluster dialog and switch over to the Advanced setup tab for connection information needed below.
+5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.
+
+== Setup a Hazelcast Client
+
+Create a new folder and navigate to it:
+
+[source]
+----
+mkdir hazelcast-python-example
+cd hazelcast-python-example
+----
+
+Download the Hazelcast Python Client library using pip:
+
+[source]
+----
+python -m pip install hazelcast-python-client
+----
+
+Extract the keystore files you downloaded from Viridian into this directory. The files you need for this tutorial are:
+
+[source,bash]
+----
+ca.pem
+cert.pem
+key.pem
+----
+
+== Understanding the Python Client
+
+The following section creates and starts a Hazelcast client with default configuration, connects to your Viridian cluster before finally shutting down the client.
+
+Create a Python file named “example.py” and put the following code inside it:
+
+[source,python]
+----
+import hazelcast
+import os
+
+####################################
+
+# Connect to your Hazelcast Cluster
+client = hazelcast.HazelcastClient(
+    # Viridian Cluster Name and Token
+    cluster_name="<YOUR_CLUSTER_ID>",
+    cloud_discovery_token="<YOUR_DISCOVERY_TOKEN>",
+
+    # configure SSL
+    ssl_enabled=True,
+    ssl_cafile=os.path.abspath("ca.pem"),
+    ssl_certfile=os.path.abspath("cert.pem"),
+    ssl_keyfile=os.path.abspath("key.pem"),
+    ssl_password="<YOUR_CERTIFICATE_PASSWORD>",
+)
+
+# take actions
+print("Welcome to your Hazelcast Viridian Cluster!")
+
+# Shutdown the client connection
+client.shutdown()
+----
+
+To understand and use the client, review the https://hazelcast.readthedocs.io/en/stable/client.html#hazelcast.client.HazelcastClient[Python API documentation] to discover what is possible.
+
+== Understanding the Hazelcast SQL API
+
+Hazelcast SQL API is a Calcite SQL-based interface to allow you to interact with Hazelcast much like any other datastore.
+
+In the following example, we will create a map and insert entries into it where the keys are ids and the values are defined as an object representing a city.
+
+[source,python]
+----
+import hazelcast
+from hazelcast import HazelcastClient
+from hazelcast.serialization.api import CompactReader, CompactSerializer, CompactWriter
+import os
+import typing
+
+class City:
+    def __init__(self, country: str, city: str, population: int) -> None:
+        self.country = country
+        self.city = city
+        self.population = population
+
+class CitySerializer(CompactSerializer[City]):
+    def read(self, reader: CompactReader) -> City:
+        city = reader.read_string("city")
+        country = reader.read_string("country")
+        population = reader.read_int32("population")
+        return City(country, city, population)
+
+    def write(self, writer: CompactWriter, obj: City) -> None:
+        writer.write_string("country", obj.country)
+        writer.write_string("city", obj.city)
+        writer.write_int32("population", obj.population)
+
+    def get_type_name(self) -> str:
+        return "city"
+
+    def get_class(self) -> typing.Type[City]:
+        return City
+
+def create_mapping(client: HazelcastClient) -> None:
+    print("Creating the mapping...", end="")
+    # See: https://docs.hazelcast.com/hazelcast/latest/sql/mapping-to-maps
+    mapping_query = """
+        CREATE OR REPLACE MAPPING
+            cities (
+                __key INT,
+                country VARCHAR,
+                city VARCHAR,
+                population INT) TYPE IMAP
+            OPTIONS (
+                'keyFormat' = 'int',
+                'valueFormat' = 'compact',
+                'valueCompactTypeName' = 'city')
+    """
+    client.sql.execute(mapping_query).result()
+    print("OK.")
+
+def populate_cities(client: HazelcastClient) -> None:
+    print("Inserting data...", end="")
+
+    insert_query = """
+        INSERT INTO cities
+        (__key, city, country, population) VALUES
+        (1, 'London', 'United Kingdom', 9540576),
+        (2, 'Manchester', 'United Kingdom', 2770434),
+        (3, 'New York', 'United States', 19223191),
+        (4, 'Los Angeles', 'United States', 3985520),
+        (5, 'Istanbul', 'Türkiye', 15636243),
+        (6, 'Ankara', 'Türkiye', 5309690),
+        (7, 'Sao Paulo ', 'Brazil', 22429800)
+    """
+
+    try:
+        client.sql.execute('DELETE from cities').result()
+        client.sql.execute(insert_query).result()
+        print("OK.")
+    except Exception as e:
+        print(f"FAILED: {e!s}.")
+
+def fetch_cities(client: HazelcastClient) -> None:
+    print("Fetching cities...", end="")
+    result = client.sql.execute("SELECT __key, this FROM cities").result()
+    print("OK.")
+
+    print("--Results of 'SELECT __key, this FROM cities'")
+    print(f"| {'id':>4} | {'country':<20} | {'city':<20} | {'population':<15} |")
+
+    for row in result:
+        city = row["this"]
+        print(
+            f"| {row['__key']:>4} | {city.country:<20} | {city.city:<20} | {city.population:<15} |"
+        )
+
+####################################
+
+# Connect to your Hazelcast Cluster
+client = hazelcast.HazelcastClient(
+    # Viridian Cluster Name and Token
+    cluster_name="<YOUR_CLUSTER_ID>",
+    cloud_discovery_token="<YOUR_DISCOVERY_TOKEN>",
+
+    # configure SSL
+    ssl_enabled=True,
+    ssl_cafile=os.path.abspath("ca.pem"),
+    ssl_certfile=os.path.abspath("cert.pem"),
+    ssl_keyfile=os.path.abspath("key.pem"),
+    ssl_password="<YOUR_CERTIFICATE_PASSWORD>",
+
+    # Register Compact serializer of City class
+    compact_serializers=[CitySerializer()],
+)
+
+# Create a map on the cluster
+create_mapping(client)
+
+# Add some data
+populate_cities(client)
+
+# Output the data
+fetch_cities(client)
+
+# Shutdown the client connection
+client.shutdown()
+----
+
+The output of this code is given below:
+
+[source,bash]
+----
+Creating the mapping...OK.
+Inserting data...OK.
+Fetching cities...OK.
+--Results of 'SELECT __key, this FROM cities'
+|   id | country              | city                 | population      |
+|    2 | United Kingdom       | Manchester           | 2770434         |
+|    6 | Türkiye              | Ankara               | 5309690         |
+|    1 | United Kingdom       | London               | 9540576         |
+|    7 | Brazil               | Sao Paulo            | 22429800        |
+|    4 | United States        | Los Angeles          | 3985520         |
+|    5 | Türkiye              | Istanbul             | 15636243        |
+|    3 | United States        | New York             | 19223191        |
+----
+
+NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to insertion order.
+
+== Understanding the Hazelcast Map API
+
+A Hazelcast Map is a distributed key-value store, similar to Python dictionary. You can store key-value pairs in a Hazelcast Map.
+
+In the following example, we will work with map entries where the keys are ids and the values are defined as a string representing a city name.
+
+[source,python]
+----
+import hazelcast
+import os
+
+####################################
+
+# Connect to your Hazelcast Cluster
+client = hazelcast.HazelcastClient(
+    # Viridian Cluster Name and Token
+    cluster_name="<YOUR_CLUSTER_ID>",
+    cloud_discovery_token="<YOUR_DISCOVERY_TOKEN>",
+
+    # configure SSL
+    ssl_enabled=True,
+    ssl_cafile=os.path.abspath("ca.pem"),
+    ssl_certfile=os.path.abspath("cert.pem"),
+    ssl_keyfile=os.path.abspath("key.pem"),
+    ssl_password="<YOUR_CERTIFICATE_PASSWORD>",
+)
+
+# Create a map on the cluster
+cities_map = client.get_map('cities').blocking()
+
+# Clear the map
+cities_map.clear()
+
+# Add some data
+cities_map.put(1, "London")
+cities_map.put(2, "New York")
+cities_map.put(3, "Tokyo")
+
+# Output the data
+entries = cities_map.entry_set()
+
+for key, value in entries:
+    print(f"{key} -> {value}")
+
+# Shutdown the client connection
+client.shutdown()
+----
+
+Following line returns a map proxy object for the `cities` map:
+
+[source, python]
+----
+cities_map = client.get_map('cities').blocking()
+----
+
+If `cities` doesn't exist, it will be automatically created. All the clients connected to the same cluster will have access to the same map.
+
+You may wonder why we have used `blocking()` method over the `get_map()`. This returns a version of this proxy with only blocking
+(sync) method calls, which is better for getting started. For async calls, please check our https://hazelcast.readthedocs.io/en/stable/#usage[API documentation].
+
+With these lines, client adds data to the `cities` map. The first parameter is the key of the entry, the second one is the value.
+
+[source, python]
+----
+cities_map.put(1, "London")
+cities_map.put(2, "New York")
+cities_map.put(3, "Tokyo")
+----
+
+Then, we get the data using the `entry_set()` method and iterate over the results.
+
+[source, python]
+----
+entries = cities_map.entry_set()
+
+for key, value in entries:
+    print(f"{key} -> {value}")
+----
+
+Finally, `client.shutdown()` terminates our client and release its resources.
+
+The output of this code is given below:
+
+[source,bash]
+----
+2 -> New York
+1 -> London
+3 -> Tokyo
+----
+
+NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to entry order.
+
+== Adding a Listener to the Map
+
+You can add an entry listener using the `add_entry_listener()` method available on the map proxy object.
+This will allow you to listen to certain events that happen in the map across the cluster.
+
+The first argument to the `add_entry_listener()` method is `includeValue`.
+This boolean parameter, if set to true, ensures the entry event contains the entry value.
+
+The second argument to the `add_entry_listener()` method is an object that is used to define listeners.
+In this example, we register listeners for the `added`, `removed` and `updated` events.
+
+This enables your code to listen to map events of that particular map.
+
+[source, python]
+----
+import hazelcast
+import os
+
+def entry_added(event):
+    print(f"Entry added with key: {event.key}, value: {event.value}")
+
+def entry_removed(event):
+    print(f"Entry removed with key: {event.key}")
+
+def entry_updated(event):
+    print(f"Entry updated with key: {event.key}, old value: {event.old_value}, new value: {event.value}")
+
+####################################
+
+# Connect to your Hazelcast Cluster
+client = hazelcast.HazelcastClient(
+    # Viridian Cluster Name and Token
+    cluster_name="<YOUR_CLUSTER_ID>",
+    cloud_discovery_token="<YOUR_DISCOVERY_TOKEN>",
+
+    # configure SSL
+    ssl_enabled=True,
+    ssl_cafile=os.path.abspath("ca.pem"),
+    ssl_certfile=os.path.abspath("cert.pem"),
+    ssl_keyfile=os.path.abspath("key.pem"),
+    ssl_password="<YOUR_CERTIFICATE_PASSWORD>",
+)
+
+# Create a map on the cluster
+cities_map = client.get_map('cities').blocking()
+
+# Add listeners
+cities_map.add_entry_listener(
+    include_value=True, added_func=entry_added, removed_func=entry_removed, updated_func=entry_updated
+)
+
+# Clear the map
+cities_map.clear()
+
+# Add some data
+cities_map.set(1, "London")
+cities_map.set(2, "New York")
+cities_map.set(3, "Tokyo")
+
+cities_map.remove(1)
+cities_map.replace(2, "Paris")
+
+# Output the data
+entries = cities_map.entry_set()
+
+for key, value in entries:
+    print(f"{key} -> {value}")
+
+# Shutdown the client connection
+client.shutdown()
+----
+
+First, the map is cleared, which will trigger removed events if there are some entries in the map. Then, entries are added, and they are logged. After that, we remove one of the entries and update the other one. Then, we log the entries again.
+
+The output is as follows.
+
+[source, bash]
+----
+Entry added with key: 1, value: London
+Entry added with key: 2, value: New York
+Entry added with key: 3, value: Tokyo
+Entry removed with key: 1
+Entry updated with key: 2, old value: New York, new value: Paris
+2 -> Paris
+3 -> Tokyo
+----
+
+The value of the first entry becomes `None` since it is removed.
+
+== Summary
+
+In this tutorial, you learned how to get started with the Hazelcast Python Client, connect to a Viridian instance and put data into a distributed map.
+
+== See Also
+
+There are many things you can do with the Python Client. For more information, such as how you can query a map with predicates and SQL,
+check out our https://github.com/hazelcast/hazelcast-python-client[Python Client repository] and our https://hazelcast.readthedocs.io/en/stable/client.html#hazelcast.client.HazelcastClient[Python API documentation] to better understand what is possible.
+
+If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].
+To contribute to the client, take a look at https://github.com/hazelcast/hazelcast-python-client/issues[the issue list].


### PR DESCRIPTION
See Jira ticket: https://hazelcast.atlassian.net/browse/DOC-369

This work is to migrate the 6 HZC Clients buried at the foot of the Tutorials page (see: https://docs.hazelcast.com/tutorials/), the content for which resides in a different repo, and into the main Tech Docs to make it easier for people to find. 

A new client tutorials landing page has been created, beneath which are the new tutorials which have been given a scrub and polish.