### PR TITLE
Remove `version-brew` property

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -15,8 +15,6 @@ asciidoc:
     jet-version: '4.5.4'
     # The minor.patch version, which is used as a variable in the docs for things like file versions
     minor-version: '6.0-SNAPSHOT'
-    # The snapshot version for installing with brew
-    version-brew: '6.0.0-SNAPSHOT'
     java-client-standalone-version: '5.5.0-BETA'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true

--- a/docs/modules/management/pages/cluster-utilities.adoc
+++ b/docs/modules/management/pages/cluster-utilities.adoc
@@ -20,23 +20,12 @@ You can install this tool using its Homebrew, RPM, or Debian packages:
 Homebrew:: 
 + 
 -- 
-ifdef::snapshot[]
-
-[source,bash,subs="attributes+"]
-----
-brew tap hazelcast/hz
-brew install hazelcast@{version-brew}
-----
-endif::[]
-
-ifndef::snapshot[]
 
 [source,bash,subs="attributes+"]
 ----
 brew tap hazelcast/hz
 brew install hazelcast@{os-version}
 ----
-endif::[]
 --
 
 Debian::


### PR DESCRIPTION
Once https://github.com/hazelcast/hz-docs/pull/1555 is merged, `os-version` will always be a brew-resolvable version and the additional `version-brew` property adds no value.

Leaving the release pipeline code that updates the value alone for maintenance branches where it still exists.