### PR TITLE
Fix MC Docker tags

### DIFF
--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -613,7 +613,7 @@ In this step, you start a local instance of Management Center and use it to view
 ----
 docker run \
     --network hazelcast-network \
-    -p 8080:8080 hazelcast/management-center:latest-snapshot
+    -p 8080:8080 hazelcast/management-center:{page-latest-supported-mc}
 ----
 
 . In a web browser, go to localhost:8080 and enable dev mode.

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -609,7 +609,7 @@ In this step, you start a local instance of Management Center and use it to view
 
 . Start Management Center.
 +
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 docker run \
     --network hazelcast-network \

--- a/docs/modules/getting-started/pages/persistence.adoc
+++ b/docs/modules/getting-started/pages/persistence.adoc
@@ -160,7 +160,7 @@ Now, check the map in Management Center.
 ----
 docker run \
     --network hazelcast-network \
-    -p 8080:8080 hazelcast/management-center:latest-snapshot
+    -p 8080:8080 hazelcast/management-center:{page-latest-supported-mc}
 ----
 . In a web browser, go to localhost:8080 and enable Dev Mode.
 +

--- a/docs/modules/getting-started/pages/persistence.adoc
+++ b/docs/modules/getting-started/pages/persistence.adoc
@@ -156,7 +156,7 @@ Now, check the map in Management Center.
 
 . Open a new terminal and start Management Center.
 +
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 docker run \
     --network hazelcast-network \

--- a/docs/modules/getting-started/pages/wan.adoc
+++ b/docs/modules/getting-started/pages/wan.adoc
@@ -147,7 +147,7 @@ Note the member's IP address and port since you are going to use it while connec
 ----
 docker run \
     --network hazelcast-network \
-    -p 8080:8080 hazelcast/management-center:{full-version}
+    -p 8080:8080 hazelcast/management-center:{page-latest-supported-mc}
 ----
 . Once you see the `Hazelcast Management Center successfully started at http://localhost:8080/` log in the terminal, open a web browser, go to localhost:8080, and enable Dev Mode.
 . You will see a **Connect** box on the screen; click on it and enter the passive cluster’s name (`london`) and IP address of its member.

--- a/docs/modules/migrate/pages/upgrading-from-jet.adoc
+++ b/docs/modules/migrate/pages/upgrading-from-jet.adoc
@@ -22,7 +22,7 @@ Hazelcast Platform is compatible only with the Job and Pipeline APIs of Jet 4.x.
 - Upgrade to {full-version} using rolling upgrades.
 - Connect to a {full-version} cluster using version 4.x of clients.
 - Resubmit jobs from snapshots that were made on Jet 4.x clusters.
-- Use versions of Management Center before {full-version}.
+- Use versions of Management Center before {page-latest-supported-mc}.
 
 == Jet Engine Security
 

--- a/docs/modules/pipelines/pages/stream-processing-client.adoc
+++ b/docs/modules/pipelines/pages/stream-processing-client.adoc
@@ -337,7 +337,7 @@ With Management Center, you can monitor the status of your jobs and manage the l
 Docker:: 
 + 
 --
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 docker run \
     --network hazelcast-network \

--- a/docs/modules/pipelines/pages/stream-processing-client.adoc
+++ b/docs/modules/pipelines/pages/stream-processing-client.adoc
@@ -341,7 +341,7 @@ Docker::
 ----
 docker run \
     --network hazelcast-network \
-    -p 8080:8080 hazelcast/management-center:latest-snapshot
+    -p 8080:8080 hazelcast/management-center:{page-latest-supported-mc}
 ----
 --
 Binary:: 


### PR DESCRIPTION
Update MC Docker tags to `hazelcast/management-center:{page-latest-supported-mc}`.

Updated from:
- `latest-snapshot` - should use released artefacts
- `full-version` - the versions of Hazelcast platform and MC are not tied (e.g. no `5.5.2` MC)