### PR TITLE
doc bug 1606 - update get-started-binary

### DIFF
--- a/docs/modules/getting-started/pages/get-started-binary.adoc
+++ b/docs/modules/getting-started/pages/get-started-binary.adoc
@@ -698,7 +698,7 @@ Linux::
 --
 [source,shell]
 ----
-hz-mc start
+management-center/bin/hz-mc start
 ----
 --
 Windows:: 

--- a/docs/modules/getting-started/pages/get-started-binary.adoc
+++ b/docs/modules/getting-started/pages/get-started-binary.adoc
@@ -690,7 +690,7 @@ Mac::
 --
 [source,shell]
 ----
-management-center/bin/start.sh
+hz-mc start
 ----
 --
 Linux:: 
@@ -698,7 +698,7 @@ Linux::
 --
 [source,shell]
 ----
-management-center/bin/start.sh
+hz-mc start
 ----
 --
 Windows:: 
@@ -706,7 +706,7 @@ Windows::
 --
 [source,shell]
 ----
-management-center/bin/start.bat
+mc-start.cmd
 ----
 --
 ====

--- a/docs/modules/getting-started/pages/get-started-binary.adoc
+++ b/docs/modules/getting-started/pages/get-started-binary.adoc
@@ -690,7 +690,7 @@ Mac::
 --
 [source,shell]
 ----
-hz-mc start
+management-center/bin/hz-mc start
 ----
 --
 Linux:: 

--- a/docs/modules/getting-started/pages/get-started-binary.adoc
+++ b/docs/modules/getting-started/pages/get-started-binary.adoc
@@ -706,7 +706,7 @@ Windows::
 --
 [source,shell]
 ----
-mc-start.cmd
+management-center/bin/mc-start.cmd
 ----
 --
 ====


### PR DESCRIPTION
For doc-bug 1606, update the step 5 MC start instructions to use the new method (as documented in https://docs.hazelcast.com/management-center/5.7/getting-started/install#binary)