### PR TITLE
Fix `Compile Java source files`

### DIFF
--- a/.github/workflows/maven-pr-builder.yaml
+++ b/.github/workflows/maven-pr-builder.yaml
@@ -18,12 +18,25 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
+
       - name: Maven compile
         run: |
           HZ_VERSION=$(grep full-version docs/antora.yml|sed "s/.*:[ ]*'\(.*\)'/\1/")
-          mvn --show-version --batch-mode --no-transfer-progress test "-Dhazelcast.version=$HZ_VERSION"
+          mvn --show-version test "-Dversion.hazelcast=${HZ_VERSION}"
+
+      - name: Slack notification
+        uses: 8398a7/action-slack@v3
+        if: failure() && github.event_name == 'schedule'
+        with:
+          status: failure
+          fields: repo,job,workflow
+          text: "👎 Test Maven compilation failed."
+          channel: "#docs-notifications"
+        env:
+          SLACK_WEBHOOK_URL: ${{ inputs.SLACK_WEBHOOK }}


### PR DESCRIPTION
`Compile Java source files` [is failing](https://github.com/hazelcast/hz-docs/actions/workflows/maven-pr-builder.yaml). Because the version property override is specified incorrectly such that it's defaulting to `5.5.2`.

In addition, this failure was not spotted for a while due to lack of visibility - addressed with a Slack notification.