### PR TITLE
Update `os-version` & `os-version` to `SNAPSHOT`s

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -10,8 +10,8 @@ asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
     full-version: '6.0.0-SNAPSHOT'
-    os-version: '5.5.0'
-    ee-version: '5.5.2'
+    os-version: '6.0.0-SNAPSHOT'
+    ee-version: '6.0.0-SNAPSHOT'
     jet-version: '4.5.4'
     # The minor.patch version, which is used as a variable in the docs for things like file versions
     minor-version: '6.0-SNAPSHOT'


### PR DESCRIPTION
For a `SNAPSHOT` release of docs, we should be using a `SNAPSHOT` link to the resources to ensure links to new Javadoc etc works.

For a _release_ we shouldn't, and this automation will be considered as part of [DI-321](https://hazelcast.atlassian.net/browse/DI-321).

Fixes:
- https://hazelcast.slack.com/archives/C035HQET5/p1739794167093319
- https://github.com/hazelcast/hz-docs/runs/37335678139
   > `URL 'https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/5.5.2' had status 404 (found in test/hazelcast/6.0-snapshot/pipelines/cdc.html`