### PR TITLE
Fix authentication yaml indent

### DIFF
--- a/docs/modules/security/pages/simple-authentication.adoc
+++ b/docs/modules/security/pages/simple-authentication.adoc
@@ -55,18 +55,18 @@ hazelcast:
     enabled: true
     realms:
       - name: simpleRealm
-      authentication:
-        simple:
-          users:
-            - username: test
-              password: 'a1234'
-              roles:
-                - monitor
-                - hazelcast
-            - username: root
-              password: 'secret'
-              roles:
-                - admin
+        authentication:
+          simple:
+            users:
+              - username: test
+                password: 'a1234'
+                roles:
+                  - monitor
+                  - hazelcast
+              - username: root
+                password: 'secret'
+                roles:
+                  - admin
     client-authentication:
       realm: simpleRealm
     client-permissions:


### PR DESCRIPTION
Fix yaml indent, `authentication` should be adjacent to `name`