### PR TITLE
doc-423-metrics: added node/cluster reset to map metrics

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -243,139 +243,173 @@ the watermark already having passed their windows.
 .Map
 [%collapsible]
 ====
-[cols="4,1,6a"]
+The Reset column shows the reset behavior of the metrics. There are two types of reset: one occurs on a node restart (indicated by 'N'), and the other on a cluster restart (indicated by 'C'). For example, operational metrics relating to map operations such as get, put, and remove track operations executed by a member during its runtime, and these are reset upon a node restart. By comparison, metrics such as hits, eviction, and expiration counts are tracked at the cluster level, and these are retained when a member is restarted. 
+
+[cols="4,1,6a,1"]
 |===
 | Name
 | Unit
 | Description
+| Reset
 
 |`map.backupCount`
 |count
 |Number of backups per entry
+| N
 
 |`map.backupEntryCount`
 |count
 |Number of backup entries held by the member
+| N
 
 |`map.backupEntryMemoryCost`
 |bytes
 |Memory cost of backup entries in this member
+| N
 
 |`map.creationTime`
 |ms
 |Creation time of the map on the member
+| N
 
 |`map.dirtyEntryCount`
 |count
 |Number of updated but not persisted yet entries, dirty entries, that the member owns
+| N
 
 |`map.evictionCount`
 |count
 |Number of evictions happened on locally owned entries, backups are not included
+| C
 
 |`map.expirationCount`
 |count
 |Number of expirations happened on locally owned entries, backups are not included
+| C
 
 |`map.getCount`
 |count
-|Number of local get operations on the map; it is incremented for every get operation even if the entries do not exist.
+|Number of local get operations on the map; it is incremented for every get operation even if the entries do not exist
+| N
 
 |`map.heapCost`
 |count
 |Total heap cost for the map on this member
+| N
 
 |`map.hits`
 |count
-|Number of reads of the locally owned entries; it is incremented for every read by any type of operation (get, set, put). So the entries should exist.
+|Number of reads of the locally owned entries; it is incremented for every read by any type of operation (get, set, put). So the entries should exist
+| N
 
 |`map.indexedQueryCount`
 |count
 |Total number of indexed local queries performed on the map
+| N
 
 |`map.lastAccessTime`
 |ms
 |Last access (read) time of the locally owned entries
+| N
 
 |`map.lastUpdateTime`
 |ms
 |Last update time of the locally owned entries
+| N
 
 |`map.lockedEntryCount`
 |count
 |Number of locked entries that the member owns
+| N
 
 |`map.merkleTreesCost`
 |count
 |Total heap cost of the Merkle trees used
+| N
 
 |`map.numberOfEvents`
 |count
 |Number of local events received on the map
+| N
 
 |`map.numberOfOtherOperations`
 |count
 |Total number of other operations performed on this member
+| N
 
 |`map.ownedEntryCount`
 |count
 |Number of map entries owned by the member
+| N
 
 |`map.ownedEntryMemoryCost`
 |bytes
 |Memory cost of owned map entries on this member
+| N
 
 |`map.putCount`
 |count
 |Number of local put operations on the map
+| N
 
 |`map.queryCount`
 |count
 |Number of queries executed on the map (it may be imprecise for queries involving partition predicates (PartitionPredicate) on the off-heap storage)
+| N
 
 |`map.removeCount`
 |count
 |Number of local remove operations on the map
+| N
 
 |`map.setCount`
 |count
 |Number of local set operations on the map
+| N
 
 |`map.totalGetLatency`
 |ms
 |Total latency of local get operations on the map
+| N
 
 |`map.totalMaxGetLatency`
 |ms
 |Maximum latency of local get operations on the map
+| N
 
 |`map.totalMaxPutLatency`
 |ms
 |Maximum latency of local put operations on the map
+| N
 
 |`map.totalMaxRemoveLatency`
 |ms
 |Maximum latency of local remove operations on the map
+| N
 
 |`map.totalMaxSetLatency`
 |ms
 |Maximum latency of local set operations on the map
+| N
 
 |`map.totalPutLatency`
 |ms
 |Total latency of local put operations on the map
+| N
 
 |`map.totalRemoveLatency`
 |ms
 |Total latency of local remove operations on the map
+| N
 
 |`map.totalSetLatency`
 |ms
 |Total latency of local set operations on the map
+| N
 
-3+a|
-The above `*latency` metrics are only measured for the members and they are not representing the overall performance of the cluster.
-We recommend monitoring the average latency for each operation, for example, `map.totalGetLatency` / `map.getCount` and `map.totalSetLatency` / `map.setCount`.
+4+a|
+The above `*latency` metrics are only measured for the members and they do not represent the overall performance of the cluster.
+Hazelcast recommends monitoring the average latency for each operation, for example, `map.totalGetLatency` / `map.getCount` and `map.totalSetLatency` / `map.setCount`.
 Increased average latency is a sign that the cluster would experience performance problems, or there is a spike in the load.
 The following may be the reasons:
 
@@ -388,50 +422,62 @@ This is because the cluster has to communicate with more members, which can add 
 |`map.index.averageHitLatency`
 |ns
 |Average hit latency for the index on this member
+| C
 
 |`map.index.averageHitSelectivity`
 |percent
 |Average selectivity of the hits served by the index on this member (the returned value is in the range from 0.0 to 1.0 - values close to 1.0 indicate a high selectivity meaning the index is efficient; values close to 0.0 indicate a low selectivity meaning the index efficiency is approaching an efficiency of a simple full scan)
+| C
 
 |`map.index.creationTime`
 |ms
 |Creation time of the index on this member
+| N
 
 |`map.index.hitCount`
 |count
 |Total number of index hits (the value of this metric may be greater than the `map.index.queryCount` since a single query may hit the same index more than once)
+| C
 
 |`map.index.insertCount`
 |count
 |Number of insert operations performed on the index
+| N
 
 |`map.index.memoryCost`
 |bytes
 |Local memory cost of the index (for on-heap indexes in OBJECT or BINARY formats, the returned value is just a best-effort approximation and doesn't indicate a precise on-heap memory usage of the index)
+| C
 
 |`map.index.queryCount`
 |count
 |Total number of queries served by the index
+| C
 
 |`map.index.removeCount`
 |count
 |Number of remove operations performed on the index
+| N
 
 |`map.index.totalInsertLatency`
 |ns
 |Total latency of insert operations performed on the index
+| N
 
 |`map.index.totalRemoveLatency`
 |ns
 |Total latency of remove operations performed on the index
+| N
 
 |`map.index.totalUpdateLatency`
 |ns
-|Total latency of update operations performed on the index.
+|Total latency of update operations performed on the index
+| N
 
 |`map.index.updateCount`
 |count
 |Number of update operations performed on the index
+| N
 |===
 ====
 

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -310,7 +310,7 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |`map.lastAccessTime`
 |ms
 |Last access (read) time of the locally owned entries
-| N
+| C
 
 |`map.lastUpdateTime`
 |ms

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -295,7 +295,7 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |`map.heapCost`
 |count
 |Total heap cost for the map on this member
-| N
+| C
 
 |`map.hits`
 |count

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -260,7 +260,7 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |`map.backupEntryCount`
 |count
 |Number of backup entries held by the member
-| N
+| C
 
 |`map.backupEntryMemoryCost`
 |bytes

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -452,7 +452,7 @@ This is because the cluster has to communicate with more members, which can add 
 |`map.index.queryCount`
 |count
 |Total number of queries served by the index
-| C
+| N
 
 |`map.index.removeCount`
 |count

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -315,7 +315,7 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |`map.lastUpdateTime`
 |ms
 |Last update time of the locally owned entries
-| N
+| C
 
 |`map.lockedEntryCount`
 |count

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -255,7 +255,7 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |`map.backupCount`
 |count
 |Number of backups per entry
-| N
+| C
 
 |`map.backupEntryCount`
 |count

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -265,7 +265,7 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |`map.backupEntryMemoryCost`
 |bytes
 |Memory cost of backup entries in this member
-| N
+| C
 
 |`map.creationTime`
 |ms

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -1,14 +1,14 @@
 = List of Hazelcast Metrics
 [[appendix]]
 
-The table below lists the metrics with their explanations in grouped by their relevant subjects.
+The table below lists the metrics and their explanations, grouped by their relevant subjects.
 
 The metrics are collected per member and are specific to the local member from which
-you collect them. For example, the distributed data structure metrics
+they were collected. For example, distributed data structure metrics
 reflect the local statistics of that data structure for the portion
 held in that member.
 
-Some metrics may store cluster-wide agreed values, that is, they may show the values obtained
+Some metrics may store cluster-wide agreed values — that is, they may show the values obtained
 by communicating with other members in the cluster. This type of
 metric reflects the member's local view of the cluster (consider split-brain scenarios). The `clusterStartTime` is an example of this type of
 metric, and its value in the local member is obtained by communicating

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -320,7 +320,7 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |`map.lockedEntryCount`
 |count
 |Number of locked entries that the member owns
-| N
+| C
 
 |`map.merkleTreesCost`
 |count

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -300,7 +300,7 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |`map.hits`
 |count
 |Number of reads of the locally owned entries; it is incremented for every read by any type of operation (get, set, put). So the entries should exist
-| N
+| C
 
 |`map.indexedQueryCount`
 |count

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -345,7 +345,7 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |`map.ownedEntryMemoryCost`
 |bytes
 |Memory cost of owned map entries on this member
-| N
+| C
 
 |`map.putCount`
 |count

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -340,7 +340,7 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |`map.ownedEntryCount`
 |count
 |Number of map entries owned by the member
-| N
+| C
 
 |`map.ownedEntryMemoryCost`
 |bytes

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -447,7 +447,7 @@ This is because the cluster has to communicate with more members, which can add 
 |`map.index.memoryCost`
 |bytes
 |Local memory cost of the index (for on-heap indexes in OBJECT or BINARY formats, the returned value is just a best-effort approximation and doesn't indicate a precise on-heap memory usage of the index)
-| C
+| N
 
 |`map.index.queryCount`
 |count

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -427,7 +427,7 @@ This is because the cluster has to communicate with more members, which can add 
 |`map.index.averageHitSelectivity`
 |percent
 |Average selectivity of the hits served by the index on this member (the returned value is in the range from 0.0 to 1.0 - values close to 1.0 indicate a high selectivity meaning the index is efficient; values close to 0.0 indicate a low selectivity meaning the index efficiency is approaching an efficiency of a simple full scan)
-| C
+| N
 
 |`map.index.creationTime`
 |ms

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -422,7 +422,7 @@ This is because the cluster has to communicate with more members, which can add 
 |`map.index.averageHitLatency`
 |ns
 |Average hit latency for the index on this member
-| C
+| N
 
 |`map.index.averageHitSelectivity`
 |percent

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -243,7 +243,7 @@ the watermark already having passed their windows.
 .Map
 [%collapsible]
 ====
-The Reset column shows the reset behavior of the metrics. There are two types of reset: one occurs on a node restart (indicated by 'N'), and the other on a cluster restart (indicated by 'C'). For example, operational metrics relating to map operations such as get, put, and remove track operations executed by a member during its runtime, and these are reset upon a node restart. By comparison, metrics such as hits, eviction, and expiration counts are tracked at the cluster level, and these are retained when a member is restarted. 
+The Reset column shows the reset behavior of the metrics. There are two types of reset: one occurs on a node restart (indicated by 'N'), and the other on a cluster restart (indicated by 'C'). For example, metrics relating to map operations such as get, put, and remove track operations executed by a member during its runtime, and these are reset upon a node restart. Metrics such as hits, evictions, and expirations are tracked at the cluster level, and these are retained when a member is restarted. 
 
 [cols="4,1,6a,1"]
 |===

--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -437,7 +437,7 @@ This is because the cluster has to communicate with more members, which can add 
 |`map.index.hitCount`
 |count
 |Total number of index hits (the value of this metric may be greater than the `map.index.queryCount` since a single query may hit the same index more than once)
-| C
+| N
 
 |`map.index.insertCount`
 |count


### PR DESCRIPTION
This change is for docs ticket:  https://github.com/hazelcast/hz-docs/issues/1598

The fix is to add a new 'reset' column to the Map metrics table to indicate whether a metric is reset at the node or at the cluster level.

A brief explanation of the column is given with examples. 