### PR TITLE
Update rolling upgrade MC version info

### DIFF
--- a/docs/modules/maintain-cluster/pages/rolling-upgrades.adoc
+++ b/docs/modules/maintain-cluster/pages/rolling-upgrades.adoc
@@ -124,8 +124,9 @@ When all members of the cluster have been upgraded to the new codebase version, 
 +
 * xref:{page-latest-supported-mc}@management-center:monitor-imdg:cluster-administration.adoc#rolling-upgrade[Management Center].
 +
-NOTE: To use Management Center, you need to upgrade your version of Management Center *before* upgrading the member version. Management Center is compatible with the previous minor version of
-Hazelcast. For example, Management Center 5.4 works with both Hazelcast 5.3 and 5.4. To change your cluster version to 5.4, you need Management Center 5.4.
+NOTE: To use Management Center to set the cluster version, you need to upgrade Management Center *before* upgrading the members.
+See xref:{page-latest-supported-mc}@management-center:getting-started:overview.adoc#hazelcast-cluster-compatibility[Hazelcast Cluster Compatibility]
+for the list of versions that Management Center can set the cluster version to.
 * xref:management:cluster-utilities.adoc#using-the-hz-cluster-admin-script[hz-cluster-admin] script.
 +
 NOTE: To use this script, you must enable the `CLUSTER_WRITE`


### PR DESCRIPTION
MC is not in lock step versions with Platform so it doesn't make sense to say "MC is compatible with the previous minor version". Replaced with more general language.