### PR TITLE
Remove `page-latest-supported-java-client` property

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -24,7 +24,6 @@ asciidoc:
     page-latest-cli: '5.2021.09'
     # Must be lowercase because this is how the version appears in the docs
     page-latest-supported-mc: '6.0-snapshot'
-    page-latest-supported-java-client: '6.0.0-SNAPSHOT'
     page-latest-supported-java-client-new: '5.5.0-BETA'
     # https://github.com/hazelcast/hazelcast-go-client/releases
     page-latest-supported-go-client: '1.4.2'


### PR DESCRIPTION
[It's not referenced anywhere](https://github.com/search?q=org%3Ahazelcast+page-latest-supported-java-client+language%3AAsciiDoc&type=code&l=AsciiDoc) and OS/EE versions make more sense because there's not really a _single_ version number.