### PR TITLE
Update versioning-compatibility.adoc

### DIFF
--- a/docs/modules/deploy/pages/versioning-compatibility.adoc
+++ b/docs/modules/deploy/pages/versioning-compatibility.adoc
@@ -42,8 +42,6 @@ Hazelcast Platform has been tested on the following system architectures.
 |AArch64/ARM64
 |From Platform 5.3
 
-|z/Architecture
-|From Platform 5.5
 
 |===
 


### PR DESCRIPTION
Removed:

|z/Architecture
|From Platform 5.5

We are launching a mainframe SKU