### PR TITLE
Fix config XML / schema outdated versions by removing `minor-version` property

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: hazelcast
 title: Hazelcast Platform
-# Version in the URL
+# Version in the URL (minor.patch version)
 version: '6.0-snapshot'
 # Version in the version selector (we display only the latest major.minor version)
 display_version: '6.0-SNAPSHOT'
@@ -13,8 +13,8 @@ asciidoc:
     os-version: '6.0.0-SNAPSHOT'
     ee-version: '6.0.0-SNAPSHOT'
     jet-version: '4.5.4'
-    # The minor.patch version, which is used as a variable in the docs for things like file versions
-    minor-version: '6.0-SNAPSHOT'
+    # The outer "version" property duplicated to allow access from inside asciidoc
+    version: '6.0-SNAPSHOT'
     java-client-standalone-version: '5.5.0-BETA'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -13,7 +13,7 @@ asciidoc:
     os-version: '6.0.0-SNAPSHOT'
     ee-version: '6.0.0-SNAPSHOT'
     jet-version: '4.5.4'
-    # Same as `version` but as an asciidoc attribute.
+    # Same as `version` above but as an asciidoc attribute
     version: '6.0-SNAPSHOT'
     java-client-standalone-version: '5.5.0-BETA'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -13,7 +13,7 @@ asciidoc:
     os-version: '6.0.0-SNAPSHOT'
     ee-version: '6.0.0-SNAPSHOT'
     jet-version: '4.5.4'
-    # The outer "version" property duplicated to allow access from inside asciidoc
+    # Same as `version` but as an asciidoc attribute.
     version: '6.0-SNAPSHOT'
     java-client-standalone-version: '5.5.0-BETA'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/

--- a/docs/modules/configuration/pages/understanding-configuration.adoc
+++ b/docs/modules/configuration/pages/understanding-configuration.adoc
@@ -23,7 +23,7 @@ The following topics are also relevant to static configuration:
 - xref:pattern-matcher.adoc[Configuration Pattern Matcher]
 - xref:using-wildcards.adoc[Using Wildcards]
 
-NOTE: Hazelcast performs schema validation through the `hazelcast-config-{minor-version}.xsd` file,
+NOTE: Hazelcast performs schema validation through the `hazelcast-config-{version}.xsd` file,
 which comes with Hazelcast libraries. If an error occurs in declarative or programmatic configuration, Hazelcast throws a meaningful exception.
 
 Static configuration cannot be changed at runtime. However, you can add <<dynamic-configuration, dynamic configuration>> for some features.

--- a/docs/modules/data-connections/pages/data-connections-configuration.adoc
+++ b/docs/modules/data-connections/pages/data-connections-configuration.adoc
@@ -274,7 +274,7 @@ XML::
           <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-              http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{display_version}.xsd">
+              http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{version}.xsd">
 
             <cluster-name>dev</cluster-name>
               <network>
@@ -334,7 +334,7 @@ config
               "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\"" +
               "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
               "      xsi:schemaLocation=\"http://www.hazelcast.com/schema/client-config" +
-              "      http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{display_version}.xsd\">" +
+              "      http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{version}.xsd\">" +
               "    " +
               "    <cluster-name>dev</cluster-name>" +
               "    <network>" +
@@ -369,7 +369,7 @@ OPTIONS (
      <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-         http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{display_version}.xsd">
+         http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{version}.xsd">
 
        <cluster-name>dev</cluster-name>
        <network>

--- a/docs/modules/data-connections/pages/data-connections-configuration.adoc
+++ b/docs/modules/data-connections/pages/data-connections-configuration.adoc
@@ -274,7 +274,7 @@ XML::
           <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-              http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{minor-version}.xsd">
+              http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{display_version}.xsd">
 
             <cluster-name>dev</cluster-name>
               <network>
@@ -334,7 +334,7 @@ config
               "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\"" +
               "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" +
               "      xsi:schemaLocation=\"http://www.hazelcast.com/schema/client-config" +
-              "      http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{minor-version}.xsd\">" +
+              "      http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{display_version}.xsd\">" +
               "    " +
               "    <cluster-name>dev</cluster-name>" +
               "    <network>" +
@@ -369,7 +369,7 @@ OPTIONS (
      <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-         http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{minor-version}.xsd">
+         http://www.hazelcast.com/schema/client-config/hazelcast-client-config-{display_version}.xsd">
 
        <cluster-name>dev</cluster-name>
        <network>


### PR DESCRIPTION
The `minor-version` property ~~is~~ was outdated and wasn't being automatically maintained, meaning references that used it were referencing old versions.

Rather that automatically increasing this version, we can simply instead reference an alternative variable that [_is_ being automatically maintained](https://github.com/hazelcast/hazelcast-pipeline-library/blob/766f1d2e302d2bb2aeb7ffe7affb0a35a37743f3/src/com/hazelcast/qe/pipeline/distribution/layout/reference/manual/UpdateHzDocs.groovy#L127).

Fixes https://github.com/hazelcast/hz-docs/issues/1091