### PR TITLE
Update `slim` distribution documentation to remove Maven references

### DIFF
--- a/docs/modules/getting-started/pages/editions.adoc
+++ b/docs/modules/getting-started/pages/editions.adoc
@@ -71,8 +71,6 @@ The full distribution contains all available Hazelcast connectors, libraries, an
 
 The slim distribution allows you to save memory by excluding Management Center and connectors. You add the additional components as required.
 
-To install a slim distribution, you can use any of the available installation options by appending `-slim` to the version number in the command; for example, to install the slim distribution of {full-version}, use `{full-version}-slim`.
-
 .Slim distribution content explanation
 [%collapsible]
 ====

--- a/docs/modules/getting-started/pages/editions.adoc
+++ b/docs/modules/getting-started/pages/editions.adoc
@@ -41,13 +41,6 @@ The permissions granted in these licenses allow you to do the following:
 == Full and Slim Distributions
 [[full-slim]]
 
-The following installation options offer a full and slim distribution:
-
-- Docker
-- ZIP/TAR Binaries
-
-Other installation options offer only the full distribution.
-
 You can find more information on installing the Hazelcast editions in the following topics:
 
 * For the {enterprise-product-name}, see the xref:install-enterprise.adoc[] topic

--- a/docs/modules/getting-started/pages/editions.adoc
+++ b/docs/modules/getting-started/pages/editions.adoc
@@ -45,7 +45,6 @@ The following installation options offer a full and slim distribution:
 
 - Docker
 - ZIP/TAR Binaries
-- Java
 
 Other installation options offer only the full distribution.
 

--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -13,9 +13,7 @@ move each member without downtime. For further information on moving members fro
 xref:migrate:community-to-enterprise.adoc[].
 ====
 
-Both slim and full distributions are available. For further information on the available editions and distributions, see the xref:editions.adoc[] topic.
-
-To install a slim distribution, append `-slim` to the version number in the commands shown in the following sections; for example, to install the slim distribution of {ee-version}, use `{ee-version}-slim`.
+For further information on the available editions and distributions, see the xref:editions.adoc[] topic.
 
 == Using the {enterprise-product-name} Docker Image
 

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -18,9 +18,6 @@ You must use one of the following installation methods if you want to install th
 
 * <<Using Docker>>
 * <<Using the Binary>>
-* <<Using Java>>
-
-To install a slim distribution, append `-slim` to the version number in the commands shown in the following sections; for example, to install the slim distribution of {os-version}, use `{os-version}-slim`.
 
 == Using a Package Manager
 

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -12,12 +12,12 @@ For further information on the available {enterprise-product-name} features and 
 
 == Distributions
 
-Both slim and full distributions are available. For further information on the available editions and distributions, see the xref:editions.adoc[] topic.
-
-You must use one of the following installation methods if you want to install the slim distribution:
+Both slim and full distributions are available:
 
 * <<Using Docker>>
 * <<Using the Binary>>
+
+For further information on the available editions and distributions, see the xref:editions.adoc#full-slim[].
 
 == Using a Package Manager
 


### PR DESCRIPTION
The documentation suggests there's a `slim` variant of `ZIP/TAR Binaries` _and_ `Java` (effectively Maven) distributions.

This is _technically_ correct - [the `hazelcast-distribution` Maven artifact offers both `slim` and regular `zip` resources](https://repo1.maven.org/maven2/com/hazelcast/hazelcast-distribution/5.3.6). However, further documentation about Maven exclusively talks about the `hazelcast` artefact that doesn't offer this.

Rather than try to explain this nuance, I think it's easier to simply drop references to `slim` + `Java` distributions.

I also think that as a concept, downloading a binary distribution (rather than a dependency) is an atypical usecase of Maven, and that following the _existing_ instructions might lead to confusion:
- Hazelcast offers a variety of download options, such as `slim`
- > [The slim distribution allows you to save memory by excluding Management Center](https://docs.hazelcast.com/hazelcast/latest/getting-started/editions#slim-distribution)
- You can download Hazelcast via Maven
- Logical next step - if you want to get started with Hazelcast, you try to look for a `slim` `distribution` but really all you want is a dependency

We can also simplify explaining how to obtain a `slim` variant - as both the binary download (via website) and Docker (via Dockerhub) show the variants and their names in their respective UI's anyway.

Fixes: https://github.com/hazelcast/hz-docs/issues/995, https://github.com/hazelcast/hazelcast/issues/26507