### PR TITLE
Add new map metrics to docs [HZG-266]

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -307,6 +307,16 @@ The Reset column shows the reset behavior of the metrics. There are two types of
 |Total number of indexed local queries performed on the map
 | N
 
+|`map.indexesSkippedQueryCount`
+|count
+|Total number of local queries performed on the map which cannot use indexes
+| N
+
+|`map.noMatchingIndexQueryCount`
+|count
+|Total number of local queries performed on the map which had no matching index
+| N
+
 |`map.lastAccessTime`
 |ms
 |Last access (read) time of the locally owned entries
@@ -477,6 +487,26 @@ This is because the cluster has to communicate with more members, which can add 
 |`map.index.updateCount`
 |count
 |Number of update operations performed on the index
+| N
+
+|`map.index.partitionsIndexed`
+|count
+|Number of partitions the index is built for on the local member
+| N
+
+|`map.index.partitionUpdatesStarted`
+|count
+|Number of times a partition set change started for the index
+| N
+
+|`map.index.partitionUpdatesFinished`
+|count
+|Number of times a partition set change completed for the index
+| N
+
+|`map.index.notReadyQueryCount`
+|count
+|Number of queries which matched the index during a partition set change
 | N
 |===
 ====


### PR DESCRIPTION
Six new map metrics were added to the platform [in this PR](https://github.com/hazelcast/hazelcast-mono/pull/3994), the PR is to add them to the "List of Hazelcast Metrics" page. No backporting is required.