### PR TITLE
Update cp-subsystem.adoc note about enterprise being a requirement

### DIFF
--- a/docs/modules/cp-subsystem/pages/cp-subsystem.adoc
+++ b/docs/modules/cp-subsystem/pages/cp-subsystem.adoc
@@ -299,7 +299,6 @@ for more information.
 [NOTE]
 ==== 
 * CP is only supported on Kubernetes with CP xref:cp-subsystem:configuration.adoc#persistence[persistence enabled,window=_blank].
-Hazelcast Enterprise is therefore a requirement.
 
 * The current limitation on CP in Kubernetes is that we do not support dynamic scaling of the cluster.
 The number of members defined at the time of deployment is static and the CP members and CP group size 


### PR DESCRIPTION
All of CP-Subsystem is now Enterprise only, so saying that CP Persistence being a requirement makes this enterprise only is redundant and confusing.