### PR TITLE
Add warning not to rely on exact vector metric value [v/5.5]

### DIFF
--- a/docs/modules/data-structures/pages/vector-collections.adoc
+++ b/docs/modules/data-structures/pages/vector-collections.adoc
@@ -113,6 +113,8 @@ When disabled, each added vector is treated as a distinct vector in the index, e
 
 NOTE: The recommended method for computing cosine similarity is to normalize all vectors to unit length and use the DOT metric instead.
 
+WARNING: Do not rely on the exact value of the metric. 
+It is a floating point number and the exact value may depend on the order of operations and rounding during evaluation which can vary in different implementations (with or without vectorization) and in different Hazelcast versions.
 
 Configuration example:
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1688