### PR TITLE
Backport: Improve native metadata memory usage clarity [HZG-260] (#1558)

### DIFF
--- a/docs/modules/ROOT/pages/capacity-planning.adoc
+++ b/docs/modules/ROOT/pages/capacity-planning.adoc
@@ -97,7 +97,7 @@ to backup data for a total memory footprint of three times your active data set.
 
 If you use only heap memory, each Hazelcast member with a 4 GB heap should
 accommodate a maximum of 3.5 GB of total data (active and backup).
-If you use the xref:storage:high-density-memory.adoc[High-Density Data Store],
+If you use the xref:storage:high-density-memory.adoc[High-Density Memory Store],
 up to 75% of your physical memory footprint may be
 used for active and backup data, with headroom of 25% for normal fragmentation.
 In both cases, however, the best practice is to keep some memory headroom available
@@ -106,13 +106,13 @@ the data previously owned by the newly offline member will be redistributed acro
 the remaining members. For this reason, we recommend that you plan to use only
 60% of available memory, with 40% headroom to handle member failure or shutdown.
 
-If you use High-Density Memory Store, Hazelcast automatically
-assigns a percentage of available off-heap memory to the internal
-memory manager. Since allocation happens lazily, if you want to
-be informed about how much off-heap memory is being used by the
-memory manager, you can set the metadata-space-percentage property
-to a percentage value and Hazelcast will log warnings when that
-value is reached. By default, this property is set to 12.5%.
+If you use the High-Density Memory Store, Hazelcast will also use off-heap memory for
+internal data structures holding your data and to track allocated memory 
+blocks or pages (depending on the allocator configured). Memory used for these 
+purposes is referred to as metadata and is tracked in exported metrics. The
+`metadata-space-percentage` property can be configured to send warning logs
+when a certain threshold has been exceeded. For more information about metadata, see 
+xref:storage:high-density-memory.adoc[High-Density Memory Store].
 
 If you're using jobs, all operational data must fit within
 available memory. This design leads to a predictable performance but requires

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -1545,15 +1545,15 @@ We also have per-object type a `summary` section which provides live and destroy
 
 |`memory.maxHeap`
 |bytes
-|Maximum amount of memory that the JVM will attempt to us
+|Maximum amount of memory that the JVM will use for the heap
 
 |`memory.maxMetadata`
 |bytes
-|Amount of native memory reserved for metadata (this memory is separate and not accounted for by the NativeMemory statistics)
+|The threshold for warning about metadata usage
 
 |`memory.maxNative`
 |bytes
-|Maximum amount of native memory that current instance (member or client) will attempt to use
+|Maximum amount of native memory that current instance (member or client) will use. This value is ignored by Hazelcast for metadata allocation and can increase from the initial configured value
 
 |`memory.totalPhysical`
 |bytes

--- a/docs/modules/storage/pages/high-density-memory.adoc
+++ b/docs/modules/storage/pages/high-density-memory.adoc
@@ -90,12 +90,9 @@ fragment a page block to assign to an allocation request. It is used only
 by the **POOLED** memory allocator. Its default value is **16 bytes**.
 * **page size:** Size of the page in bytes to allocate memory as a block.
 It is used only by the **POOLED** memory allocator. Its default value is `1 << 22` = **4194304 Bytes**, about **4 MB**.
-* **metadata space percentage:** Defines the percentage of the allocated
-native memory that is used for internal memory structures by the High-Density
-Memory for tracking the used and available memory blocks. It is used only by
-the **POOLED** memory allocator. Its default value is **12.5**. Please note that
-when the memory runs out, you get a `NativeOutOfMemoryException`;  if your store
-has a large number of entries, you should consider increasing this percentage.
+* **metadata space percentage:** Defines the percentage of the configured native memory that is estimated to be used 
+for internal High-Density Memory data structures. It is used only by the **POOLED** memory allocator. 
+Its default value is **12.5**. Hazelcast will allow the actual metadata usage to exceed this defined threshold but will send warning logs. See <<metadata>>.
 * **persistent-memory:** See <<using-persistent-memory, Using the High-Density Memory Store with Persistent Memory Devices>>.
 
 The following is the programmatic configuration example.
@@ -160,6 +157,61 @@ NOTE: You can check whether there is enough free physical memory for the
 requested number of bytes using the system property `hazelcast.hidensity.check.freememory`.
 See the xref:ROOT:system-properties.adoc[System Properties appendix] on how to use Hazelcast
 system properties.
+
+[[metadata]]
+== Metadata
+
+Metadata refers to the off-heap memory used by Hazelcast
+internal data structures holding user data and for tracking allocated memory
+blocks or pages when using the `POOLED` allocator. Metadata is
+included when calculating the total committed off-heap memory.
+
+There is no configurable limit for metadata usage -- it will expand as needed to
+accommodate user data. This means it is possible for total committed off-heap
+memory to exceed the configured limit. This is an important consideration in
+deployment environments such as Kubernetes, where containers in Pods can be
+terminated if allocated memory exceeds configured limits.
+
+While metadata usage expands as needed, this is not the case for user data. If
+you have 256MB native memory configured and 10MB of that is metadata, then you
+have 246MB available for storing your data. Exceeding that will result in a
+`NativeOutOfMemoryError`.
+
+=== Estimating Usage
+
+You can estimate member sizing by benchmarking in a simulated
+production environment and monitoring the `memory.usedMetadata` metric.
+
+The majority of metadata usage comes from the space allocated for the underlying
+data structures holding the entries for `IMap` and `ICache`. These data structures
+are similar to a hashmap, with a buffer expanding by a factor of two each time the
+number of entries exceeds a load factor of 0.6 on the existing buffer size. Each
+slot in the buffer costs 16 bytes and the minimum buffer size is 128.
+
+You can define the rough cost of this structure in bytes for `n` entries with the
+following Python snippet:
+
+```python
+import math as m
+
+def mapCost(n):
+    nextPow2 = 2 ** m.ceil(m.log2(n))
+    return 16 * max(128, nextPow2 if n < 0.6 * nextPow2 else 2 * nextPow2)
+```
+
+Then for a cluster with `p` partitions and `m` members, you can estimate per
+member metadata usage for an `IMap` or `ICache` with `b` backups and `n` entries
+to be:
+
+```python
+(p * (b + 1) * mapCost(int(n / p))) / m
+```
+
+Using the `HazelcastJsonValue` type in an `IMap` will roughly double the
+metadata storage costs because structural information will be stored for each entry.
+
+Finally, the cost of tracking allocated memory blocks requires further metadata. 
+Increase the above estimate by about 25% to cover this.
 
 [[using-persistent-memory]]
 == Using the High-Density Memory Store with Persistent Memory Devices


### PR DESCRIPTION
Cleaned up some incorrect and misleading docs around the metadata for native memory data structures. Added a formula for estimating metadata usage to help in capacity planning.

---------