### PR TITLE
Fix HD index documentation [SUP-908]

### DIFF
--- a/docs/modules/query/pages/indexing-maps.adoc
+++ b/docs/modules/query/pages/indexing-maps.adoc
@@ -863,7 +863,7 @@ performed using the regular `IMap` querying methods:
 
 == Global and Partitioned Indexes
 
-Indexes can be either global or partitioned, depending on where the map entries are stored. On-heap indexes are always global, whereas indexes in the xref:storage:high-density-memory.adoc#configuring-high-density-memory-store[High-Density Memory Store] are partitioned.
+Indexes can be either global or partitioned, depending on where the map entries are stored. On-heap indexes are always global, whereas indexes in the xref:storage:high-density-memory.adoc#configuring-high-density-memory-store[High-Density Memory Store] are global by default, but can be changed to partitioned indexes.
 
 NOTE: If you configure a map to use
 xref:storage:high-density-memory.adoc#configuring-high-density-memory-store[High-Density Memory Store] **and**

--- a/docs/modules/query/pages/indexing-maps.adoc
+++ b/docs/modules/query/pages/indexing-maps.adoc
@@ -882,7 +882,7 @@ bring all the benefits of global indexes to maps that are backed by High-Density
 
 The global High-Density Memory Store indexes are enabled by default and controlled
 by the `hazelcast.hd.global.index.enabled` property. You can disable these indexes by setting
-this property to `false.`
+this property to `false`, in which case High-Density Memory Store will use partitioned indexes instead.
 
 == Copying Indexes
 


### PR DESCRIPTION
The documentation currently contradicts itself, stating that HD memory indexes are partitioned (not accurate for default settings). This PR corrects this contradiction.

Fixes https://hazelcast.atlassian.net/browse/SUP-908