### PR TITLE
Fix Install Hazelcast OS JAR Download Link

### DIFF
--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -190,17 +190,15 @@ The Java package includes both a member API and a Java client API. The member AP
 
 . xref:get-started-java.adoc[Start the cluster].
 
+// Only support OS non-SNAPSHOTs
+ifndef::snapshot[]
 === Using the JAR
 
 If you aren't using a build tool:
 
-ifdef::snapshot[]
 * link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{os-version}/hazelcast-{os-version}.jar[download the Hazelcast JAR file]
-endif::[]
-ifndef::snapshot[]
-* link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{ee-version}/hazelcast-{ee-version}.jar[download the Hazelcast JAR file]
-endif::[]
 * add it to your classpath.
+endif::[]
 
 === Using Modular Java
 


### PR DESCRIPTION
In https://github.com/hazelcast/hz-docs/pull/1540 an error was introduced linking to the _EE_ version in the _OS_ docs in the case of _non-`SNAPSHOT`s. Not only was the link dead, but the EE version makes no sense in the OS installation steps.

This was trying to workaround the issue of lack of OS `SNAPSHOT`s, but actually this issue isn't resolvable - we can't link to what we don't publish (OS `SNAPSHOT`s) so instead the link should not be displayed in this case.