### PR TITLE
Fix `jet-version` mixup

### DIFF
--- a/docs/modules/pipelines/pages/kinesis.adoc
+++ b/docs/modules/pipelines/pages/kinesis.adoc
@@ -88,7 +88,7 @@ Maven::
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
-            <version>{os-version}</version>
+            <version>{jet-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>

--- a/docs/modules/pipelines/pages/map-join.adoc
+++ b/docs/modules/pipelines/pages/map-join.adoc
@@ -83,7 +83,7 @@ Maven::
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>{jet-version}</version>
+            <version>{os-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.samples.jet</groupId>


### PR DESCRIPTION
The new `jet-version` property added in https://github.com/hazelcast/hz-docs/pull/1540 was used in the wrong place.