### PR TITLE
Centralise supported maintenance branch definition [DI-349]

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,7 +8,7 @@ jobs:
   get-maintenance-versions:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.get-maintenance-versions-and-branches.outputs.versions-and-branches }}
+      versions-and-branches: ${{ steps.get-maintenance-versions-and-branches.outputs.versions-and-branches }}
     steps:
       - id: get-maintenance-versions
         uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions) }}
+        version: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions-and-branches) }}
     uses: ./.github/workflows/backport-workflow.yml
     with:
       label-to-check-for: '["backport to all versions"]'
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions) }}
+        version: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions-and-branches) }}
     uses: ./.github/workflows/backport-workflow.yml
     with:
       label-to-check-for: '["backport to ${{ matrix.version }}"]'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/backport-workflow.yml
     with:
       label-to-check-for: '["backport to all versions"]'
-      target-branch: ${{ matrix.branch }}
+      target-branch: ${{ matrix.version.branch }}
     secrets: inherit
 
   backport-to-specified-branch:
@@ -37,6 +37,6 @@ jobs:
         version: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions-and-branches) }}
     uses: ./.github/workflows/backport-workflow.yml
     with:
-      label-to-check-for: '["backport to ${{ matrix.version }}"]'
-      target-branch: ${{ matrix.branch }}
+      label-to-check-for: '["backport to ${{ matrix.version.version }}"]'
+      target-branch: ${{ matrix.version.branch }}
     secrets: inherit

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
       versions-and-branches: ${{ steps.get-maintenance-versions-and-branches.outputs.versions-and-branches }}
     steps:
       - id: get-maintenance-versions
-        uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions
+        uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions@master
       - id: get-maintenance-versions-and-branches
         run: |
           # Convert from versions -> branches (i.e. prepend "v/")

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,11 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions-and-branches) }}
+        version-and-branch: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions-and-branches) }}
     uses: ./.github/workflows/backport-workflow.yml
     with:
       label-to-check-for: '["backport to all versions"]'
-      target-branch: ${{ matrix.version.branch }}
+      target-branch: ${{ matrix.version-and-branch.branch }}
     secrets: inherit
 
   backport-to-specified-branch:
@@ -34,9 +34,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions-and-branches) }}
+        version-and-branch: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions-and-branches) }}
     uses: ./.github/workflows/backport-workflow.yml
     with:
-      label-to-check-for: '["backport to ${{ matrix.version.version }}"]'
-      target-branch: ${{ matrix.version.branch }}
+      label-to-check-for: '["backport to ${{ matrix.version-and-branch.version }}"]'
+      target-branch: ${{ matrix.version-and-branch.branch }}
     secrets: inherit

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,33 +5,34 @@ on:
    - main
    - v/*
 jobs:
-  get-maintenance-branches:
+  get-maintenance-versions:
     runs-on: ubuntu-latest
     outputs:
-      branches: "['5.3', '5.4', '5.5']"
+      versions: ${{ steps.get-maintenance-versions.outputs.versions }}
     steps:
-      - run: exit 0
+      - id: get-maintenance-versions
+        uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions
 
   backport-to-all-branch:
-    needs: get-maintenance-branches
+    needs: get-maintenance-versions
     strategy:
       fail-fast: false
       matrix:
-        branch: ${{ fromJSON(needs.get-maintenance-branches.outputs.branches) }}
+        version: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions) }}
     uses: ./.github/workflows/backport-workflow.yml
     with:
       label-to-check-for: '["backport to all versions"]'
-      target-branch: v/${{ matrix.branch }}
+      target-branch: v/${{ matrix.version }}
     secrets: inherit
 
   backport-to-specified-branch:
-    needs: get-maintenance-branches
+    needs: get-maintenance-versions
     strategy:
       fail-fast: false
       matrix:
-        branch: ${{ fromJSON(needs.get-maintenance-branches.outputs.branches) }}
+        version: ${{ fromJSON(needs.get-maintenance-versions.outputs.versions) }}
     uses: ./.github/workflows/backport-workflow.yml
     with:
-      label-to-check-for: '["backport to ${{ matrix.branch }}"]'
-      target-branch: v/${{ matrix.branch }}
+      label-to-check-for: '["backport to ${{ matrix.version }}"]'
+      target-branch: v/${{ matrix.version }}
     secrets: inherit

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,10 +8,14 @@ jobs:
   get-maintenance-versions:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.get-maintenance-versions.outputs.versions }}
+      versions: ${{ steps.get-maintenance-versions-and-branches.outputs.versions-and-branches }}
     steps:
       - id: get-maintenance-versions
         uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions
+      - id: get-maintenance-versions-and-branches
+        run: |
+          # Convert from versions -> branches (i.e. prepend "v\")
+          echo "versions-and-branches=$(jq --compact-output 'map({version: ., branch: "v/\(.)"})' <<< '${{ steps.get-maintenance-versions.outputs.versions }}')" >> ${GITHUB_OUTPUT}
 
   backport-to-all-branch:
     needs: get-maintenance-versions
@@ -22,7 +26,7 @@ jobs:
     uses: ./.github/workflows/backport-workflow.yml
     with:
       label-to-check-for: '["backport to all versions"]'
-      target-branch: v/${{ matrix.version }}
+      target-branch: ${{ matrix.branch }}
     secrets: inherit
 
   backport-to-specified-branch:
@@ -34,5 +38,5 @@ jobs:
     uses: ./.github/workflows/backport-workflow.yml
     with:
       label-to-check-for: '["backport to ${{ matrix.version }}"]'
-      target-branch: v/${{ matrix.version }}
+      target-branch: ${{ matrix.branch }}
     secrets: inherit

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ jobs:
         uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions
       - id: get-maintenance-versions-and-branches
         run: |
-          # Convert from versions -> branches (i.e. prepend "v\")
+          # Convert from versions -> branches (i.e. prepend "v/")
           echo "versions-and-branches=$(jq --compact-output 'map({version: ., branch: "v/\(.)"})' <<< '${{ steps.get-maintenance-versions.outputs.versions }}')" >> ${GITHUB_OUTPUT}
 
   backport-to-all-branch:


### PR DESCRIPTION
Uses the centralised supported maintenance branch definition introduced in https://github.com/hazelcast/hazelcast-mono/pull/4185

[Example job execution output (private repo)](https://github.com/JackPGreen/backport-test/actions/runs/14382149392/).

_Partially addresses_: [DI-349](https://hazelcast.atlassian.net/browse/DI-349)

[DI-349]: https://hazelcast.atlassian.net/browse/DI-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ