### PR TITLE
Updated outdated CLC version

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -36,7 +36,7 @@ asciidoc:
     # https://github.com/hazelcast/hazelcast-nodejs-client/releases
     page-latest-supported-nodejs-client: '5.3.0'
     # https://github.com/hazelcast/clc/releases
-    page-latest-supported-clc: '5.4.1'
+    page-latest-supported-clc: '5.6.0'
     open-source-product-name: 'Community Edition'
     enterprise-product-name: 'Enterprise Edition'
     java-client-new: 'Java Client (Standalone)'

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -35,8 +35,8 @@ asciidoc:
     page-latest-supported-python-client: '5.5.0'
     # https://github.com/hazelcast/hazelcast-nodejs-client/releases
     page-latest-supported-nodejs-client: '5.3.0'
-    # https://github.com/hazelcast/clc/releases
-    page-latest-supported-clc: '5.6.0'
+    # https://github.com/hazelcast/hazelcast-commandline-client/releases
+    page-latest-supported-clc: '5.5.0'
     open-source-product-name: 'Community Edition'
     enterprise-product-name: 'Enterprise Edition'
     java-client-new: 'Java Client (Standalone)'


### PR DESCRIPTION
The CLC version in the docs is outdated.

Note this step is listed in the [CLC release process](https://hazelcast.atlassian.net/wiki/spaces/HZC/pages/3731193857/Commandline+Client+Releases).

Unsure version compatibility ranges to determine appropriate backport.