### PR TITLE
Correct maximum recommended clients per member

### DIFF
--- a/docs/modules/clients/pages/client-overview.adoc
+++ b/docs/modules/clients/pages/client-overview.adoc
@@ -34,8 +34,13 @@ Clients are available for xref:java.adoc[Java], xref:dotnet.adoc[.NET], xref:pyt
 ==== Maximum number of client connections per member
 
 The maximum recommended number of clients per member is 100.
-By default, members have `core count * 20` threads that handle all the requests.
-For example, if a member has 4 cores, it will have 80 threads available to handle requests.
+Members use different executors, each with a different thread count, for handling different types of client message tasks:
+
+* Query tasks: `core count` threads
+* Blocking tasks: `core count * 20` threads
+* All other tasks: `core count` threads
+
+These values, as well as each member's xref:cluster-performance:threading.adoc#io-threading[I/O Thread] counts, need to be taken into consideration when determining the appropriate client connection limits for clusters.
 
 ==== Serialization in client/server mode
 


### PR DESCRIPTION
The information currently presented in the docs is outdated, as client tasks are handled by 3 executors instead of 1 now (since 2018).

This section also did not mention I/O thread counts which are also relevant when determining client connection limits.

This PR updates this section with more details and up-to-date information.