### PR TITLE
Fix page-enterprise label in some pages [v5.5]

### DIFF
--- a/docs/modules/getting-started/pages/get-started-rest-api-with-java.adoc
+++ b/docs/modules/getting-started/pages/get-started-rest-api-with-java.adoc
@@ -1,6 +1,5 @@
 = Get Started with REST API using Java
 :description: This tutorial provides a step-by-step guide to help you enable, run and use the REST API with minimal configuration using Java.
-
 :page-enterprise: true
 
 {description}

--- a/docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
+++ b/docs/modules/maintain-cluster/pages/dynamic-config-via-rest.adoc
@@ -1,6 +1,5 @@
 = Dynamic Configuration using the REST API
 :description: This tutorial provides a step-by-step guide to help you add a data structure dynamically using the REST API.
-
 :page-enterprise: true
 
 {description}

--- a/docs/modules/migrate/pages/lts.adoc
+++ b/docs/modules/migrate/pages/lts.adoc
@@ -1,5 +1,4 @@
 = Long-term Support Releases
-
 :description: Hazelcast simplifies your upgrade experience with the introduction of long-term support (LTS) releases. You can upgrade directly from a supported previous release to the LTS release or directly between LTS releases using a rolling upgrade.
 :page-enterprise: true
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1662

The `ENTERPRISE` label does not appear [in the production docs](https://docs.hazelcast.com/hazelcast/latest/getting-started/get-started-rest-api-with-java) but does [for other REST pages](https://docs.hazelcast.com/hazelcast/latest/getting-started/get-started-rest-api-with-docker).

I _think_ this is because of a blank line, based on local testing:
![image](https://github.com/user-attachments/assets/20f7ad65-0d28-409c-a8f0-36ed0c57f664)


Fixes: https://github.com/hazelcast/hz-docs/issues/1663
Fixes: https://github.com/hazelcast/hazelcast/issues/26486