### PR TITLE
Remove Java 1.8 references

### DIFF
--- a/docs/modules/pipelines/pages/cdc-postgres.adoc
+++ b/docs/modules/pipelines/pages/cdc-postgres.adoc
@@ -218,8 +218,7 @@ Maven::
    <version>1.0-SNAPSHOT</version>
 
    <properties>
-       <maven.compiler.target>1.8</maven.compiler.target>
-       <maven.compiler.source>1.8</maven.compiler.source>
+       <maven.compiler.release>17</maven.compiler.release>
    </properties>
 
    <dependencies>

--- a/docs/modules/pipelines/pages/kafka.adoc
+++ b/docs/modules/pipelines/pages/kafka.adoc
@@ -81,8 +81,7 @@ Maven::
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/docs/modules/pipelines/pages/kinesis.adoc
+++ b/docs/modules/pipelines/pages/kinesis.adoc
@@ -80,8 +80,7 @@ Maven::
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/docs/modules/pipelines/pages/map-join.adoc
+++ b/docs/modules/pipelines/pages/map-join.adoc
@@ -75,8 +75,7 @@ Maven::
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/docs/modules/pipelines/pages/pulsar.adoc
+++ b/docs/modules/pipelines/pages/pulsar.adoc
@@ -101,8 +101,7 @@ Maven::
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/docs/modules/pipelines/pages/python.adoc
+++ b/docs/modules/pipelines/pages/python.adoc
@@ -88,8 +88,7 @@ Maven::
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/docs/modules/pipelines/pages/windowing.adoc
+++ b/docs/modules/pipelines/pages/windowing.adoc
@@ -80,8 +80,7 @@ Maven::
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Hazelcast requires Java 17:
https://github.com/hazelcast/hz-docs/blob/35730b5b0b0ee283692b497dd25565bdfe1b0f12/docs/antora.yml#L48