### PR TITLE
Backport of Update map-connector.adoc

### DIFF
--- a/docs/modules/integrate/pages/map-connector.adoc
+++ b/docs/modules/integrate/pages/map-connector.adoc
@@ -188,6 +188,11 @@ setting their values to `null`. To put it another way, if these map sink
 variants set the entry’s value to null, the entry will be removed
 from the map.
 
+NOTE: Custom classes, such as an `EntryProcessor`, must be available to all members
+of the cluster. This can be done by adding the classes to each member's classpath
+directly, or by using {ucn}. If using {ucn}, ensure that the Job and underlying IMap
+are both associated with a namespace that contains the same `EntryProcessor` implementation.
+
 == Predicates and Projections
 
 If your use case calls for some filtering and/or transformation of the


### PR DESCRIPTION
Added note:

NOTE: Custom classes, such as an `EntryProcessor`, must be available to all members of the cluster. This can be done by adding the classes to each member's classpath directly, or by using {ucn}. If using {ucn}, ensure that the Job and underlying IMap are both associated with a namespace that contains the same `EntryProcessor` implementation.