### PR TITLE
Remove `hazelcast.diagnostics.metric.level`

### DIFF
--- a/docs/modules/maintain-cluster/pages/monitoring.adoc
+++ b/docs/modules/maintain-cluster/pages/monitoring.adoc
@@ -1264,7 +1264,6 @@ XML::
     ...
     <properties>
         <property name="hazelcast.diagnostics.enabled">true</property>
-        <property name="hazelcast.diagnostics.metric.level">info</property>
         <property name="hazelcast.diagnostics.invocation.sample.period.seconds">30</property>
         <property name="hazelcast.diagnostics.pending.invocations.period.seconds">30</property>
         <property name="hazelcast.diagnostics.slowoperations.period.seconds">30</property>


### PR DESCRIPTION
`hazelcast.diagnostics.metric.level` property is deprecated in v4 at https://github.com/hazelcast/hazelcast/pull/16468