### PR TITLE
Synchronize backport labels with maintenance versions

### DIFF
--- a/.github/workflows/sync-backport-labels.yml
+++ b/.github/workflows/sync-backport-labels.yml
@@ -1,0 +1,52 @@
+name: Synchronize backport labels with maintenance versions
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # midnight, daily
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: get-maintenance-versions
+        uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions@master
+
+      - run: |
+          set -euo pipefail ${RUNNER_DEBUG:+-x}
+
+          # Compute desired labels based off maintenance versions:
+          # - "backport to 5.3" (e.g.)
+          # - "backport to all versions""
+          desired_labels=$(jq -r '. + ["all versions"] | .[] | "backport to \(. )"' <<< '${{ steps.get-maintenance-versions.outputs.versions }}')
+
+          # Get existing repository "backport to" labels
+          existing_labels=$(gh label list \
+            --limit 1000 \
+            --json name \
+            --jq '[.[].name] | map(select(startswith("backport to "))) | .[]')
+
+          # Add any that are missing
+          while IFS= read -r label; do
+            if ! echo "${existing_labels}" | grep --quiet "${label}"; then
+              echo "::notice::Creating new label - ${label}"
+              gh label create "${label}"
+            fi
+          done <<< "${desired_labels}"
+
+          # Remove those that are no longer required
+          while IFS= read -r label; do
+            if ! echo "${desired_labels}" | grep --quiet "${label}"; then
+              echo "::notice::Deleting deprecated label - ${label}"
+              gh label delete "${label}" --yes
+            fi
+          done <<< "${existing_labels}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Using the functionality introduced in https://github.com/hazelcast/hazelcast-mono/pull/4185, we can automate the adding/removing `backport to {version}` labels in the repo by polling nightly for any new (or deprecated) versions and [remove another manual step from the checklist](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/4681400429/Post+release+tasks+5.x).

Tested [here](https://github.com/JackPGreen/label-test/actions/runs/14456905951/job/40542037459) - private repo, request access.