### PR TITLE
Remove erroneous `WARNING` section from CDC docs

### DIFF
--- a/docs/modules/pipelines/pages/cdc.adoc
+++ b/docs/modules/pipelines/pages/cdc.adoc
@@ -170,8 +170,6 @@ You should see the following jars:
 * hazelcast-enterprise-cdc-debezium-{ee-version}-jar-with-dependencies.jar
 * hazelcast-enterprise-cdc-mysql-{ee-version}-jar-with-dependencies.jar
 * hazelcast-enterprise-cdc-postgres-{ee-version}-jar-with-dependencies.jar
-+
-WARNING: If you have Hazelcast {enterprise-product-name}, you need to manually download the MySQL CDC plugin from https://repo1.maven.org/maven2/com/hazelcast/jet/hazelcast-jet-cdc-mysql/{os-version}/hazelcast-jet-cdc-mysql-{os-version}-jar-with-dependencies.jar[Hazelcast's Maven repository] and then copy it to the `lib/` directory.
 
 . Start Hazelcast.
 +


### PR DESCRIPTION
In discussion with @TomaszGaweda:
- this section doesn't make sense
- [the links don't work](https://github.com/hazelcast/hz-docs/actions/runs/13497599672) for `SNAPSHOT` versions

Removed.

Fixes: https://github.com/hazelcast/hz-docs/issues/1571