### PR TITLE
[EMGR-481] Remove vert.x Hazelcast Enterprise Module Reference

### DIFF
--- a/docs/modules/integrate/pages/get-started-with-vertx.adoc
+++ b/docs/modules/integrate/pages/get-started-with-vertx.adoc
@@ -227,25 +227,7 @@ set-cookie: vertx-web.session=a1486c5ed6416972fdc356e4d91d2397; Path=/
 }
 ----
 
-We will fix that by using a Hazelcast Cluster Manager. There are two modules that provide Hazelcast Cluster Manager:
-
-- `io.vertx:vertx-hazelcast` - this module is maintained by the Vert.x team, with contributions from Hazelcast, and is built on top of open-source Hazelcast
-- `com.hazelcast:vertx-hazelcast-enterprise` - this module is maintained by the Hazelcast team and is built on top of the `vertx-hazelcast` but uses Hazelcast Enterprise instead. You need an enterprise license to use Hazelcast Enterprise.
-
-You can use either module for most of this tutorial. At the end of this tutorial you will need the `vertx-hazelcast-enterprise` module.
-
-NOTE: You can get your trial key at https://hazelcast.com/get-started/?utm_source=docs-website[hazelcast.com] or you can use `vertx-hazelcast` and a community edition of Hazelcast.
-
-Add the following dependency to the `pom.xml`:
-
-[source,xml]
-----
-<dependency>
-  <groupId>com.hazelcast</groupId>
-  <artifactId>vertx-hazelcast-enterprise</artifactId>
-  <version>{vertx.version}</version>
-</dependency>
-----
+We will fix that by using a Hazelcast Cluster Manager which resides in the `io.vertx:vertx-hazelcast` which is maintained by the Vert.x team, with contributions from Hazelcast, and is built on top of open-source Hazelcast.
 
 Change the following part of the `start` method:
 
@@ -275,8 +257,6 @@ We also need to provide a Hazelcast configuration file, and create a file cluste
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.hazelcast.com/schema/config
            https://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
-
-  <license-key>replace/with/your/key</license-key> <!-- Only if using vertx-hazelcast-enterprise -->
 
   <network>
     <join>
@@ -421,41 +401,3 @@ set-cookie: vertx-web.session=d9fb4cada5c0fc625089a38f3de13e3c; Path=/
     "requestId": 1
 }
 ----
-
-== CP Subsystem backed Lock and Counter
-
-The module `vertx-hazelcast-enterprise` provides a different implementation of the `io.vertx.core.shareddata.Counter` and `io.vertx.core.shareddata.Lock` data structures. The implementation in `vertx-hazelcast` is based on the IMap data structure and provides guarantees defined in the xref:architecture:data-partitioning.adoc#best-effort-consistency[Best-effort consistency] section. This means that under certain network partition conditions the counter doesn't provide strong consistency guarantees and can generate duplicate values.
-
-The module `vertx-hazelcast-enterprise` uses the CP Subsystem from {enterprise-product-name} to implement the Lock and Counter.
-
-NOTE: For the rest of this tutorial you need to have an {enterprise-product-name} license.
-
-Make sure you have the following dependency:
-
-[source,xml]
-----
-<dependency>
-  <groupId>com.hazelcast</groupId>
-  <artifactId>vertx-hazelcast-enterprise</artifactId>
-  <version>{vertx.version}</version>
-</dependency>
-----
-
-and your XML config contains a valid license key:
-
-[source,xml]
-----
-...
-  <license-key>replace/with/your/key</license-key>
-...
-----
-
-Enable the CP subsystem, and in cluster.xml change the value of the `` property to `3`:
-
-[source,xml]
-----
-    <cp-member-count>3</cp-member-count>
-----
-
-You need to start at least 3 instances for the cluster to form successfully. For complete documentation, see the xref:cp-subsystem:cp-subsystem.adoc[CP Subsystem] section.
-

--- a/docs/modules/integrate/pages/integrate-with-vertx.adoc
+++ b/docs/modules/integrate/pages/integrate-with-vertx.adoc
@@ -13,53 +13,7 @@ In Vert.x a cluster manager is used for various functions including:
 - Distributed Locks
 - Distributed Counters
 
-There are 2 modules to choose from:
-- `io.vertx:vertx-hazelcast` - this module is part of Vert.x and is maintained by the Vert.x team with contributions from Hazelcast developers. This module is licensed under the Apache 2 license.
-
-- `com.hazelcast:vertx-hazelcast-enterprise` - this module is built on top of `vertx-hazelcast` and leverages functionality of {enterprise-product-name} to implement some of the cluster manager functionality (e.g. it uses the CP Subsystem to implement strongly consistent `io.vertx.core.shareddata.Lock` and `io.vertx.core.shareddata.Counter`).
-
-== Using Vert.x Hazelcast Enterprise Cluster Manager
-[.enterprise]*Enterprise* 
-
-To use the Vert.x Hazelcast Enterprise Cluster Manager, add the following dependency to your Vert.x application:
-
-NOTE: The version `5.0.0.CR2` is a candidate release. A GA version will be released once Vert.x itself goes GA.
-
-[source,xml]
-----
-<dependency>
-  <groupId>com.hazelcast</groupId>
-  <artifactId>vertx-hazelcast-enterprise</artifactId>
-  <version>5.0.0.CR2</version>
-</dependency>
-----
-
-The dependency is located in the Hazelcast private repository, and you need to add that as well:
-
-[source,xml]
-----
-<repositories>
-  <repository>
-    <id>hazelcast-private-repository</id>
-    <name>Hazelcast Private Repository</name>
-    <url>https://repository.hazelcast.com/release/</url>
-  </repository>
-</repositories>
-----
-
-Alternatively, if you need to use a snapshot version (you should never use a snapshot version in production,
-but it might be useful to test if an issue has been fixed):
-
-[source,xml]
-----
-<repositories>
-  <repository>
-    <id>hazelcast-private-snapshot-repository</id>
-    <name>Hazelcast Private Snapshot Repository</name>
-    <url>https://repository.hazelcast.com/snapshot/</url>
-  </repository>
-</repositories>
-----
+The `io.vertx:vertx-hazelcast` module is part of Vert.x and is maintained by the Vert.x team with contributions from Hazelcast developers. This module is licensed under the Apache 2 license.
 
 To enable clustering, start your Vert.x application with the `-cluster` parameter.
 
@@ -67,15 +21,11 @@ To enable clustering, start your Vert.x application with the `-cluster` paramete
 
 Provide a file named `cluster.xml` on your classpath to configure a Hazelcast instance used by Vert.x.
 
-To take advantage of the Lock and Counter data structures backed by the CP subsystem, you need to enable the xref:cp-subsystem:cp-subsystem.adoc[CP Subsytem].
-
 For other configuration methods see the link:https://vertx.io/docs/vertx-hazelcast/java/#configcluster[Vert.x documentation].
 
 === Versioning and Hazelcast compatibility
 
-The Vert.x Hazelcast Enterprise module follows the versioning of Vertx. If you use an `x.y.z` version of Vert.x, you should use an `x.y.z` version of `vertx-hazelcast-enteprise`.
-
-The `vertx-hazelcast-enteprise` module is compatible with all Hazelcast versions supported at the time of the release of the `vertx-hazelcast-enteprise` module unless stated otherwise.
+The Vert.x Hazelcast module follows the versioning of Vertx. If you use an `x.y.z` version of Vert.x, you should use an `x.y.z` version of `vertx-hazelcast`.
 
 While older versions may work, such configurations are not supported.
 
@@ -99,27 +49,6 @@ There are multiple ways to replace the transitive dependency. The most reliable 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-hazelcast</artifactId>
-  <exclusions>
-    <exclusion>
-      <groupId>com.hazelcast</groupId>
-      <artifactId>hazelcast</artifactId>
-    </exclusion>
-  </exclusions>
-</dependency>
-<dependency>
-  <groupId>com.hazelcast</groupId>
-  <artifactId>hazelcast</artifactId>
-  <version>5.5.0</version>
-</dependency>
-----
-
-Similarly, for `vertx-hazelcast-enterprise`:
-
-[source,xml]
-----
-<dependency>
-  <groupId>com.hazelcast</groupId>
-  <artifactId>vertx-hazelcast-enterprise</artifactId>
   <exclusions>
     <exclusion>
       <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
Hazelcast Enterprise Vert.x module was never published (and still isn't). So, we need to update the documentation for now to remove its reference as it's not possible for any user to follow.

Note. The tutorial would need to be re-verified -- I think it should be fine as the Enterprise component was additive.