### PR TITLE
Backport of Update client-authorization.adoc

### DIFF
--- a/docs/modules/security/pages/client-authorization.adoc
+++ b/docs/modules/security/pages/client-authorization.adoc
@@ -181,6 +181,11 @@ decides whether the current `Subject` has permission to access the requested res
 
 == Permissions
 
+All Hazelcast clients authorized to connect to a cluster are able to receive proxy information
+for data structures present on the cluster. This proxy only provides the client with the
+data structure's type and name. Permissions for other actions related to these data structures
+can be configured as required.
+
 The following is the list of client permissions that can be configured on the member:
 
 === All permissions


### PR DESCRIPTION
Adds note:

All Hazelcast clients authorized to connect to a cluster are able to receive proxy information for data structures present on the cluster. This proxy only provides the client with the data structure's type and name. Permissions for other actions related to these data structures can be configured as required.