### PR TITLE
Clarify version compatibility by removing specific patch versions

### DIFF
--- a/docs/modules/deploy/pages/versioning-compatibility.adoc
+++ b/docs/modules/deploy/pages/versioning-compatibility.adoc
@@ -135,7 +135,7 @@ Hazelcast Platform runs on Java, and supports the following LTS JDKs. It may run
 [options="header"]
 .Supported JDKs
 |===
-|JDK | Platform {full-version}
+|JDK | Platform {minor-version}
 
 |Amazon Corretto 17 and 21
 |✓


### PR DESCRIPTION
Updated the supported operating systems section to use major.minor or major.minor.X instead of specific patch versions. This resolves confusion about patch version support and ensures clarity that all patch versions within the major.minor range are supported.

Fixes: https://github.com/hazelcast/hz-docs/issues/1568