### PR TITLE
Escape `C++` in AsciiDoc

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -25,7 +25,7 @@
 ** xref:clients:java-client-getting-started.adoc[Get started with Java]
 ** xref:clients:csharp-client-getting-started.adoc[Get started with .NET]
 ** xref:clients:python-client-getting-started.adoc[Get started with Python]
-** xref:clients:cpp-client-getting-started.adoc[Get started with C++]
+** xref:clients:cpp-client-getting-started.adoc[Get started with {cpp}]
 ** xref:clients:go-client-getting-started.adoc[Get started with Go]
 ** xref:clients:nodejs-client-getting-started.adoc[Get started with Node.js]
 // Support

--- a/docs/modules/ROOT/pages/ask-ai.adoc
+++ b/docs/modules/ROOT/pages/ask-ai.adoc
@@ -11,7 +11,7 @@ To use Ask AI, click the *Ask AI* button in the bottom right of any docs.hazelca
 Ask AI currently indexes the following sources:
 
 - docs.hazelcast.com (the /latest version for all products and tools)
-- API docs for languages and clients (Javadoc, C++, .NET/C#, Node.js, Python, Go)
+- API docs for languages and clients (Javadoc, {cpp}, .NET/C#, Node.js, Python, Go)
 - hazelcast.com/blog (from last two years)
 - hazelcast.com/developers/clients
 - support.hazelcast.com

--- a/docs/modules/ROOT/pages/compact-binary-specification.adoc
+++ b/docs/modules/ROOT/pages/compact-binary-specification.adoc
@@ -29,7 +29,7 @@ You cannot redefine the endianness in Compact Serialization; it is inherited fro
 
 [cols="1,1,1,1,1,1,1,1,3,1"]
 |===
-|Type |Java |C++ |C# |Python |Node.js |Go |SQL |Description| Fixed Size
+|Type |Java |{cpp} |C# |Python |Node.js |Go |SQL |Description| Fixed Size
 
 |boolean
 |boolean

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -16,7 +16,7 @@ retrieved from disk and put into RAM prior to processing. Using Hazelcast,
 you can store and process your data in RAM, spread and replicate it across a cluster of
 machines; replication gives you resilience to failures of cluster members.
 
-Hazelcast is implemented in Java language and has clients for Java, C++, .NET, REST, Python,
+Hazelcast is implemented in Java language and has clients for Java, {cpp}, .NET, REST, Python,
 Go and Node.js. Hazelcast also speaks Memcached and REST protocols.
 
 Your cloud-native applications can easily use Hazelcast.
@@ -47,7 +47,7 @@ another process to add more capacity, data and backups are automatically and eve
 
 You can request data, listen to events, submit data processing tasks using
 Hazelcast clients connected to a cluster. Hazelcast has clients implemented in Java,
-.Net, C++, Node.js, Go and Python languages. It also communicates with Memcache and
+.Net, {cpp}, Node.js, Go and Python languages. It also communicates with Memcache and
 REST protocols. See the xref:clients:hazelcast-clients.adoc[Hazelcast Clients section].
 
 You can build data pipelines using SQL or the Java API which enable the data to

--- a/docs/modules/ROOT/pages/what-is-hazelcast.adoc
+++ b/docs/modules/ROOT/pages/what-is-hazelcast.adoc
@@ -16,7 +16,7 @@ retrieved from disk and put into RAM prior to processing. Using Hazelcast,
 you can store and process your data in RAM, spread and replicate it across a cluster of
 machines; replication gives you resilience to failures of cluster members.
 
-Hazelcast is implemented in Java language and has clients for Java, C++, .NET, REST, Python,
+Hazelcast is implemented in Java language and has clients for Java, {cpp}, .NET, REST, Python,
 Go and Node.js. Hazelcast also speaks Memcached and REST protocols.
 
 Your cloud-native applications can easily use Hazelcast.
@@ -47,7 +47,7 @@ another process to add more capacity, data and backups are automatically and eve
 
 You can request data, listen to events, submit data processing tasks using
 Hazelcast clients connected to a cluster. Hazelcast has clients implemented in Java,
-.Net, C++, Node.js, Go and Python languages. It also communicates with Memcache and
+.Net, {cpp}, Node.js, Go and Python languages. It also communicates with Memcache and
 REST protocols. See the xref:clients:hazelcast-clients.adoc[Hazelcast Clients section].
 
 You can build data pipelines using SQL or the Java API which enable the data to

--- a/docs/modules/ROOT/partials/clients.adoc
+++ b/docs/modules/ROOT/partials/clients.adoc
@@ -1,4 +1,4 @@
-- C++
+- {cpp}
 - C#
 - Go
 - Java

--- a/docs/modules/clients/pages/client-overview.adoc
+++ b/docs/modules/clients/pages/client-overview.adoc
@@ -22,7 +22,7 @@ Hazelcast clients must be installed locally to communicate with the server.
 ==== Benefits of using Hazelcast clients
 
 * Language flexibility: Hazelcast offers clients in multiple programming languages, allowing you to use Hazelcast in various environments. 
-Clients are available for xref:java.adoc[Java], xref:dotnet.adoc[.NET], xref:python.adoc[Python], xref:cplusplus.adoc[C++], xref:go.adoc[Go], and xref:nodejs.adoc[Node.js]
+Clients are available for xref:java.adoc[Java], xref:dotnet.adoc[.NET], xref:python.adoc[Python], xref:cplusplus.adoc[{cpp}], xref:go.adoc[Go], and xref:nodejs.adoc[Node.js]
 * Independent scaling: in client/server mode, you can scale the Hazelcast cluster independently from your application. For details, see: https://docs.hazelcast.com/hazelcast/latest/deploy/choosing-a-deployment-option[Choosing an Application Topology]
 * Polyglot applications: client/server mode allows you to write polyglot applications that can all connect to the same cache cluster
 * Decoupling application from data: the application and cached data are separated, which can be beneficial for management and security purposes
@@ -79,7 +79,7 @@ For detailed information and code samples for each client, see:
 * xref:java.adoc[Java]
 * xref:dotnet.adoc[.NET]
 * xref:python.adoc[Python]
-* xref:cplusplus.adoc[C++]
+* xref:cplusplus.adoc[{cpp}]
 * xref:go.adoc[Go]
 * xref:nodejs.adoc[Node.js]
 

--- a/docs/modules/clients/pages/cplusplus.adoc
+++ b/docs/modules/clients/pages/cplusplus.adoc
@@ -1,8 +1,8 @@
-= C++ Client
+= {cpp} Client
 :page-api-reference: http://hazelcast.github.io/hazelcast-cpp-client/{page-latest-supported-cplusplus-client}/index.html
 [[c-client]]
 
-TIP: For the latest {cpp} API documentation, see http://hazelcast.github.io/hazelcast-cpp-client/{page-latest-supported-cplusplus-client}/index.html[Hazelcast C++ Client docs].
+TIP: For the latest {cpp} API documentation, see http://hazelcast.github.io/hazelcast-cpp-client/{page-latest-supported-cplusplus-client}/index.html[Hazelcast {cpp} Client docs].
 
 The Hazelcast native {cpp} client is an official library that allows {cpp} applications to connect to and interact with Hazelcast clusters. The key features and benefits include:
 

--- a/docs/modules/clients/pages/cpp-client-getting-started.adoc
+++ b/docs/modules/clients/pages/cpp-client-getting-started.adoc
@@ -1,5 +1,5 @@
-= Get started with the Hazelcast C++ Client
-:description: This tutorial will get you started with the Hazelcast C++ client and show you how to manipulate a map.
+= Get started with the Hazelcast {cpp} Client
+:description: This tutorial will get you started with the Hazelcast {cpp} client and show you how to manipulate a map.
 
 == Overview
 
@@ -11,7 +11,7 @@ This tutorial will take approximately 5-10 minutes to complete.
 
 Before you begin, make sure you have the following:
 
-* C++ 11 or above
+* {cpp} 11 or above
 * https://cloud.hazelcast.com/[Hazelcast Cloud Account]
 * A text editor or IDE
 
@@ -103,11 +103,11 @@ key.pem
 vcpkg
 ----
 
-== Understand the C++ Client
+== Understand the {cpp} Client
 
 The following section creates and starts a Hazelcast client with default configuration, and connects to your cluster before finally shutting down the client.
 
-Create a C++ file named “example.cpp” and insert the following code in it:
+Create a {cpp} file named “example.cpp” and insert the following code in it:
 
 [source,cpp]
 ----
@@ -171,11 +171,11 @@ Once complete, run the example:
 ./build/example
 ----
 
-For more information about Vcpkg installation check the https://github.com/hazelcast/hazelcast-cpp-client/blob/master/Reference_Manual.md#111-vcpkg-users-recommended[C++ client library].
+For more information about Vcpkg installation check the https://github.com/hazelcast/hazelcast-cpp-client/blob/master/Reference_Manual.md#111-vcpkg-users-recommended[{cpp} client library].
 
-In this tutorial we use CMake for compilation; for other options check the https://github.com/hazelcast/hazelcast-cpp-client/blob/master/Reference_Manual.md#13-compiling-your-project[C++ client library].
+In this tutorial we use CMake for compilation; for other options check the https://github.com/hazelcast/hazelcast-cpp-client/blob/master/Reference_Manual.md#13-compiling-your-project[{cpp} client library].
 
-To understand and use the client, review the https://hazelcast.github.io/hazelcast-cpp-client/api-index.html[C++ API documentation] to discover what's possible.
+To understand and use the client, review the https://hazelcast.github.io/hazelcast-cpp-client/api-index.html[{cpp} API documentation] to discover what's possible.
 
 == Understand the Hazelcast SQL API
 
@@ -406,11 +406,11 @@ NOTE: Ordering of the keys is NOT enforced and results may NOT correspond to ins
 
 == Summary
 
-In this tutorial, you learned how to get started with the Hazelcast C++ Client, connect to an instance, and put data into a distributed map.
+In this tutorial, you learned how to get started with the Hazelcast {cpp} Client, connect to an instance, and put data into a distributed map.
 
 == Next steps
 
-There are many things you can do with the C++ Client. For more information, such as how you can query a map with predicates and SQL,
+There are many things you can do with the {cpp} Client. For more information, such as how you can query a map with predicates and SQL,
 check out the https://github.com/hazelcast/hazelcast-cpp-client[client repository] and the https://hazelcast.github.io/hazelcast-cpp-client/api-index.html[API documentation] to better understand what is possible.
 
 If you have any questions, suggestions, or feedback, reach out to us via https://slack.hazelcast.com/[Hazelcast Community Slack].

--- a/docs/modules/clients/pages/hazelcast-clients.adoc
+++ b/docs/modules/clients/pages/hazelcast-clients.adoc
@@ -1,5 +1,5 @@
 = Getting Started with a Hazelcast Client
-:description: Hazelcast has clients in Java, .NET, Python, C++, Go, and Node.js. You can use these clients to communicate with cluster members.
+:description: Hazelcast has clients in Java, .NET, Python, {cpp}, Go, and Node.js. You can use these clients to communicate with cluster members.
 
 {description}
 
@@ -9,7 +9,7 @@ For documentation and code samples for each client, see the following:
 * xref:java.adoc[Java]
 * xref:dotnet.adoc[.NET]
 * xref:python.adoc[Python]
-* xref:cplusplus.adoc[C++]
+* xref:cplusplus.adoc[{cpp}]
 * xref:go.adoc[Go]
 * xref:nodejs.adoc[Node.js]
 
@@ -24,7 +24,7 @@ See the following:
 * xref:clients:java-client-getting-started.adoc[Get started with Java]
 * xref:clients:csharp-client-getting-started.adoc[Get started with .NET]
 * xref:clients:python-client-getting-started.adoc[Get started with Python]
-* xref:clients:cpp-client-getting-started.adoc[Get started with C++]
+* xref:clients:cpp-client-getting-started.adoc[Get started with {cpp}]
 * xref:clients:go-client-getting-started.adoc[Get started with Go]
 * xref:clients:nodejs-client-getting-started.adoc[Get started with Node.js]
 

--- a/docs/modules/data-structures/pages/creating-a-map.adoc
+++ b/docs/modules/data-structures/pages/creating-a-map.adoc
@@ -26,7 +26,7 @@ capitalcities.put( 4, "Ankara" );
 capitalcities.put( 5, "Brussels" );
 ----
 --
-C++:: 
+{cpp}:: 
 + 
 -- 
 [source,cpp]
@@ -118,7 +118,7 @@ capitalcities.set( 5, "Brussels" );
 
 ----
 --
-C++:: 
+{cpp}:: 
 + 
 -- 
 [source,cpp]
@@ -261,7 +261,7 @@ idPersonMap.put(2, new HazelcastJsonValue(person2));
 idPersonMap.put(3, new HazelcastJsonValue(person3));
 ----
 --
-C++:: 
+{cpp}:: 
 + 
 -- 
 [source,cpp]

--- a/docs/modules/data-structures/pages/list.adoc
+++ b/docs/modules/data-structures/pages/list.adoc
@@ -65,11 +65,11 @@ public class Client {
 <2> Add items to `list`.
 --
 
-C++::
+{cpp}::
 +
 --
 
-. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.0.0/Reference_Manual.md#11-installing[Install the latest C++ client library^]
+. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.0.0/Reference_Manual.md#11-installing[Install the latest {cpp} client library^]
 
 . Add the following to your file:
 +

--- a/docs/modules/data-structures/pages/listening-for-map-entries.adoc
+++ b/docs/modules/data-structures/pages/listening-for-map-entries.adoc
@@ -32,7 +32,7 @@ Java::
 include::ROOT:example$/dds/map/Employee.java[tag=emp]
 ----
 --
-C++:: 
+{cpp}:: 
 +
 --
 [source,cpp]
@@ -96,7 +96,7 @@ Java::
 include::ROOT:example$/dds/map/ListenerWithPredicate.java[tag=lwp]
 ----
 --
-C++:: 
+{cpp}:: 
 +
 --
 [source,cpp]

--- a/docs/modules/data-structures/pages/locking-maps.adoc
+++ b/docs/modules/data-structures/pages/locking-maps.adoc
@@ -22,7 +22,7 @@ Java::
 include::ROOT:example$/dds/map/PessimisticUpdateMember.java[tag=pum]
 ----
 --
-C++:: 
+{cpp}:: 
 + 
 -- 
 [source,cpp]

--- a/docs/modules/data-structures/pages/multimap.adoc
+++ b/docs/modules/data-structures/pages/multimap.adoc
@@ -70,11 +70,11 @@ public class Client {
 <3> Print the entries.
 --
 
-C++::
+{cpp}::
 +
 --
 
-. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.0.0/Reference_Manual.md#11-installing[Install the latest C++ client library^]
+. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.0.0/Reference_Manual.md#11-installing[Install the latest {cpp} client library^]
 
 . Add the following to your file:
 +

--- a/docs/modules/data-structures/pages/queue.adoc
+++ b/docs/modules/data-structures/pages/queue.adoc
@@ -43,11 +43,11 @@ include::ROOT:example$/dds/queue/ProducerMember.java[tag=producer]
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 
-. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.0.0/Reference_Manual.md#11-installing[Install the latest C++ client library^]
+. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.0.0/Reference_Manual.md#11-installing[Install the latest {cpp} client library^]
 
 . Add the following to your file:
 +
@@ -269,11 +269,11 @@ include::ROOT:example$/dds/queue/ConsumerMember.java[tag=consumer]
 <3> Wait for 5 seconds until the next message is taken.
 --
 
-C++::
+{cpp}::
 +
 --
 
-. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.0.0/Reference_Manual.md#11-installing[Install the latest C++ client library^]
+. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.0.0/Reference_Manual.md#11-installing[Install the latest {cpp} client library^]
 
 . Add the following to your file:
 +

--- a/docs/modules/data-structures/pages/reading-a-map.adoc
+++ b/docs/modules/data-structures/pages/reading-a-map.adoc
@@ -29,7 +29,7 @@ for (Map.Entry<Integer, String> entry : myMap.entrySet()) {
     };
 ----
 --
-C++:: 
+{cpp}:: 
 + 
 -- 
 [source,cpp]

--- a/docs/modules/data-structures/pages/reading-map-metrics.adoc
+++ b/docs/modules/data-structures/pages/reading-map-metrics.adoc
@@ -168,7 +168,7 @@ System.out.println ( "key             : " + entry.getKey() );
 System.out.println ( "value           : " + entry.getValue() );
 ----
 --
-C++:: 
+{cpp}:: 
 + 
 --
 

--- a/docs/modules/data-structures/pages/set.adoc
+++ b/docs/modules/data-structures/pages/set.adoc
@@ -65,11 +65,11 @@ public class Client {
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 
-. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.0.0/Reference_Manual.md#11-installing[Install the latest C++ client library^]
+. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.0.0/Reference_Manual.md#11-installing[Install the latest {cpp} client library^]
 
 . Add the following to your file:
 +

--- a/docs/modules/data-structures/pages/updating-map-entries.adoc
+++ b/docs/modules/data-structures/pages/updating-map-entries.adoc
@@ -24,7 +24,7 @@ countries.put( 4, "Turkey" );
 countries.put( 5, "Ukraine" );
 ----
 --
-C++:: 
+{cpp}:: 
 + 
 -- 
 [source,cpp]
@@ -116,7 +116,7 @@ countries.replace( 3, "United States", "Canada"); <3>
 <2> Replaces only if current value is "France". Value is "France", so returns `true`.
 <3> Replaces only if current value is "United States". Value is "USA", so replace fails and returns `false.`
 --
-C++:: 
+{cpp}:: 
 + 
 -- 
 [source,cpp]
@@ -212,7 +212,7 @@ System.out.println(distributedMap.size());
 
 ----
 --
-C++:: 
+{cpp}:: 
 + 
 -- 
 [source,cpp]
@@ -373,7 +373,7 @@ IMap<Integer, Student> studentmap = hzClient.getMap("studentmap");
 studentmap.removeAll(Predicates.equal("GradYear", 2020));
 ----
 --
-C++:: 
+{cpp}:: 
 + 
 -- 
 [source,cpp]

--- a/docs/modules/deploy/pages/deploying-on-aws.adoc
+++ b/docs/modules/deploy/pages/deploying-on-aws.adoc
@@ -99,7 +99,7 @@ Note that if you don't specify any of the optional properties, then Hazelcast us
 === Client Discovery of EC2 Hazelcast Cluster
 
 Hazelcast clients can automatically discover the Hazelcast cluster running in EC2 environment.
-This section is for the Hazelcast Java clients. See https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.3.0/Reference_Manual.md#57-enabling-hazelcast-aws-discovery[{cpp} client] and https://github.com/hazelcast/hazelcast-go-client-discovery[Go client] documentations to learn how to configure Hazelcast C++ and Go clients to automatically discover members running in EC2 environment.
+This section is for the Hazelcast Java clients. See https://github.com/hazelcast/hazelcast-cpp-client/blob/v5.3.0/Reference_Manual.md#57-enabling-hazelcast-aws-discovery[{cpp} client] and https://github.com/hazelcast/hazelcast-go-client-discovery[Go client] documentations to learn how to configure Hazelcast {cpp} and Go clients to automatically discover members running in EC2 environment.
 
 - *Client running in EC2:*
 

--- a/docs/modules/deploy/pages/versioning-compatibility.adoc
+++ b/docs/modules/deploy/pages/versioning-compatibility.adoc
@@ -201,7 +201,7 @@ Hazelcast Platform sends metrics to Management Center and other means such as JM
 Hazelcast Platform has clients implemented in the following languages:
 
 * Java
-* C++
+* {cpp}
 * .NET
 * Python
 * Go
@@ -229,17 +229,17 @@ The following table lists the compatibilities between client and Platform/IMDG v
 |
 * IMDG 3.6.x through 3.12.x
 
-|C++ 5.x.y
+|{cpp} 5.x.y
 |
 * Platform 5.x.y
 * IMDG 4.x.y
 
-|C++ 4.x.y
+|{cpp} 4.x.y
 |
 * Platform 5.x.y
 * IMDG 4.x.y
 
-|C++ 3.6.x through 3.12.x
+|{cpp} 3.6.x through 3.12.x
 |
 * IMDG 3.6.x through 3.12.x
 

--- a/docs/modules/events/pages/event-listeners-for-clients.adoc
+++ b/docs/modules/events/pages/event-listeners-for-clients.adoc
@@ -24,7 +24,7 @@ Follow the below links to learn how to configure the event listeners on other
 Hazelcast clients:
 
 * https://github.com/hazelcast/hazelcast-csharp-client#75-distributed-events[.NET client^]
-* https://github.com/hazelcast/hazelcast-cpp-client#75-distributed-events[C++ client^]
+* https://github.com/hazelcast/hazelcast-cpp-client#75-distributed-events[{cpp} client^]
 * https://github.com/hazelcast/hazelcast-nodejs-client/blob/master/DOCUMENTATION.md#75-distributed-events[Node.js client^]
 * https://github.com/hazelcast/hazelcast-go-client#75-distributed-events[Go client^]
 * https://github.com/hazelcast/hazelcast-python-client#75-distributed-events[Python client^]

--- a/docs/modules/getting-started/pages/authenticate-clients.adoc
+++ b/docs/modules/getting-started/pages/authenticate-clients.adoc
@@ -222,11 +222,11 @@ var client = await HazelcastClientFactory.StartNewClientAsync(options);
 ----
 . Run this class in the IDE.
 
-C++::
+{cpp}::
 +
 
-. Install the latest https://github.com/hazelcast/hazelcast-cpp-client/blob/v4.1.0/Reference_Manual.md#11-installing[C++ client library]
-. In your preferred C++ IDE, create a new project to include a class containing the following code.
+. Install the latest https://github.com/hazelcast/hazelcast-cpp-client/blob/v4.1.0/Reference_Manual.md#11-installing[{cpp} client library]
+. In your preferred {cpp} IDE, create a new project to include a class containing the following code.
 +
 [source,cpp]
 ----

--- a/docs/modules/getting-started/pages/get-started-binary.adoc
+++ b/docs/modules/getting-started/pages/get-started-binary.adoc
@@ -225,11 +225,11 @@ public class MapSample {
 <4> Write some keys and values to the map.
 --
 
-C++::
+{cpp}::
 +
 --
 
-. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v4.1.0/Reference_Manual.md#11-installing[Install the latest C++ client library^]
+. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v4.1.0/Reference_Manual.md#11-installing[Install the latest {cpp} client library^]
 
 . Add the following to your file:
 +
@@ -507,7 +507,7 @@ public class MapSample {
 <2> Disconnect from the member.
 --
 
-C++::
+{cpp}::
 +
 --
 

--- a/docs/modules/getting-started/pages/get-started-cli.adoc
+++ b/docs/modules/getting-started/pages/get-started-cli.adoc
@@ -124,7 +124,7 @@ write data to it and visualize that data in Management Center. To continue your 
 - Get started with one of the available client libraries:
 
   ** xref:clients:java.adoc[Java client]
-  ** https://github.com/hazelcast/hazelcast-cpp-client[C++ client]
+  ** https://github.com/hazelcast/hazelcast-cpp-client[{cpp} client]
   ** https://github.com/hazelcast/hazelcast-csharp-client[C# client]
   ** https://github.com/hazelcast/hazelcast-nodejs-client[Node.js client]
   ** https://github.com/hazelcast/hazelcast-python-client[Python client]

--- a/docs/modules/getting-started/pages/get-started-docker.adoc
+++ b/docs/modules/getting-started/pages/get-started-docker.adoc
@@ -135,11 +135,11 @@ public class MapSample {
 <4> Write some keys and values to the map.
 --
 
-C++::
+{cpp}::
 +
 --
 
-. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v4.1.0/Reference_Manual.md#11-installing[Install the latest C++ client library^]
+. link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v4.1.0/Reference_Manual.md#11-installing[Install the latest {cpp} client library^]
 
 . Add the following to your file:
 +
@@ -428,7 +428,7 @@ public class MapSample {
 <2> Disconnect from the member.
 --
 
-C++::
+{cpp}::
 +
 --
 

--- a/docs/modules/kubernetes/pages/kubernetes-auto-discovery.adoc
+++ b/docs/modules/kubernetes/pages/kubernetes-auto-discovery.adoc
@@ -328,7 +328,7 @@ client = hazelcast.HazelcastClient(
 )
 ```
 --
-C++:: 
+{cpp}:: 
 + 
 -- 
 ```cpp

--- a/docs/modules/migrate/pages/upgrading-from-imdg-4.adoc
+++ b/docs/modules/migrate/pages/upgrading-from-imdg-4.adoc
@@ -42,7 +42,7 @@ purpose to migrate your 3.12.x data to 5.x; see xref:migrate:migration-tool-imdg
 
 === Compatibility with Client Versions
 
-All the 4.x.y versions of Hazelcast Java, .NET, C++. Python and Node.js clients are compatible
+All the 4.x.y versions of Hazelcast Java, .NET, {cpp}. Python and Node.js clients are compatible
 with Hazelcast Platform. The Hazelcast Go client 1.0.0 version is compatible with Hazelcast Platform.
 
 However, the 3.12.x versions of Hazelcast clients *is not* compatible with Hazelcast Platform. See xref:migrate:migration-tool-imdg.adoc#client-migration[Client Migration].

--- a/docs/modules/serialization/pages/compact-serialization.adoc
+++ b/docs/modules/serialization/pages/compact-serialization.adoc
@@ -390,7 +390,7 @@ public record Employee(long Id, string Name);
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 [source,cpp]
@@ -505,7 +505,7 @@ public class EmployeeSerializer : ICompactSerializer<Employee>
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 [source,cpp]
@@ -638,7 +638,7 @@ can be implemented on top of these, by using these types as building blocks.
 
 [cols="1m,1a,1a,1a,1a,1a,1a,1a]
 |===
-| Type | Java | .NET | C++ | Node.js | Python | Go | Description
+| Type | Java | .NET | {cpp} | Node.js | Python | Go | Description
 
 | BOOLEAN
 | boolean
@@ -1182,7 +1182,7 @@ public record Employee(long Id, string Name);
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 [source,cpp]
@@ -1263,7 +1263,7 @@ public record Employee(
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 [source,cpp]
@@ -1365,7 +1365,7 @@ public class EmployeeSerializer : ICompactSerializer<Employee>
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 [source,cpp]
@@ -1497,7 +1497,7 @@ public class EmployeeSerializer : ICompactSerializer<Employee>
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 [source,cpp]

--- a/docs/modules/serialization/pages/implementing-identifieddataserializable.adoc
+++ b/docs/modules/serialization/pages/implementing-identifieddataserializable.adoc
@@ -144,7 +144,7 @@ in the client configuration, e.g., `hazelcast-client.xml/yaml`.
 For the other Hazelcast clients, see the following for details:
 
 * https://github.com/hazelcast/hazelcast-csharp-client#41-identifieddataserializable-serialization[.NET^]
-* https://github.com/hazelcast/hazelcast-cpp-client#41-identifieddataserializable-serialization[C++^]
+* https://github.com/hazelcast/hazelcast-cpp-client#41-identifieddataserializable-serialization[{cpp}^]
 * https://github.com/hazelcast/hazelcast-nodejs-client#41-identifieddataserializable-serialization[Node.js^]
 * https://github.com/hazelcast/hazelcast-python-client#41-identifieddataserializable-serialization[Python^]
 * https://github.com/hazelcast/hazelcast-go-client#41-identifieddataserializable-serialization[Go^]

--- a/docs/modules/serialization/pages/implementing-portable-serialization.adoc
+++ b/docs/modules/serialization/pages/implementing-portable-serialization.adoc
@@ -112,7 +112,7 @@ in the client configuration, e.g., `hazelcast-client.xml/yaml`.
 For the other Hazelcast clients, see the following for details:
 
 * https://github.com/hazelcast/hazelcast-csharp-client#42-portable-serialization[.NET^]
-* https://github.com/hazelcast/hazelcast-cpp-client#42-portable-serialization[C++^]
+* https://github.com/hazelcast/hazelcast-cpp-client#42-portable-serialization[{cpp}^]
 * https://github.com/hazelcast/hazelcast-nodejs-client#42-portable-serialization[Node.js^]
 * https://github.com/hazelcast/hazelcast-python-client#42-portable-serialization[Python^]
 * https://github.com/hazelcast/hazelcast-go-client#42-portable-serialization[Go^]

--- a/docs/modules/tutorials/pages/kubernetes.adoc
+++ b/docs/modules/tutorials/pages/kubernetes.adoc
@@ -127,7 +127,7 @@ pip install hazelcast-python-client
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 [source, bash]
@@ -194,7 +194,7 @@ client = hazelcast.HazelcastClient(
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 [source, cpp]
@@ -269,7 +269,7 @@ docker build -t hazelcastguides/hazelcast-client python
 ----
 --
 
-C++::
+{cpp}::
 +
 --
 [source, bash]


### PR DESCRIPTION
AsciiDoc treats `++` as an escape for formatting, [which in _some_ situations breaks formatting when the text `C++` is used](https://docs.hazelcast.com/tutorials/cpp-client-getting-started#see-also):
![image](https://github.com/user-attachments/assets/07244a40-976e-4e53-b0b6-770a6227c767)

[Using the `{cpp}` replacement avoids this](https://docs.asciidoctor.org/asciidoc/latest/attributes/character-replacement-ref/):
![image](https://github.com/user-attachments/assets/51a63c2e-de7b-4cf6-9c16-4407afd79612)