### PR TITLE
Remove more `full-version` usages

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -12,6 +12,7 @@ asciidoc:
     full-version: '6.0.0-SNAPSHOT'
     os-version: '5.5.0'
     ee-version: '5.5.2'
+    jet-version: '4.5.4'
     # The minor.patch version, which is used as a variable in the docs for things like file versions
     minor-version: '6.0-SNAPSHOT'
     # The snapshot version for installing with brew

--- a/docs/modules/ROOT/examples/operator/bundle.yaml
+++ b/docs/modules/ROOT/examples/operator/bundle.yaml
@@ -78,7 +78,7 @@ spec:
                 description: Repository to pull the Hazelcast Platform image from.
                 type: string
               version:
-                default: '{full-version}-slim'
+                default: '{ee-version}-slim'
                 description: Version of Hazelcast Platform.
                 type: string
             type: object

--- a/docs/modules/ROOT/examples/operator/hazelcast.yaml
+++ b/docs/modules/ROOT/examples/operator/hazelcast.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  version: '{full-version}-slim'
+  version: '{ee-version}-slim'
   licenseKeySecret: hazelcast-license-key

--- a/docs/modules/ROOT/examples/operator/hazelcast_expose_externally.yaml
+++ b/docs/modules/ROOT/examples/operator/hazelcast_expose_externally.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   clusterSize: 3
   repository: 'docker.io/hazelcast/hazelcast-enterprise'
-  version: '{full-version}-slim'
+  version: '{ee-version}-slim'
   licenseKeySecret: hazelcast-license-key
   exposeExternally:
     type: Smart

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -47,7 +47,7 @@ Add the `hazelcast-enterprise` dependency to your `pom.xml`:
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-enterprise</artifactId>
-    <version>{full-version}</version>
+    <version>{ee-version}</version>
 </dependency>
 ----
 NOTE: 
@@ -62,7 +62,7 @@ Add the `hazelcast` dependency to your `pom.xml`:
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast</artifactId>
-    <version>{full-version}</version>
+    <version>{os-version}</version>
 </dependency>
 ----
 

--- a/docs/modules/deploy/pages/deploying-with-docker.adoc
+++ b/docs/modules/deploy/pages/deploying-with-docker.adoc
@@ -249,10 +249,10 @@ This example creates a Docker image for Hazelcast with the Kafka extension.
 
 [source,dockerfile,subs="attributes+"]
 ----
-FROM hazelcast:{full-version}-slim
+FROM hazelcast:{os-version}-slim
 ARG HZ_HOME=/opt/hazelcast
-ARG REPO_URL=https://repo1.maven.org/maven2/com/hazelcast
-ADD $REPO_URL/hazelcast-kafka/5.0/hazelcast-kafka-5.0-jar-with-dependencies.jar $HZ_HOME/lib/
+ARG REPO_URL=https://repo1.maven.org/maven2/com/hazelcast/jet
+ADD $REPO_URL/hazelcast-jet-kafka/{os-version}/hazelcast-jet-kafka-{os-version}-jar-with-dependencies.jar $HZ_HOME/lib/
 # ... more ADD statements ...
 ----
 

--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -15,7 +15,7 @@ xref:migrate:community-to-enterprise.adoc[].
 
 Both slim and full distributions are available. For further information on the available editions and distributions, see the xref:editions.adoc[] topic.
 
-To install a slim distribution, append `-slim` to the version number in the commands shown in the following sections; for example, to install the slim distribution of {full-version}, use `{full-version}-slim`.
+To install a slim distribution, append `-slim` to the version number in the commands shown in the following sections; for example, to install the slim distribution of {ee-version}, use `{ee-version}-slim`.
 
 == Using the {enterprise-product-name} Docker Image
 
@@ -45,7 +45,7 @@ Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-curl -L 'https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-{full-version}.tar.gz' | tar xvzf -
+curl -L 'https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-{ee-version}.tar.gz' | tar xvzf -
 ----
 --
 Linux:: 
@@ -53,17 +53,17 @@ Linux::
 --
 [source,bash,subs="attributes+"]
 ----
-wget -O - 'https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-{full-version}.tar.gz' | tar xvzf -
+wget -O - 'https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-{ee-version}.tar.gz' | tar xvzf -
 ----
 --
 Windows:: 
 +
 --
 ifdef::snapshot[]
-Download and extract the Hazelcast ZIP file from link:https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{full-version}[the repository].
+Download and extract the Hazelcast ZIP file from link:https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{ee-version}[the repository].
 endif::[]
 ifndef::snapshot[]
-Download and extract the link:https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-{full-version}.zip[Hazelcast ZIP file].
+Download and extract the link:https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-{ee-version}.zip[Hazelcast ZIP file].
 endif::[]
 --
 ====
@@ -102,7 +102,7 @@ ifdef::snapshot[]
     <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-enterprise</artifactId>
-        <version>{full-version}</version>
+        <version>{ee-version}</version>
     </dependency>
 </dependencies>
 ----
@@ -128,7 +128,7 @@ ifndef::snapshot[]
     <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-enterprise</artifactId>
-        <version>{full-version}</version>
+        <version>{ee-version}</version>
     </dependency>
 </dependencies>
 ----

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -198,7 +198,7 @@ ifdef::snapshot[]
 * link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{os-version}/hazelcast-{os-version}.jar[download the Hazelcast JAR file]
 endif::[]
 ifndef::snapshot[]
-* link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{full-version}/hazelcast-{full-version}.jar[download the Hazelcast JAR file]
+* link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{ee-version}/hazelcast-{ee-version}.jar[download the Hazelcast JAR file]
 endif::[]
 * add it to your classpath.
 

--- a/docs/modules/integrate/pages/cdc-connectors.adoc
+++ b/docs/modules/integrate/pages/cdc-connectors.adoc
@@ -31,7 +31,7 @@ Generic connector:
 <dependency>
     <groupId>com.hazelcast.jet</groupId>
     <artifactId>hazelcast-enterprise-cdc-debezium</artifactId>
-    <version>{full-version}</version>
+    <version>{ee-version}</version>
 </dependency>
 ----
 
@@ -42,7 +42,7 @@ MySQL-specific connector:
 <dependency>
     <groupId>com.hazelcast.jet</groupId>
     <artifactId>hazelcast-enterprise-cdc-mysql</artifactId>
-    <version>{full-version}</version>
+    <version>{ee-version}</version>
 </dependency>
 ----
 NOTE: Due to licensing, MySQL connector does not include the MySQL driver as a dependency. You have to manually add the `com.mysql:mysql-connector-j` dependency to the classpath.
@@ -54,7 +54,7 @@ PostgreSQL-specific connector:
 <dependency>
     <groupId>com.hazelcast.jet</groupId>
     <artifactId>hazelcast-enterprise-cdc-postgres</artifactId>
-    <version>{full-version}</version>
+    <version>{ee-version}</version>
 </dependency>
 ----
 
@@ -62,12 +62,12 @@ PostgreSQL-specific connector:
 
 The Java API supports the following types of CDC source:
 
-* link:https://docs.hazelcast.org/hazelcast-ee-docs/{full-version}/javadoc/com/hazelcast/enterprise/jet/cdc/DebeziumCdcSources.html[DebeziumCdcSources, window=_blank]:
+* link:https://docs.hazelcast.org/hazelcast-ee-docs/{ee-version}/javadoc/com/hazelcast/enterprise/jet/cdc/DebeziumCdcSources.html[DebeziumCdcSources, window=_blank]:
   a generic source for all databases supported by Debezium
-* link:https://docs.hazelcast.org/hazelcast-ee-docs/{full-version}/javadoc/com/hazelcast/enterprise/jet/cdc/mysql/MySqlCdcSources.html[MySqlCdcSources, window=_blank]:
+* link:https://docs.hazelcast.org/hazelcast-ee-docs/{ee-version}/javadoc/com/hazelcast/enterprise/jet/cdc/mysql/MySqlCdcSources.html[MySqlCdcSources, window=_blank]:
   a specific, first class Jet CDC source for MySQL databases (also based
   on Debezium, but with the additional benefits provided by Hazelcast)
-* link:https://docs.hazelcast.org/hazelcast-ee-docs/{full-version}/javadoc/com/hazelcast/enterprise/jet/cdc/postgres/PostgresCdcSources.html[PostgresCdcSources, window=_blank]:
+* link:https://docs.hazelcast.org/hazelcast-ee-docs/{ee-version}/javadoc/com/hazelcast/enterprise/jet/cdc/postgres/PostgresCdcSources.html[PostgresCdcSources, window=_blank]:
   a specific, first class CDC source for PostgreSQL databases (also based
 on Debezium, but with the additional benefits provided by Hazelcast)
 

--- a/docs/modules/integrate/pages/file-connector.adoc
+++ b/docs/modules/integrate/pages/file-connector.adoc
@@ -35,27 +35,27 @@ If you use the slim distribution of Hazelcast, be sure to add the respective mod
 |path/to/a/directory
 
 |Hadoop Distributed File System (HDFS)
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-hadoop-all/{full-version}[hazelcast-jet-hadoop-all]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-hadoop-all/{os-version}[hazelcast-jet-hadoop-all]
 |hdfs://path/to/a/directory
 
 |Amazon S3
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{full-version}[hazelcast-jet-files-s3]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{os-version}[hazelcast-jet-files-s3]
 |s3a://example-bucket/path/in/the/bucket
 
 |Google Cloud Storage
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-gcs/{full-version}[hazelcast-jet-files-gcs]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-gcs/{os-version}[hazelcast-jet-files-gcs]
 |gs://example-bucket/path/in/the/bucket
 
 |Windows Azure Blob Storage
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{full-version}[hazelcast-jet-files-azure]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
 |wasbs://example-container@examplestorageaccount.blob.core.windows.net/path/in/the/container
 
 |Azure Data Lake Generation 1
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{full-version}[hazelcast-jet-files-azure]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
 |adl://exampledatalake.azuredatalakestore.net/path/in/the/container
 
 |Azure Data Lake Generation 2
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{full-version}[hazelcast-jet-files-azure]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
 |abfs://example-container@exampledatalakeaccount.dfs.core.windows.net/path/in/the/container
 |===
 

--- a/docs/modules/integrate/pages/kafka-connect-connectors.adoc
+++ b/docs/modules/integrate/pages/kafka-connect-connectors.adoc
@@ -22,7 +22,7 @@ Maven::
 <dependency>
     <groupId>com.hazelcast.jet</groupId>
     <artifactId>hazelcast-jet-kafka-connect</artifactId>
-    <version>{full-version}</version>
+    <version>{os-version}</version>
     <classifier>jar-with-dependencies</classifier>
 </dependency>
 ----
@@ -32,7 +32,7 @@ Gradle::
 --
 [source,shell,subs="attributes+"]
 ----
-compile group: 'com.hazelcast.jet', name: 'hazelcast-jet-kafka-connect', version: ${full-version}, classifier: 'jar-with-dependencies'
+compile group: 'com.hazelcast.jet', name: 'hazelcast-jet-kafka-connect', version: ${os-version}, classifier: 'jar-with-dependencies'
 ----
 --
 ====

--- a/docs/modules/integrate/pages/kafka-connector.adoc
+++ b/docs/modules/integrate/pages/kafka-connector.adoc
@@ -12,7 +12,7 @@ the Kafka cluster.
 
 This connector is included in the full distribution of Hazelcast.
 
-If you're using the slim distribution, you must add the link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-kafka/{full-version}[`hazelcast-jet-kafka` module] to your member's classpath.
+If you're using the slim distribution, you must add the link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-kafka/{os-version}[`hazelcast-jet-kafka` module] to your member's classpath.
 
 == Permissions
 [.enterprise]*{enterprise-product-name}*

--- a/docs/modules/integrate/pages/kinesis-connector.adoc
+++ b/docs/modules/integrate/pages/kinesis-connector.adoc
@@ -50,7 +50,7 @@ Gradle::
 -- 
 [source,groovy,subs="attributes+"]
 ----
-compile 'com.hazelcast.jet:hazelcast-jet-kinesis:{full-version}'
+compile 'com.hazelcast.jet:hazelcast-jet-kinesis:{os-version}'
 ----
 -- 
 Maven:: 
@@ -61,7 +61,7 @@ Maven::
 <dependency>
   <groupId>com.hazelcast.jet</groupId>
   <artifactId>hazelcast-jet-kinesis</artifactId>
-  <version>{full-version}</version>
+  <version>{os-version}</version>
 </dependency>
 ----
 --

--- a/docs/modules/integrate/pages/legacy-file-connector.adoc
+++ b/docs/modules/integrate/pages/legacy-file-connector.adoc
@@ -38,13 +38,13 @@ If you use the slim distribution of Hazelcast, be sure to add the respective mod
 |Included in both full and slim distributions of Hazelcast.
 
 |Apache Avro
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-avro/{full-version}[hazelcast-jet-avro]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-avro/{os-version}[hazelcast-jet-avro]
 
 |Hadoop Distributed File System (HDFS)
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-hadoop/{full-version}[hazelcast-jet-hadoop]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-hadoop/{os-version}[hazelcast-jet-hadoop]
 
 |Amazon S3
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{full-version}[hazelcast-jet-files-s3]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{os-version}[hazelcast-jet-files-s3]
 |===
 
 Although these are the officially supported sources, you can also read from
@@ -196,7 +196,7 @@ Gradle::
 -- 
 [source,groovy,subs="attributes+"]
 ----
-compile 'com.hazelcast.jet:hazelcast-jet-avro:{full-version}'
+compile 'com.hazelcast.jet:hazelcast-jet-avro:{os-version}'
 ----
 --
 Maven:: 
@@ -207,7 +207,7 @@ Maven::
 <dependency>
   <groupId>com.hazelcast.jet</groupId>
   <artifactId>hazelcast-jet-avro</artifactId>
-  <version>{full-version}</version>
+  <version>{os-version}</version>
 </dependency>
 ----
 --

--- a/docs/modules/jcache/pages/setup.adoc
+++ b/docs/modules/jcache/pages/setup.adoc
@@ -49,7 +49,7 @@ add the
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast</artifactId>
-    <version>{full-version}</version>
+    <version>{os-version}</version>
 </dependency>
 ----
 
@@ -68,7 +68,7 @@ it contains the client libraries, too:
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast</artifactId>
-    <version>{full-version}</version>
+    <version>{os-version}</version>
 </dependency>
 ----
 

--- a/docs/modules/management/pages/cluster-utilities.adoc
+++ b/docs/modules/management/pages/cluster-utilities.adoc
@@ -34,7 +34,7 @@ ifndef::snapshot[]
 [source,bash,subs="attributes+"]
 ----
 brew tap hazelcast/hz
-brew install hazelcast@{full-version}
+brew install hazelcast@{os-version}
 ----
 endif::[]
 --
@@ -54,7 +54,7 @@ ifndef::snapshot[]
 ----
 wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
-sudo apt update && sudo apt install hazelcast={full-version}
+sudo apt update && sudo apt install hazelcast={os-version}
 ----
 endif::[]
 
@@ -73,7 +73,7 @@ ifndef::snapshot[]
 ----
 wget https://repository.hazelcast.com/rpm/stable/hazelcast-rpm-stable.repo -O hazelcast-rpm-stable.repo
 sudo mv hazelcast-rpm-stable.repo /etc/yum.repos.d/
-sudo yum install hazelcast-{full-version}
+sudo yum install hazelcast-{os-version}
 ----
 endif::[]
 ====

--- a/docs/modules/pipelines/pages/cdc-join.adoc
+++ b/docs/modules/pipelines/pages/cdc-join.adoc
@@ -606,16 +606,16 @@ You should see the following jars:
 {enterprise-product-name}::
 +
 --
-* hazelcast-enterprise-cdc-debezium-{full-version}.jar
-* hazelcast-enterprise-cdc-mysql-{full-version}.jar (for MySQL)
-* hazelcast-enterprise-cdc-postgres-{full-version}.jar (for Postgres)
+* hazelcast-enterprise-cdc-debezium-{ee-version}.jar
+* hazelcast-enterprise-cdc-mysql-{ee-version}.jar (for MySQL)
+* hazelcast-enterprise-cdc-postgres-{ee-version}.jar (for Postgres)
 --
 {open-source-product-name}::
 +
 --
-* hazelcast-jet-cdc-debezium-{full-version}.jar
-* hazelcast-jet-cdc-mysql-{full-version}.jar (for MySQL)
-* hazelcast-jet-cdc-postgres-{full-version}.jar (for Postgres)
+* hazelcast-jet-cdc-debezium-{os-version}.jar
+* hazelcast-jet-cdc-mysql-{os-version}.jar (for MySQL)
+* hazelcast-jet-cdc-postgres-{os-version}.jar (for Postgres)
 --
 ====
 

--- a/docs/modules/pipelines/pages/cdc-postgres.adoc
+++ b/docs/modules/pipelines/pages/cdc-postgres.adoc
@@ -144,14 +144,14 @@ You should see the following jars:
 {enterprise-product-name}::
 +
 --
-* hazelcast-enterprise-cdc-debezium-{full-version}.jar
-* hazelcast-enterprise-cdc-postgres-{full-version}.jar (for Postgres)
+* hazelcast-enterprise-cdc-debezium-{ee-version}.jar
+* hazelcast-enterprise-cdc-postgres-{ee-version}.jar (for Postgres)
 --
 {open-source-product-name}::
 +
 --
-* hazelcast-jet-cdc-debezium-{full-version}.jar
-* hazelcast-jet-cdc-postgres-{full-version}.jar (for Postgres)
+* hazelcast-jet-cdc-debezium-{os-version}.jar
+* hazelcast-jet-cdc-postgres-{os-version}.jar (for Postgres)
 --
 ====
 
@@ -194,9 +194,9 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    implementation 'com.hazelcast:hazelcast:{full-version}'
-    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-debezium:{full-version}'
-    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-postgres:{full-version}'
+    implementation 'com.hazelcast:hazelcast:{os-version}'
+    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-debezium:{ee-version}'
+    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-postgres:{ee-version}'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.0'
 }
 
@@ -226,17 +226,17 @@ Maven::
        <dependency>
            <groupId>com.hazelcast</groupId>
            <artifactId>hazelcast</artifactId>
-           <version>{full-version}</version>
+           <version>{os-version}</version>
        </dependency>
        <dependency>
            <groupId>com.hazelcast.jet</groupId>
            <artifactId>hazelcast-enterprise-cdc-debezium</artifactId>
-           <version>{full-version}</version>
+           <version>{ee-version}</version>
        </dependency>
        <dependency>
            <groupId>com.hazelcast.jet</groupId>
            <artifactId>hazelcast-enterprise-cdc-postgres</artifactId>
-           <version>{full-version}</version>
+           <version>{ee-version}</version>
        </dependency>
        <dependency>
            <groupId>com.fasterxml.jackson.core</groupId>

--- a/docs/modules/pipelines/pages/cdc.adoc
+++ b/docs/modules/pipelines/pages/cdc.adoc
@@ -153,11 +153,11 @@ mysql> SELECT * FROM customers;
 If you already have Hazelcast and you skipped the above steps, make sure to
 follow from here on.
 ifdef::snapshot[]
-Download and extract the Hazelcast ZIP file from link:https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{full-version}[the repository].
-. Make sure the MySQL CDC plugin is in the `lib/` directory. You must manually download the MySQL CDC plugin's `jar-with-dependencies` from link:https://repository.hazelcast.com/snapshot/com/hazelcast/jet/hazelcast-enterprise-cdc-mysql/{full-version}[Hazelcast's Maven repository, window=_blank] and then copy it to the `lib/` directory.
+Download and extract the Hazelcast ZIP file from link:https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{ee-version}[the repository].
+. Make sure the MySQL CDC plugin is in the `lib/` directory. You must manually download the MySQL CDC plugin's `jar-with-dependencies` from link:https://repository.hazelcast.com/snapshot/com/hazelcast/jet/hazelcast-enterprise-cdc-mysql/{ee-version}[Hazelcast's Maven repository, window=_blank] and then copy it to the `lib/` directory.
 endif::[]
 ifndef::snapshot[]
-. Make sure the MySQL CDC plugin is in the `lib/` directory. You must manually download the MySQL CDC plugin from link:https://repository.hazelcast.com/release/com/hazelcast/jet/hazelcast-enterprise-cdc-mysql/{full-version}/hazelcast-enterprise-cdc-mysql-{full-version}-jar-with-dependencies.jar[Hazelcast's Maven repository, window=_blank] and then copy it to the `lib/` directory.
+. Make sure the MySQL CDC plugin is in the `lib/` directory. You must manually download the MySQL CDC plugin from link:https://repository.hazelcast.com/release/com/hazelcast/jet/hazelcast-enterprise-cdc-mysql/{ee-version}/hazelcast-enterprise-cdc-mysql-{ee.-version}-jar-with-dependencies.jar[Hazelcast's Maven repository, window=_blank] and then copy it to the `lib/` directory.
 endif::[]
 +
 [source,bash]
@@ -167,9 +167,9 @@ ls lib/
 +
 You should see the following jars:
 +
-* hazelcast-enterprise-cdc-debezium-{full-version}-jar-with-dependencies.jar
-* hazelcast-enterprise-cdc-mysql-{full-version}-jar-with-dependencies.jar
-* hazelcast-enterprise-cdc-postgres-{full-version}-jar-with-dependencies.jar
+* hazelcast-enterprise-cdc-debezium-{ee-version}-jar-with-dependencies.jar
+* hazelcast-enterprise-cdc-mysql-{ee-version}-jar-with-dependencies.jar
+* hazelcast-enterprise-cdc-postgres-{ee-version}-jar-with-dependencies.jar
 +
 WARNING: If you have Hazelcast {enterprise-product-name}, you need to manually download the MySQL CDC plugin from https://repo1.maven.org/maven2/com/hazelcast/jet/hazelcast-jet-cdc-mysql/{os-version}/hazelcast-jet-cdc-mysql-{os-version}-jar-with-dependencies.jar[Hazelcast's Maven repository] and then copy it to the `lib/` directory.
 
@@ -212,9 +212,9 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    implementation 'com.hazelcast:hazelcast:{full-version}'
-    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-debezium:{full-version}'
-    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-mysql:{full-version}'
+    implementation 'com.hazelcast:hazelcast:{os-version}'
+    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-debezium:{ee-version}'
+    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-mysql:{ee-version}'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.0'
 }
 
@@ -243,17 +243,17 @@ Maven::
        <dependency>
            <groupId>com.hazelcast</groupId>
            <artifactId>hazelcast</artifactId>
-           <version>{full-version}</version>
+           <version>{os-version}</version>
        </dependency>
        <dependency>
            <groupId>com.hazelcast.jet</groupId>
            <artifactId>hazelcast-enterprise-cdc-debezium</artifactId>
-           <version>{full-version}</version>
+           <version>{ee-version}</version>
        </dependency>
        <dependency>
            <groupId>com.hazelcast.jet</groupId>
            <artifactId>hazelcast-enterprise-cdc-mysql</artifactId>
-           <version>{full-version}</version>
+           <version>{ee-version}</version>
        </dependency>
        <dependency>
            <groupId>com.fasterxml.jackson.core</groupId>

--- a/docs/modules/pipelines/pages/grpc.adoc
+++ b/docs/modules/pipelines/pages/grpc.adoc
@@ -22,7 +22,7 @@ Gradle::
 -- 
 [source,groovy,subs="attributes+"]
 ----
-compile 'com.hazelcast.jet:hazelcast-jet-grpc:{full-version}'
+compile 'com.hazelcast.jet:hazelcast-jet-grpc:{os-version}'
 ----
 --
 Maven:: 
@@ -34,7 +34,7 @@ Maven::
 <dependency>
   <groupId>com.hazelcast.jet</groupId>
   <artifactId>hazelcast-jet-grpc</artifactId>
-  <version>{full-version}</version>
+  <version>{os-version}</version>
 </dependency>
 ----
 --

--- a/docs/modules/pipelines/pages/kafka.adoc
+++ b/docs/modules/pipelines/pages/kafka.adoc
@@ -18,7 +18,7 @@ From now on we assume Kafka is running on your machine.
 +
 If you already have Hazelcast, and you skipped the above steps, make sure to
 follow from here on (just check that
-`hazelcast-jet-kafka-{full-version}.jar` is in the `lib/` directory of your
+`hazelcast-jet-kafka-{os-version}.jar` is in the `lib/` directory of your
 distribution, because you might have the slim distribution).
 
 . Start Hazelcast:
@@ -59,8 +59,8 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    implementation 'com.hazelcast:hazelcast:{full-version}'
-    implementation 'com.hazelcast.jet:hazelcast-jet-kafka:{full-version}'
+    implementation 'com.hazelcast:hazelcast:{os-version}'
+    implementation 'com.hazelcast.jet:hazelcast-jet-kafka:{os-version}'
 }
 
 jar.manifest.attributes 'Main-Class': 'org.example.JetJob'
@@ -89,12 +89,12 @@ Maven::
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>{full-version}</version>
+            <version>{os-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-kafka</artifactId>
-            <version>{full-version}</version>
+            <version>{os-version}</version>
         </dependency>
     </dependencies>
 

--- a/docs/modules/pipelines/pages/kinesis.adoc
+++ b/docs/modules/pipelines/pages/kinesis.adoc
@@ -60,8 +60,8 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    implementation 'com.hazelcast:hazelcast:{full-version}'
-    implementation 'com.hazelcast.jet:hazelcast-jet-kinesis:{full-version}'
+    implementation 'com.hazelcast:hazelcast:{os-version}'
+    implementation 'com.hazelcast.jet:hazelcast-jet-kinesis:{os-version}'
 }
 ----
 --
@@ -88,12 +88,12 @@ Maven::
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
-            <version>{full-version}</version>
+            <version>{os-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-kinesis</artifactId>
-            <version>{full-version}</version>
+            <version>{os-version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/docs/modules/pipelines/pages/map-join.adoc
+++ b/docs/modules/pipelines/pages/map-join.adoc
@@ -43,8 +43,8 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    implementation 'com.hazelcast:hazelcast:{full-version}'
-    implementation 'com.hazelcast.samples.jet:hazelcast-jet-examples-trade-source:{full-version}'
+    implementation 'com.hazelcast:hazelcast:{os-version}'
+    implementation 'com.hazelcast.samples.jet:hazelcast-jet-examples-trade-source:{os-version}'
 }
 
 jar {
@@ -55,7 +55,7 @@ jar {
 
 shadowJar {
     dependencies {
-        exclude(dependency('com.hazelcast:hazelcast:{full-version}'))
+        exclude(dependency('com.hazelcast:hazelcast:{os-version}'))
     }
 }
 ----
@@ -83,12 +83,12 @@ Maven::
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>{full-version}</version>
+            <version>{jet-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.samples.jet</groupId>
             <artifactId>hazelcast-jet-examples-trade-source</artifactId>
-            <version>{full-version}</version>
+            <version>{jet-version}</version>
         </dependency>
     </dependencies>
 

--- a/docs/modules/pipelines/pages/pulsar.adoc
+++ b/docs/modules/pipelines/pages/pulsar.adoc
@@ -68,7 +68,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.hazelcast:hazelcast:{full-version}'
+    implementation 'com.hazelcast:hazelcast:{os-version}'
     implementation 'com.hazelcast.jet-contrib:pulsar:0.1'
     implementation 'org.apache.pulsar:pulsar-client:2.5.0'
 }
@@ -81,7 +81,7 @@ jar {
 
 shadowJar {
     dependencies {
-        exclude(dependency('com.hazelcast:hazelcast:{full-version}'))
+        exclude(dependency('com.hazelcast:hazelcast:{os-version}'))
     }
 }
 ----
@@ -109,7 +109,7 @@ Maven::
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>{full-version}</version>
+            <version>{os-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet.contrib</groupId>

--- a/docs/modules/pipelines/pages/python.adoc
+++ b/docs/modules/pipelines/pages/python.adoc
@@ -66,8 +66,8 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    implementation 'com.hazelcast:hazelcast:{full-version}'
-    implementation 'com.hazelcast.jet:hazelcast-jet-python:{full-version}'
+    implementation 'com.hazelcast:hazelcast:{os-version}'
+    implementation 'com.hazelcast.jet:hazelcast-jet-python:{os-version}'
 }
 
 jar.manifest.attributes 'Main-Class': 'org.example.JetJob'
@@ -96,12 +96,12 @@ Maven::
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
-      <version>{full-version}</version>
+      <version>{os-version}</version>
   </dependency>
   <dependency>
       <groupId>com.hazelcast.jet</groupId>
       <artifactId>hazelcast-jet-python</artifactId>
-      <version>{full-version}</version>
+      <version>{os-version}</version>
     </dependency>
   </dependencies>
 

--- a/docs/modules/pipelines/pages/serialization.adoc
+++ b/docs/modules/pipelines/pages/serialization.adoc
@@ -351,7 +351,7 @@ Gradle::
 -- 
 [source,groovy,subs="attributes+"]
 ----
-compile "com.hazelcast.jet:hazelcast-jet-protobuf:{full-version}"
+compile "com.hazelcast.jet:hazelcast-jet-protobuf:{os-version}"
 ----
 --
 Maven:: 
@@ -362,7 +362,7 @@ Maven::
 <dependency>
     <groupId>com.hazelcast.jet</groupId>
     <artifactId>hazelcast-jet-protobuf</artifactId>
-    <version>{full-version}</version>
+    <version>{os-version}</version>
 </dependency>
 ----
 --

--- a/docs/modules/pipelines/pages/stream-processing-client.adoc
+++ b/docs/modules/pipelines/pages/stream-processing-client.adoc
@@ -89,7 +89,7 @@ ifdef::snapshot[]
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>{full-version}</version>
+            <version>{os-version}</version>
         </dependency>
     </dependencies>
 
@@ -118,7 +118,7 @@ ifndef::snapshot[]
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>{full-version}</version>
+            <version>{os-version}</version>
         </dependency>
     </dependencies>
 

--- a/docs/modules/pipelines/pages/stream-processing-embedded.adoc
+++ b/docs/modules/pipelines/pages/stream-processing-embedded.adoc
@@ -80,7 +80,7 @@ ifdef::snapshot[]
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>{full-version}</version>
+            <version>{os-version}</version>
         </dependency>
     </dependencies>
 
@@ -109,7 +109,7 @@ ifndef::snapshot[]
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>{full-version}</version>
+            <version>{os-version}</version>
         </dependency>
     </dependencies>
 

--- a/docs/modules/pipelines/pages/windowing.adoc
+++ b/docs/modules/pipelines/pages/windowing.adoc
@@ -48,8 +48,8 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    implementation 'com.hazelcast:hazelcast:{full-version}'
-    implementation 'com.hazelcast.samples.jet:hazelcast-jet-examples-trade-source:{full-version}'
+    implementation 'com.hazelcast:hazelcast:{os-version}'
+    implementation 'com.hazelcast.samples.jet:hazelcast-jet-examples-trade-source:{jet-version}'
 }
 
 jar {
@@ -60,7 +60,7 @@ jar {
 
 shadowJar {
     dependencies {
-        exclude(dependency('com.hazelcast:hazelcast:{full-version}'))
+        exclude(dependency('com.hazelcast:hazelcast:{os-version}'))
     }
 }
 ----
@@ -88,12 +88,12 @@ Maven::
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
-            <version>{full-version}</version>
+            <version>{jet-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.samples.jet</groupId>
             <artifactId>hazelcast-jet-examples-trade-source</artifactId>
-            <version>{full-version}</version>
+            <version>{jet-version}</version>
         </dependency>
     </dependencies>
 

--- a/docs/modules/spring/pages/configuration.adoc
+++ b/docs/modules/spring/pages/configuration.adoc
@@ -7,7 +7,7 @@ for Spring Configuration.
 
 _Classpath Configuration:_
 
-NOTE: To enable Spring integration, `hazelcast-spring-{full-version}.jar` must be on the classpath.
+NOTE: To enable Spring integration, `hazelcast-spring-{os-version}.jar` must be on the classpath.
 
 If you use Maven, add the following lines to your `pom.xml`:
 
@@ -16,7 +16,7 @@ If you use Maven, add the following lines to your `pom.xml`:
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-spring</artifactId>
-    <version>{full-version}</version>
+    <version>{os-version}</version>
 </dependency>
 ----
 
@@ -27,12 +27,12 @@ If you want to use `hazelcast-spring` with `hazelcast-enterprise`, you need to e
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-enterprise</artifactId>
-    <version>{full-version}</version>
+    <version>{ee-version}</version>
 </dependency>
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-spring</artifactId>
-    <version>{full-version}</version>
+    <version>{os-version}</version>
     <exclusions>
         <exclusion>
           <groupId>com.hazelcast</groupId>

--- a/docs/modules/sql/pages/mapping-to-a-file-system.adoc
+++ b/docs/modules/sql/pages/mapping-to-a-file-system.adoc
@@ -276,27 +276,27 @@ a|Included in both full and slim distributions of Hazelcast.
 |path/to/a/directory
 
 |Hadoop Distributed File System (HDFS)
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-hadoop-all/{full-version}[hazelcast-jet-hadoop-all]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-hadoop-all/{os-version}[hazelcast-jet-hadoop-all]
 |hdfs://path/to/a/directory
 
 |Amazon S3
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{full-version}[hazelcast-jet-files-s3]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{os-version}[hazelcast-jet-files-s3]
 |s3a://example-bucket/path/in/the/bucket
 
 |Google Cloud Storage
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-gcs/{full-version}[hazelcast-jet-files-gcs]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-gcs/{os-version}[hazelcast-jet-files-gcs]
 |gs://example-bucket/path/in/the/bucket
 
 |Windows Azure Blob Storage
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{full-version}[hazelcast-jet-files-azure]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
 |wasbs://example-container@examplestorageaccount.blob.core.windows.net/path/in/the/container
 
 |Azure Data Lake Generation 1
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{full-version}[hazelcast-jet-files-azure]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
 |adl://exampledatalake.azuredatalakestore.net/path/in/the/container
 
 |Azure Data Lake Generation 2
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{full-version}[hazelcast-jet-files-azure]
+|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
 |abfs://example-container@exampledatalakeaccount.dfs.core.windows.net/path/in/the/container
 |===
 

--- a/docs/modules/sql/pages/mapping-to-kafka.adoc
+++ b/docs/modules/sql/pages/mapping-to-kafka.adoc
@@ -12,7 +12,7 @@ The Kafka connector acts as a consumer or a producer so that you can create stre
 
 This connector is included in the full distribution of Hazelcast.
 
-If you're using the slim distribution, you must add the link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-kafka/{full-version}[`hazelcast-jet-kafka` module] to your member's classpath.
+If you're using the slim distribution, you must add the link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-kafka/{os-version}[`hazelcast-jet-kafka` module] to your member's classpath.
 
 The Kafka connector is compatible with Kafka version equal to
 or greater than 1.0.0.

--- a/docs/modules/sql/pages/mapping-to-mongo.adoc
+++ b/docs/modules/sql/pages/mapping-to-mongo.adoc
@@ -30,7 +30,7 @@ Add the following lines to your `pom.xml` to include it as a dependency to your 
 <dependency>
     <groupId>com.hazelcast.jet</groupId>
     <artifactId>hazelcast-jet-mongodb</artifactId>
-    <version>${full-version}</version>
+    <version>${os-version}</version>
 </dependency>
 ----
 
@@ -38,7 +38,7 @@ or if you are using Gradle:
 
 [source,plain,subs="attributes+"]
 ----
-compile group: 'com.hazelcast.jet', name: 'hazelcast-jet-mongodb', version: ${full-version}.
+compile group: 'com.hazelcast.jet', name: 'hazelcast-jet-mongodb', version: ${os-version}.
 ----
 
 NOTE: To be able to use SQL over MongoDB, you have to include `hazelcast-sql` as well as a dependency.

--- a/docs/modules/test/pages/testing.adoc
+++ b/docs/modules/test/pages/testing.adoc
@@ -20,7 +20,7 @@ Gradle::
 --
 [source,shell,subs="attributes+"]
 ----
-compile 'com.hazelcast:hazelcast:{full-version}:tests'
+compile 'com.hazelcast:hazelcast:{os-version}:tests'
 ----
 --
 Maven:: 
@@ -31,7 +31,7 @@ Maven::
 <dependency>
   <groupId>com.hazelcast</groupId>
   <artifactId>hazelcast</artifactId>
-  <version>{full-version}</version>
+  <version>{os-version}</version>
   <classifier>tests</classifier>
 </dependency>
 ----


### PR DESCRIPTION
`full-version` property is problematic as EE and OS are versioned separately, which can lead to broken references.

_Where possible_ I've updated all `full-version` usages to be either OS or EE, covering the following scenarios:
- Maven JAR version specifications (`pom.xml` or direct download links)
- `hazelcast-jet-kafka` link was just broken (previously missed because the link isn't fully formed in the documentation)
- packaging references (brew etc)
- gradle references

*Many* of the above were producing the wrong result in our current documentation (e.g. referencing `5.5.3` of Hazelcast OS in Maven which doesn't exist).

One of the files also referenced a Jet artefact, but used the `full-version` - Jet hasn't been updated since `4.x` so didn't work. I've added a new property for the Jet version and have referenced that instead, although the content is probably outdated and needs updating.