### PR TITLE
Fix EE `SNAPSHOT` binary download links incorrect

### DIFF
--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -35,9 +35,13 @@ docker version
 
 == Using the {enterprise-product-name} Binary
 
+// tag::download-package-ee[]
+ifdef::snapshot[]
+Download and extract the Hazelcast ZIP file from link:https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{ee-version}[the repository].
+endif::[]
+ifndef::snapshot[]
 Download and extract the binaries.
 
-// tag::download-package-ee[]
 [tabs] 
 ==== 
 Mac:: 
@@ -59,14 +63,10 @@ wget -O - 'https://repository.hazelcast.com/download/hazelcast-enterprise/hazelc
 Windows:: 
 +
 --
-ifdef::snapshot[]
-Download and extract the Hazelcast ZIP file from link:https://repository.hazelcast.com/snapshot/com/hazelcast/hazelcast-enterprise-distribution/{ee-version}[the repository].
-endif::[]
-ifndef::snapshot[]
 Download and extract the link:https://repository.hazelcast.com/download/hazelcast-enterprise/hazelcast-enterprise-{ee-version}.zip[Hazelcast ZIP file].
-endif::[]
 --
 ====
+endif::[]
 // end::download-package-ee[]
 
 To start the cluster, see xref:get-started-binary.adoc[].


### PR DESCRIPTION
Distinct `SNAPSHOT`/release links were added to the page in https://github.com/hazelcast/hz-docs/pull/859, _but only for Windows_.

For release, we have a durable link so providing a template command _per platform_ (`curl www.hazelcast.com/hazelcast-6.zip` or whatever) makes sense. But for `SNAPSHOT`s we can't (as the `SNAPSHOT` names are deliberately unique), so instructions _per platform_ make no sense and as such, removed.

New `SNAPSHOT` output:
<img width="535" alt="image" src="https://github.com/user-attachments/assets/4c8a28f5-cc8b-4fdf-be63-df9e4e59e746" />

Release output:
<img width="1410" alt="image" src="https://github.com/user-attachments/assets/170aae6a-e66e-4601-a29b-a952d33ac760" />


[Slack discussion](https://hazelcast.slack.com/archives/C035HQET5/p1744364373485339).