### PR TITLE
Change `test external links` output format from annotations to job summary

### DIFF
--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -51,7 +51,6 @@ runs:
             ${RUNNER_DEBUG:+set -o xtrace}
 
             distinct_urls=$(sort -u "${temp_file}")
-            summary_file=$(mktemp)
 
             echo "| URL | Status | Locations |" >> "$GITHUB_STEP_SUMMARY"
             echo "| --- | -----: | --------- |" >> "$GITHUB_STEP_SUMMARY"
@@ -77,9 +76,6 @@ runs:
                       echo "::debug::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
                       echo "| ${url} | ${status} | ${locations} |" >> "$GITHUB_STEP_SUMMARY"
                       found_error=1
-
-                      # TODO REMOVE
-                      exit 1
                   else
                       echo "::debug::✅ URL '${url}' had status ${status}"
                   fi

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -80,7 +80,7 @@ runs:
                     fi
                 fi
             done <<< "${distinct_urls}"
-
+            
             if [[ "${found_error}" -eq 1 ]]; then
                 exit 1
             else

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -58,10 +58,10 @@ runs:
             while read -r url; do
                 if [[ -n "${url}" ]]; then
                     echo "::debug::Checking URL '${url}'..."
-
+  
                     # Some links will probably still fail to resolve, e.g. `localhost`, "some.dummy.url" etc, so don't treat CURL exit codes as fact
                     # We want to identify when a real server responds to the request
-  
+
                     # First try a HEAD request to avoid downloading the whole response
                     status=$(curl --globoff --silent --output /dev/null --location --head --write-out "%{http_code}" "${url}" || true)
   

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -58,7 +58,7 @@ runs:
             while read -r url; do
                 if [[ -n "${url}" ]]; then
                     echo "::debug::Checking URL '${url}'..."
-  
+
                     # Some links will probably still fail to resolve, e.g. `localhost`, "some.dummy.url" etc, so don't treat CURL exit codes as fact
                     # We want to identify when a real server responds to the request
   

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -75,7 +75,7 @@ runs:
                         # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
                         locations=$(grep -rl "${url}" "${docs_output}" || true)
                         echo "::debug::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
-                        echo "| ${url} | ${status} | $(awk '{printf "- %s<br>", $0}' <<< "${locations}") |" >> ${GITHUB_STEP_SUMMARY}
+                        echo "| ${url} | ${status} | <ul>$(awk '{printf "<li>%s</li>", $0}' <<< "${locations}")</ul> |" >> ${GITHUB_STEP_SUMMARY}
                         found_error=1
                     else
                         echo "::debug::✅ URL '${url}' had status ${status}"

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -51,11 +51,10 @@ runs:
             ${RUNNER_DEBUG:+set -o xtrace}
 
             distinct_urls=$(sort -u "${temp_file}")
+            summary_file=$(mktemp)
 
-            echo "## ❌ Dead links found" >> "${summary_file}"
-            echo "" >> "${summary_file}"
-            echo "| URL | Status | Locations |" >> "${summary_file}"
-            echo "| --- | -----: | --------- |" >> "${summary_file}"
+            echo "| URL | Status | Locations |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| --- | -----: | --------- |" >> "$GITHUB_STEP_SUMMARY"
 
             while read -r url; do
                 if [[ -n "${url}" ]]; then
@@ -76,11 +75,10 @@ runs:
                       # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
                       locations=$(grep -rl "${url}" || true)
                       echo "::debug::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
-                      echo "| ${url} | ${status} | ${locations} |" >> "${summary_file}"
+                      echo "| ${url} | ${status} | ${locations} |" >> "$GITHUB_STEP_SUMMARY"
                       found_error=1
 
                       # TODO REMOVE
-                      cat "${summary_file}" >> "$GITHUB_STEP_SUMMARY"
                       exit 1
                   else
                       echo "::debug::✅ URL '${url}' had status ${status}"
@@ -89,10 +87,8 @@ runs:
             done <<< "${distinct_urls}"
 
             if [[ "${found_error}" -eq 1 ]]; then
-                cat "${summary_file}" >> "$GITHUB_STEP_SUMMARY"
                 exit 1
             else
-                echo "✅ No dead links found" >> "$GITHUB_STEP_SUMMARY"
                 exit 0
             fi
 

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -57,28 +57,27 @@ runs:
 
             while read -r url; do
                 if [[ -n "${url}" ]]; then
-                  echo "::debug::Checking URL '${url}'..."
+                    echo "::debug::Checking URL '${url}'..."
 
-                  # Some links will probably still fail to resolve, e.g. `localhost`, "some.dummy.url" etc, so don't treat CURL exit codes as fact
-                  # We want to identify when a real server responds to the request
+                    # Some links will probably still fail to resolve, e.g. `localhost`, "some.dummy.url" etc, so don't treat CURL exit codes as fact
+                    # We want to identify when a real server responds to the request
+                    # First try a HEAD request to avoid downloading the whole response
+                    status=$(curl --globoff --silent --output /dev/null --location --head --write-out "%{http_code}" "${url}" || true)
 
-                  # First try a HEAD request to avoid downloading the whole response
-                  status=$(curl --globoff --silent --output /dev/null --location --head --write-out "%{http_code}" "${url}" || true)
+                    if [[ "${status}" -eq 404 ]]; then
+                      # But not all servers support "HEAD" (e.g. azure.microsoft.com), so try again
+                      status=$(curl --globoff --silent --output /dev/null --location --write-out "%{http_code}" "${url}" || true)
+                    fi
 
-                  if [[ "${status}" -eq 404 ]]; then
-                    # But not all servers support "HEAD" (e.g. azure.microsoft.com), so try again
-                    status=$(curl --globoff --silent --output /dev/null --location --write-out "%{http_code}" "${url}" || true)
-                  fi
-
-                  if [[ "${status}" -eq 404 ]]; then
-                      # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
-                      locations=$(grep -rl "${url}" || true)
-                      echo "::debug::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
-                      echo "| ${url} | ${status} | ${locations} |" >> "$GITHUB_STEP_SUMMARY"
-                      found_error=1
-                  else
-                      echo "::debug::✅ URL '${url}' had status ${status}"
-                  fi
+                    if [[ "${status}" -eq 404 ]]; then
+                        # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
+                        locations=$(grep -rl "${url}" || true)
+                        echo "::debug::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
+                        echo "| ${url} | ${status} | ${locations} |" >> "$GITHUB_STEP_SUMMARY"
+                        found_error=1
+                    else
+                        echo "::debug::✅ URL '${url}' had status ${status}"
+                    fi
                 fi
             done <<< "${distinct_urls}"
 

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -52,8 +52,8 @@ runs:
 
             distinct_urls=$(sort -u "${temp_file}")
 
-            echo "| URL | Status | Locations |" >> "$GITHUB_STEP_SUMMARY"
-            echo "| --- | -----: | --------- |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| URL | Status | Locations |" >> ${GITHUB_STEP_SUMMARY}
+            echo "| --- | -----: | --------- |" >> ${GITHUB_STEP_SUMMARY}
   
             while read -r url; do
                 if [[ -n "${url}" ]]; then
@@ -74,7 +74,7 @@ runs:
                         # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
                         locations=$(grep -rl "${url}" || true)
                         echo "::debug::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
-                        echo "| ${url} | ${status} | ${locations} |" >> "$GITHUB_STEP_SUMMARY"
+                        echo "| ${url} | ${status} | $(awk '{printf "- %s<br>", $0}' <<< "${locations}") |" >> ${GITHUB_STEP_SUMMARY}
                         found_error=1
                     else
                         echo "::debug::✅ URL '${url}' had status ${status}"

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -54,7 +54,7 @@ runs:
 
             echo "| URL | Status | Locations |" >> "$GITHUB_STEP_SUMMARY"
             echo "| --- | -----: | --------- |" >> "$GITHUB_STEP_SUMMARY"
-
+  
             while read -r url; do
                 if [[ -n "${url}" ]]; then
                     echo "::debug::Checking URL '${url}'..."
@@ -63,7 +63,7 @@ runs:
                     # We want to identify when a real server responds to the request
                     # First try a HEAD request to avoid downloading the whole response
                     status=$(curl --globoff --silent --output /dev/null --location --head --write-out "%{http_code}" "${url}" || true)
-
+  
                     if [[ "${status}" -eq 404 ]]; then
                       # But not all servers support "HEAD" (e.g. azure.microsoft.com), so try again
                       status=$(curl --globoff --silent --output /dev/null --location --write-out "%{http_code}" "${url}" || true)

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -33,6 +33,7 @@ runs:
         - shell: ${{ env.shell }}
           run: |
             echo "temp_file=$(mktemp)" >> $GITHUB_ENV
+            echo "docs_output=test" >> $GITHUB_ENV
   
         - name: Extract links
           shell: ${{ env.shell }}
@@ -41,7 +42,7 @@ runs:
 
             # Extract all unique URLs
             # Faster than potentially checking the same link on multiple pages
-            find test -name "*.html" | while read -r file; do
+            find "${docs_output}" -name "*.html" | while read -r file; do
                 lynx -dump -listonly -nonumbers "${file}" | { grep --extended-regexp "^http" || test $? = 1; } >> "${temp_file}"
             done
   
@@ -72,7 +73,7 @@ runs:
 
                     if [[ "${status}" -eq 404 ]]; then
                         # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
-                        locations=$(grep -rl "${url}" || true)
+                        locations=$(grep -rl "${url}" "${docs_output}" || true)
                         echo "::debug::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
                         echo "| ${url} | ${status} | $(awk '{printf "- %s<br>", $0}' <<< "${locations}") |" >> ${GITHUB_STEP_SUMMARY}
                         found_error=1

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -61,6 +61,7 @@ runs:
   
                     # Some links will probably still fail to resolve, e.g. `localhost`, "some.dummy.url" etc, so don't treat CURL exit codes as fact
                     # We want to identify when a real server responds to the request
+  
                     # First try a HEAD request to avoid downloading the whole response
                     status=$(curl --globoff --silent --output /dev/null --location --head --write-out "%{http_code}" "${url}" || true)
   

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -51,36 +51,48 @@ runs:
             ${RUNNER_DEBUG:+set -o xtrace}
 
             distinct_urls=$(sort -u "${temp_file}")
-  
+
+            echo "## ❌ Dead links found" >> "${summary_file}"
+            echo "" >> "${summary_file}"
+            echo "| URL | Status | Locations |" >> "${summary_file}"
+            echo "| --- | -----: | --------- |" >> "${summary_file}"
+
             while read -r url; do
                 if [[ -n "${url}" ]]; then
-                    echo "::debug::Checking URL '${url}'..."
-  
-                    # Some links will probably still fail to resolve, e.g. `localhost`, "some.dummy.url" etc, so don't treat CURL exit codes as fact
-                    # We want to identify when a real server responds to the request
+                  echo "::debug::Checking URL '${url}'..."
 
-                    # First try a HEAD request to avoid downloading the whole response
-                    status=$(curl --globoff --silent --output /dev/null --location --head --write-out "%{http_code}" "${url}" || true)
-  
-                    if [[ "${status}" -eq 404 ]]; then
-                      # But not all servers support "HEAD" (e.g. azure.microsoft.com), so try again
-                      status=$(curl --globoff --silent --output /dev/null --location --write-out "%{http_code}" "${url}" || true)
-                    fi
+                  # Some links will probably still fail to resolve, e.g. `localhost`, "some.dummy.url" etc, so don't treat CURL exit codes as fact
+                  # We want to identify when a real server responds to the request
 
-                    if [[ "${status}" -eq 404 ]]; then
-                        # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
-                        locations=$(grep -rl "${url}" || true)
-                        echo "::error::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
-                        found_error=1
-                    else
-                        echo "::debug::✅ URL '${url}' had status ${status}"
-                    fi
+                  # First try a HEAD request to avoid downloading the whole response
+                  status=$(curl --globoff --silent --output /dev/null --location --head --write-out "%{http_code}" "${url}" || true)
+
+                  if [[ "${status}" -eq 404 ]]; then
+                    # But not all servers support "HEAD" (e.g. azure.microsoft.com), so try again
+                    status=$(curl --globoff --silent --output /dev/null --location --write-out "%{http_code}" "${url}" || true)
+                  fi
+
+                  if [[ "${status}" -eq 404 ]]; then
+                      # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
+                      locations=$(grep -rl "${url}" || true)
+                      echo "::debug::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
+                      echo "| ${url} | ${status} | ${locations} |" >> "${summary_file}"
+                      found_error=1
+
+                      # TODO REMOVE
+                      cat "${summary_file}" >> "$GITHUB_STEP_SUMMARY"
+                      exit 1
+                  else
+                      echo "::debug::✅ URL '${url}' had status ${status}"
+                  fi
                 fi
             done <<< "${distinct_urls}"
-            
+
             if [[ "${found_error}" -eq 1 ]]; then
+                cat "${summary_file}" >> "$GITHUB_STEP_SUMMARY"
                 exit 1
             else
+                echo "✅ No dead links found" >> "$GITHUB_STEP_SUMMARY"
                 exit 0
             fi
 

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -58,7 +58,7 @@ runs:
             while read -r url; do
                 if [[ -n "${url}" ]]; then
                     echo "::debug::Checking URL '${url}'..."
-
+  
                     # Some links will probably still fail to resolve, e.g. `localhost`, "some.dummy.url" etc, so don't treat CURL exit codes as fact
                     # We want to identify when a real server responds to the request
                     # First try a HEAD request to avoid downloading the whole response


### PR DESCRIPTION
We use [error annotations to report the dead links found](https://github.com/hazelcast/hz-docs/actions/runs/14087424233) by  `test external links`.

[GitHub has a limit of 10 error annotations](https://github.com/orgs/community/discussions/26680), which means further failures are not being reported.

Converted the output to a markdown-formatted job summary table instead.

[Example output](https://github.com/hazelcast/hz-docs/actions/runs/14124153038).