### PR TITLE
Fix release versions in for `5.5.5` [5.5][REL-559]

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,14 +8,14 @@ display_version: '5.5'
 asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
-    full-version: '5.5.6'
+    full-version: '5.5.5'
     os-version: '5.5.0'
     ee-version: '5.5.5'    
     jet-version: '4.5.4'
     # The minor.patch version, which is used as a variable in the docs for things like file versions
     minor-version: '5.5'
     # The snapshot version for installing with brew
-    version-brew: '5.5.6'
+    version-brew: '5.5.5'
     java-client-standalone-version: '5.5.0-BETA'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true


### PR DESCRIPTION
Was manually incremented in https://github.com/hazelcast/hz-docs/pull/1600 but the automation then incremented again. I should've left alone...