### PR TITLE
Clarify that GenericMapStore does not support domain object transformation [HZG-253]

### DIFF
--- a/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
+++ b/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
@@ -6,7 +6,7 @@
 
 NOTE: The objects created in the distributed map are stored as GenericRecord. You can use the `type-name` property to store the data in a POJO (Plain Old Java Object).
 
-IMPORTANT: GenericMapStore is designed to handle GenericRecord and does not support automatic transformation between stored data (GenericRecord) and domain objects (POJOs). While the type-name property allows specifying a type, it does not enable domain object mapping.
+IMPORTANT: GenericMapStore is designed to handle GenericRecord and does not support automatic transformation between stored data (GenericRecord) and domain objects (POJOs) in embedded mode. While the `type-name` property allows specifying a https://docs.hazelcast.com/hazelcast/latest/serialization/compact-serialization[Compact type name], it does not enable domain object mapping.
 
 For a list of all supported external systems, including databases, see available xref:data-connections:data-connections-configuration.adoc#connectors[data connection types].
 

--- a/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
+++ b/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
@@ -6,6 +6,8 @@
 
 NOTE: The objects created in the distributed map are stored as GenericRecord. You can use the `type-name` property to store the data in a POJO (Plain Old Java Object).
 
+IMPORTANT: GenericMapStore is designed to handle GenericRecord and does not support automatic transformation between stored data (GenericRecord) and domain objects (POJOs). While the type-name property allows specifying a type, it does not enable domain object mapping.
+
 For a list of all supported external systems, including databases, see available xref:data-connections:data-connections-configuration.adoc#connectors[data connection types].
 
 == Before you begin


### PR DESCRIPTION
This update is improves the documentation by explicitly stating that `GenericMapStore` is designed to handle `GenericRecord` and does not support automatic transformation between `GenericRecord` and POJOs.

SUP Ticket: [SUP-670](https://hazelcast.atlassian.net/browse/SUP-670)

[SUP-670]: https://hazelcast.atlassian.net/browse/SUP-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ