### PR TITLE
Correct MultiMap supported events [HZG-113]

### DIFF
--- a/docs/modules/ROOT/examples/distributedevents/ExampleEntryListener.java
+++ b/docs/modules/ROOT/examples/distributedevents/ExampleEntryListener.java
@@ -9,15 +9,16 @@ public class ExampleEntryListener implements EntryListener<String, String> {
         System.out.println("Entry Added: " + event);
     }
     @Override
-    public void entryUpdated(EntryEvent<String, String> event) {
-        System.out.println( "Entry Updated: " + event );
+    public void entryRemoved(EntryEvent<String, String> event) {
+        System.out.println( "Entry Removed: " + event );
     }
     @Override
     public void mapCleared(MapEvent event) {
         System.out.println( "Map Cleared: " + event );
     }
     @Override
-    public void entryRemoved(EntryEvent<String, String> event) {
+    public void entryUpdated(EntryEvent<String, String> event) {
+        // not supported for MultiMap
     }
     @Override
     public void entryEvicted(EntryEvent<String, String> event) {

--- a/docs/modules/events/pages/object-events.adoc
+++ b/docs/modules/events/pages/object-events.adoc
@@ -208,7 +208,7 @@ Its default value is `false`.
 You can listen to entry-based events in the MultiMap using an entry listener.
 The following is an example entry listener implementation for MultiMap.
 
-NOTE: The entry listener for MultiMap supports only `entryAdded`, `entryUpdated` and `mapCleared` events.
+NOTE: The entry listener for MultiMap supports only `entryAdded`, `entryRemoved` and `mapCleared` events.
 
 [source,java]
 ----
@@ -277,7 +277,7 @@ hazelcast:
     somemap:
       value-collection: SET
       entry-listeners:
-        - class-name: com.your-package.MyEntryListener
+        - class-name: com.yourpackage.MyEntryListener
           include-value: false
           local: false
 ----

--- a/docs/modules/pipelines/pages/object-events.adoc
+++ b/docs/modules/pipelines/pages/object-events.adoc
@@ -210,6 +210,8 @@ Its default value is `false`.
 You can listen to entry-based events in the MultiMap using `EntryListener`.
 The following is an example entry listener implementation for MultiMap.
 
+NOTE: The entry listener for MultiMap supports only `entryAdded`, `entryRemoved` and `mapCleared` events.
+
 [source,java]
 ----
 include::ROOT:example$/distributedevents/ExampleEntryListener.java[tag=mm]


### PR DESCRIPTION
Our documentation incorrectly states we only support `entryAdded`, `entryUpdated` and `mapCleared` events - however we do not support `entryUpdated`, and instead support `entryRemoved`. This is validated in the MultiMap code, and notably validated by `MultiMapListenerTest#testMultiMapEntryListener` which asserts that entry update events are not published.

Fixes https://hazelcast.atlassian.net/browse/HZG-113