### PR TITLE
Fix required parameters for name of index in Vector Collections [v/5.5]

### DIFF
--- a/docs/modules/data-structures/pages/vector-collections.adoc
+++ b/docs/modules/data-structures/pages/vector-collections.adoc
@@ -60,7 +60,7 @@ Can include letters, numbers, and the symbols `-`, `_`, `*`.
 |name
 |The name of the vector index.
 Can include letters, numbers, and the symbols `-` and `_`.
-|Required for single-index vector collections. Optional for multi-index collection
+|Required for multi-index vector collections. Optional for single-index collection
 |`NULL`
 
 |dimension


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1474