### PR TITLE
Update `Hazelcast Cloud` references to use `{hazelcast-cloud}` property

### DIFF
--- a/docs/modules/ROOT/pages/glossary.adoc
+++ b/docs/modules/ROOT/pages/glossary.adoc
@@ -28,7 +28,7 @@ usable by other systems, for the purposes of replication, analysis and more.
 CEP:: Complex event processing is a set of techniques for capturing and analyzing streams of data as they arrive to identify opportunities
  or threats in real time. 
 
-CLC:: Hazelcast Command Line Client, used to connect to and interact with clusters on Hazelcast Cloud and Hazelcast Platform direct from the command line or through scripts.
+CLC:: Hazelcast Command Line Client, used to connect to and interact with clusters on Hazelcast {hazelcast-cloud} and Hazelcast Platform direct from the command line or through scripts.
 
 CLI:: Command-line interface. 
 

--- a/docs/modules/clients/pages/cpp-client-getting-started.adoc
+++ b/docs/modules/clients/pages/cpp-client-getting-started.adoc
@@ -12,13 +12,13 @@ This tutorial will take approximately 5-10 minutes to complete.
 Before you begin, make sure you have the following:
 
 * C++ 11 or above
-* https://cloud.hazelcast.com/[Hazelcast Cloud Account]
+* https://cloud.hazelcast.com/[Hazelcast {hazelcast-cloud} Account]
 * A text editor or IDE
 
-== Start a Hazelcast Cloud Cluster
+== Start a Hazelcast {hazelcast-cloud} Cluster
 
-1. Sign up for a Hazelcast Cloud account (free trial is available).
-2. Log in to your Hazelcast Cloud account and start your trial by filling in the welcome questionnaire.
+1. Sign up for a Hazelcast {hazelcast-cloud} account (free trial is available).
+2. Log in to your Hazelcast {hazelcast-cloud} account and start your trial by filling in the welcome questionnaire.
 3. A cluster is created automatically when you start your trial.
 4. Press the *Connect Cluster* dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.

--- a/docs/modules/clients/pages/csharp-client-getting-started.adoc
+++ b/docs/modules/clients/pages/csharp-client-getting-started.adoc
@@ -12,13 +12,13 @@ This tutorial will take approximately 5-10 minutes to complete.
 Before you begin, make sure you have the following:
 
 * .NET SDK 6.0 or above
-* https://cloud.hazelcast.com/[Hazelcast Cloud Account]
+* https://cloud.hazelcast.com/[Hazelcast {hazelcast-cloud} Account]
 * An IDE
 
-== Start a Hazelcast Cloud Cluster
+== Start a Hazelcast {hazelcast-cloud} Cluster
 
-1. Sign up for a Hazelcast Cloud account (free trial is available).
-2. Log in to your Hazelcast Cloud account and start your trial by filling in the welcome questionnaire.
+1. Sign up for a Hazelcast {hazelcast-cloud} account (free trial is available).
+2. Log in to your Hazelcast {hazelcast-cloud} account and start your trial by filling in the welcome questionnaire.
 3. A cluster is created automatically when you start your trial.
 4. Press the *Connect Cluster* dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.

--- a/docs/modules/clients/pages/go-client-getting-started.adoc
+++ b/docs/modules/clients/pages/go-client-getting-started.adoc
@@ -12,13 +12,13 @@ This tutorial will take approximately 5-10 minutes to complete.
 Before you begin, make sure you have the following:
 
 * Go 1.15 or above
-* https://cloud.hazelcast.com/[Hazelcast Cloud Account]
+* https://cloud.hazelcast.com/[Hazelcast {hazelcast-cloud} Account]
 * A text editor or IDE
 
-== Start a Hazelcast Cloud Cluster
+== Start a Hazelcast {hazelcast-cloud} Cluster
 
-1. Sign up for a Hazelcast Cloud account (free trial is available).
-2. Log in to your Hazelcast Cloud account and start your trial by filling in the welcome questionnaire.
+1. Sign up for a Hazelcast {hazelcast-cloud} account (free trial is available).
+2. Log in to your Hazelcast {hazelcast-cloud} account and start your trial by filling in the welcome questionnaire.
 3. A cluster is created automatically when you start your trial.
 4. Press the *Connect Cluster* dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later. 

--- a/docs/modules/clients/pages/java-client-getting-started.adoc
+++ b/docs/modules/clients/pages/java-client-getting-started.adoc
@@ -12,13 +12,13 @@ This tutorial will take approximately 5-10 minutes to complete.
 Before you begin, make sure you have the following:
 
 * JDK 11.0 or above
-* https://cloud.hazelcast.com/[Hazelcast Cloud Account]
+* https://cloud.hazelcast.com/[Hazelcast {hazelcast-cloud} Account]
 * An IDE
 
-== Start a Hazelcast Cloud Cluster
+== Start a Hazelcast {hazelcast-cloud} Cluster
 
-1. Sign up for a Hazelcast Cloud account (free trial is available).
-2. Log in to your Hazelcast Cloud account and start your trial by filling in the welcome questionnaire. 
+1. Sign up for a Hazelcast {hazelcast-cloud} account (free trial is available).
+2. Log in to your Hazelcast {hazelcast-cloud} account and start your trial by filling in the welcome questionnaire. 
 3. A cluster is created automatically when you start your trial.
 4. Press the *Connect Cluster* dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -120,7 +120,7 @@ The {java-client-new} is only available as a Beta release and does not have full
 
 // check standalone
 
-* Hazelcast Cloud is not supported
+* Hazelcast {hazelcast-cloud} is not supported
 * You cannot use the {java-client} and the {java-client-new} on the same JVM
 * Any methods that raise the`UnsupportedOperationException` exception are not available e.g. `addLocalEntryListener(@Nonnull MapListener listener)`
 * MultiMap and Set are not supported data structures

--- a/docs/modules/clients/pages/nodejs-client-getting-started.adoc
+++ b/docs/modules/clients/pages/nodejs-client-getting-started.adoc
@@ -12,13 +12,13 @@ This tutorial will take approximately 5-10 minutes to complete.
 Before you begin, make sure you have the following:
 
 * Node.js 10.4 or above
-* https://cloud.hazelcast.com/[Hazelcast Cloud Account]
+* https://cloud.hazelcast.com/[Hazelcast {hazelcast-cloud} Account]
 * A text editor or IDE
 
-== Start a Hazelcast Cloud Cluster
+== Start a Hazelcast {hazelcast-cloud} Cluster
 
-1. Sign up for a Hazelcast Cloud account (free trial is available).
-2. Log in to your Hazelcast Cloud account and start your trial by filling in the welcome questionnaire.
+1. Sign up for a Hazelcast {hazelcast-cloud} account (free trial is available).
+2. Log in to your Hazelcast {hazelcast-cloud} account and start your trial by filling in the welcome questionnaire.
 3. A cluster is created automatically when you start your trial.
 4. Press the *Connect Cluster* dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.

--- a/docs/modules/clients/pages/python-client-getting-started.adoc
+++ b/docs/modules/clients/pages/python-client-getting-started.adoc
@@ -12,13 +12,13 @@ This tutorial will take approximately 5-10 minutes to complete.
 Before you begin, make sure you have the following:
 
 * Python 3.6 or above
-* https://cloud.hazelcast.com/[Hazelcast Cloud Account]
+* https://cloud.hazelcast.com/[Hazelcast {hazelcast-cloud} Account]
 * A text editor or IDE
 
-== Start a Hazelcast Cloud Cluster
+== Start a Hazelcast {hazelcast-cloud} Cluster
 
-1. Sign up for a Hazelcast Cloud account (free trial is available).
-2. Log in to your Hazelcast Cloud account and start your trial by filling in the welcome questionnaire.
+1. Sign up for a Hazelcast {hazelcast-cloud} account (free trial is available).
+2. Log in to your Hazelcast {hazelcast-cloud} account and start your trial by filling in the welcome questionnaire.
 3. A cluster is created automatically when you start your trial.
 4. Press the *Connect Cluster* dialog and switch over to the Advanced setup tab for connection information needed below.
 5. From the Advanced setup tab, download the keystore files and take note of your Cluster ID, Discovery Token and Password as you will need them later.

--- a/docs/modules/integrate/pages/feast-config.adoc
+++ b/docs/modules/integrate/pages/feast-config.adoc
@@ -50,7 +50,7 @@ The available options are as follows:
 
 |discovery_token
 |String
-|Discovery token used by a Hazelcast Cloud cluster
+|Discovery token used by a Hazelcast {hazelcast-cloud} cluster
 |""
 
 |ssl_cafile_path


### PR DESCRIPTION
Using the _existing_ externalized values makes future updates easier.