### PR TITLE
Clarify that GenericMapStore does not support domain object transformation [v/5.3]

### DIFF
--- a/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
+++ b/docs/modules/mapstore/pages/configuring-a-generic-mapstore.adoc
@@ -6,6 +6,8 @@
 
 NOTE: The objects created in the distributed map are stored as GenericRecord. You can use the `type-name` property to store the data in a POJO (Plain Old Java Object).
 
+IMPORTANT: GenericMapStore is designed to handle GenericRecord and does not support automatic transformation between stored data (GenericRecord) and domain objects (POJOs) in embedded mode. While the `type-name` property allows specifying a https://docs.hazelcast.com/hazelcast/latest/serialization/compact-serialization[Compact type name], it does not enable domain object mapping.
+
 For a list of all supported external systems, including databases, see available xref:external-data-stores:external-data-stores.adoc#connectors[data connection types].
 
 == Before you begin


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1534

This update is improves the documentation by explicitly stating that GenericMapStore is designed to handle GenericRecord and does not support automatic transformation between GenericRecord and POJOs.

SUP Ticket: [SUP-670](https://hazelcast.atlassian.net/browse/SUP-670)

[SUP-670]: https://hazelcast.atlassian.net/browse/SUP-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ