### PR TITLE
Centralise C++ Client installations instructions

### DIFF
--- a/docs/modules/clients/pages/cpp-client-getting-started.adoc
+++ b/docs/modules/clients/pages/cpp-client-getting-started.adoc
@@ -13,6 +13,7 @@ Before you begin, make sure you have the following:
 
 * C++ 11 or above
 * https://cloud.hazelcast.com/[Hazelcast Cloud Account]
+* https://github.com/hazelcast/hazelcast-cpp-client#vcpkg-users[`vcpkg` & Hazelcast {cpp} client]
 * A text editor or IDE
 
 == Start a Hazelcast Cloud Cluster
@@ -31,36 +32,6 @@ Create a new folder and navigate to it:
 ----
 mkdir hazelcast-cpp-example
 cd hazelcast-cpp-example
-----
-
-Download and install Vcpkg: +
-
-for Windows;
-[source,bash]
-----
-git clone https://github.com/microsoft/vcpkg
-.\vcpkg\bootstrap-vcpkg.bat
-----
-
-for non-Windows;
-[source,bash]
-----
-git clone https://github.com/microsoft/vcpkg
-./vcpkg/bootstrap-vcpkg.sh
-----
-
-Download and install hazelcast-cpp-client: +
-
-for Windows;
-[source,bash]
-----
-.\vcpkg\vcpkg.exe install "hazelcast-cpp-client[openssl]" --recurse
-----
-
-for non-Windows;
-[source,bash]
-----
-./vcpkg/vcpkg install "hazelcast-cpp-client[openssl]" --recurse
 ----
 
 NOTE: Avoid directory names in your path that contain spaces or other non-standard characters.

--- a/docs/modules/clients/pages/cpp-client-getting-started.adoc
+++ b/docs/modules/clients/pages/cpp-client-getting-started.adoc
@@ -13,7 +13,7 @@ Before you begin, make sure you have the following:
 
 * C++ 11 or above
 * https://cloud.hazelcast.com/[Hazelcast Cloud Account]
-* https://github.com/hazelcast/hazelcast-cpp-client#vcpkg-users[`vcpkg` & Hazelcast {cpp} client]
+* https://github.com/hazelcast/hazelcast-cpp-client#vcpkg-users[vcpkg and Hazelcast {cpp} client]
 * A text editor or IDE
 
 == Start a Hazelcast Cloud Cluster


### PR DESCRIPTION
The installation instructions for the C++ client need adjusting - https://github.com/hazelcast/hazelcast-cpp-client/pull/1272

To save duplicating the fix, it's more maintainable to link to the existing instructions and avoid duplication.

_(note - originally raised done in https://github.com/hazelcast-guides/cpp-client-getting-started/pull/4 but that repo should've been archived)_