### PR TITLE
Remove Gradle examples

### DIFF
--- a/docs/modules/data-connections/pages/build-map-loader-data-connection.adoc
+++ b/docs/modules/data-connections/pages/build-map-loader-data-connection.adoc
@@ -15,7 +15,7 @@ To complete this tutorial, you need the following:
 
 |Java {minimum-java-version} or newer
 |
-|Maven
+|Maven {minimum-maven-version}
 | https://maven.apache.org/install.html
 |Docker
 |https://docs.docker.com/get-started/[Get Started on docker.com]

--- a/docs/modules/data-connections/pages/build-map-loader-data-connection.adoc
+++ b/docs/modules/data-connections/pages/build-map-loader-data-connection.adoc
@@ -15,8 +15,8 @@ To complete this tutorial, you need the following:
 
 |Java {minimum-java-version} or newer
 |
-|Maven or Gradle
-| https://maven.apache.org/install.html or https://gradle.org/install/
+|Maven
+| https://maven.apache.org/install.html
 |Docker
 |https://docs.docker.com/get-started/[Get Started on docker.com]
 
@@ -60,7 +60,7 @@ INSERT INTO my_table VALUES (9, 'nine');
 
 == Step 2. Create new java project
 
-Create a blank Java project named pipeline-service-data-connection-example and copy the Gradle or Maven file into it:
+Create a blank Java project named pipeline-service-data-connection-example and copy the Maven file into it:
 
 [source,xml]
 ----

--- a/docs/modules/data-connections/pages/build-pipeline-service-data-connection.adoc
+++ b/docs/modules/data-connections/pages/build-pipeline-service-data-connection.adoc
@@ -13,8 +13,8 @@ To complete this tutorial, you need the following:
 
 |Java {minimum-java-version} or newer
 |
-|Maven {minimum-maven-version} or Gradle
-| https://maven.apache.org/install.html or https://gradle.org/install/
+|Maven {minimum-maven-version}
+| https://maven.apache.org/install.html
 |Docker
 |https://docs.docker.com/get-started/[Get Started on docker.com]
 
@@ -58,7 +58,7 @@ INSERT INTO my_table VALUES (9, 'nine');
 
 == Step 2. Create new java project
 
-Create a blank Java project named `pipeline-service-data-connection-example`` and copy the Gradle or Maven file into it:
+Create a blank Java project named `pipeline-service-data-connection-example`` and copy the Maven file into it:
 
 [source,xml]
 ----

--- a/docs/modules/integrate/pages/kafka-connect-connectors.adoc
+++ b/docs/modules/integrate/pages/kafka-connect-connectors.adoc
@@ -12,10 +12,6 @@ Kafka Connect Source connector dependencies are included in the slim and full di
 
 To use the latest version of the dependencies, add the `hazelcast-jet-kafka-connect` module to your Java project.
 
-[tabs] 
-====
-Maven:: 
-+ 
 --
 [source,xml,subs="attributes+"]
 ----
@@ -27,15 +23,6 @@ Maven::
 </dependency>
 ----
 --
-Gradle:: 
-+ 
---
-[source,shell,subs="attributes+"]
-----
-compile group: 'com.hazelcast.jet', name: 'hazelcast-jet-kafka-connect', version: ${os-version}, classifier: 'jar-with-dependencies'
-----
---
-====
 
 == Downloading the Kafka Connect Source Connector
 

--- a/docs/modules/integrate/pages/kinesis-connector.adoc
+++ b/docs/modules/integrate/pages/kinesis-connector.adoc
@@ -43,18 +43,6 @@ To use the Kinesis connectors, make sure the
 `hazelcast-jet-kinesis` module is present in the `lib` directory
 and add the following dependency to your application:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,groovy,subs="attributes+"]
-----
-compile 'com.hazelcast.jet:hazelcast-jet-kinesis:{os-version}'
-----
--- 
-Maven:: 
-+ 
 -- 
 [source,xml,subs="attributes+"]
 ----
@@ -65,7 +53,6 @@ Maven::
 </dependency>
 ----
 --
-====
 
 == Fault-tolerance
 

--- a/docs/modules/integrate/pages/legacy-file-connector.adoc
+++ b/docs/modules/integrate/pages/legacy-file-connector.adoc
@@ -189,18 +189,6 @@ To use the Avro connector, make sure the `hazelcast-jet-avro`
 module is present in the `lib` directory and add the following
 dependency to your application:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,groovy,subs="attributes+"]
-----
-compile 'com.hazelcast.jet:hazelcast-jet-avro:{os-version}'
-----
---
-Maven:: 
-+ 
 -- 
 [source,xml,subs="attributes+"]
 ----
@@ -211,7 +199,6 @@ Maven::
 </dependency>
 ----
 --
-====
 
 With Avro sources, you can use either the `SpecificReader` or
 `DatumReader` depending on the data type:

--- a/docs/modules/pipelines/pages/cdc-join.adoc
+++ b/docs/modules/pipelines/pages/cdc-join.adoc
@@ -37,7 +37,7 @@ supported databases are as follows:
 == Step 4. Create a New Java Project
 
 We'll assume you're using an IDE. Create a blank Java project named
-`cdc-tutorial` and copy the provided Gradle or Maven file into it.
+`cdc-tutorial` and copy the provided Maven file into it.
 They differ slightly depending on which database you use:
 
 * xref:cdc.adoc#5-create-a-new-java-project[MySQL]
@@ -562,21 +562,6 @@ all the code that we have written.
 For this reason we create a JAR containing everything we need. All we
 need to do is to run the build command:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-[source,bash]
-----
-gradle build
-----
-
-This will produce a JAR file called `cdc-tutorial-1.0-SNAPSHOT.jar`
-in the `build/libs` directory of our project.
---
-Maven:: 
-+ 
 --
 [source,bash]
 ----
@@ -586,7 +571,6 @@ mvn package
 This will produce a JAR file called `cdc-tutorial-1.0-SNAPSHOT.jar`
 in the `target` directory or our project.
 --
-====
 
 == Step 7. Start Hazelcast
 
@@ -640,21 +624,6 @@ file, at the end of the `hazelcast` block:
 Also add these config lines to the `config/hazelcast-client.yaml` file,
 at the end of the `hazelcast-client` block:
 +
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-[source,yaml]
-----
-  user-code-deployment:
-    enabled: true
-    jarPaths:
-      - <path_to_project>/build/libs/cdc-tutorial-1.0-SNAPSHOT.jar
-----
---
-Maven:: 
-+ 
 --
 [source,yaml]
 ----
@@ -664,7 +633,6 @@ Maven::
       - <path_to_project>/target/cdc-tutorial-1.0-SNAPSHOT.jar
 ----
 --
-====
 +
 Make sure to replace `<path_to_project>` with the absolute path to where
 you created the project for this tutorial.
@@ -691,18 +659,6 @@ Assuming our cluster is <<7-start-hazelcast-jet, running>> and the
 database <<2-start-database, is up>>, all we need to issue is
 following command:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-[source,bash]
-----
-bin/hz-cli submit build/libs/cdc-tutorial-1.0-SNAPSHOT.jar
-----
---
-Maven:: 
-+ 
 --
 
 [source,bash]
@@ -710,7 +666,6 @@ Maven::
 bin/hz-cli submit target/cdc-tutorial-1.0-SNAPSHOT.jar
 ----
 --
-====
 
 The output in the Hazelcast member's log should look something like this (we
 see these lines due to the `peek()` stages we've inserted):

--- a/docs/modules/pipelines/pages/cdc-postgres.adoc
+++ b/docs/modules/pipelines/pages/cdc-postgres.adoc
@@ -174,37 +174,8 @@ Members {size:1, ver:1} [
 == Step 5. Create a New Java Project
 
 We'll assume you're using an IDE. Create a blank Java project named
-`cdc-tutorial` and copy the Gradle or Maven file into it:
+`cdc-tutorial` and copy the Maven file into it:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-[source,groovy,subs="attributes+"]
-----
-plugins {
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
-    id 'java'
-}
-
-group 'org.example'
-version '1.0-SNAPSHOT'
-
-repositories.mavenCentral()
-
-dependencies {
-    implementation 'com.hazelcast:hazelcast:{os-version}'
-    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-debezium:{ee-version}'
-    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-postgres:{ee-version}'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.0'
-}
-
-jar.manifest.attributes 'Main-Class': 'org.example.JetJob'
-----
---
-Maven:: 
-+ 
 -- 
 [source,xml,subs="attributes+"]
 ----
@@ -262,7 +233,6 @@ Maven::
 </project>
 ----
 --
-====
 
 If you are using {open-source-product-name}, you have to replace `hazelcast-enterprise-cdc-debezium`
 with `hazelcast-jet-cdc-debezium` and `hazelcast-enterprise-cdc-postgres` with `hazelcast-jet-cdc-postgres`.
@@ -468,21 +438,6 @@ standalone process we need to give it all the code that we have written.
 For this reason we create a JAR containing everything we need. All we
 need to do is to run the build command:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,bash]
-----
-gradle build
-----
-
-This will produce a JAR file called `cdc-tutorial-1.0-SNAPSHOT.jar`
-in the `build/libs` directory of our project.
---
-Maven:: 
-+ 
 -- 
 [source,bash]
 ----
@@ -492,32 +447,18 @@ mvn package
 This will produce a JAR file called `cdc-tutorial-1.0-SNAPSHOT.jar`
 in the `target` directory or our project.
 --
-====
 
 == Step 8. Submit the Job for Execution
 
 Assuming our cluster is <<4-start-hazelcast-jet, still running>> and the database <<2-start-postgresql-database, is up>>, all we need to
 issue is following command:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,bash]
-----
-bin/hz-cli submit build/libs/cdc-tutorial-1.0-SNAPSHOT.jar
-----
---
-Maven:: 
-+ 
 -- 
 [source,bash]
 ----
 bin/hz-cli submit target/cdc-tutorial-1.0-SNAPSHOT.jar
 ----
 --
-====
 
 The output in the Hazelcast member's log should look something like this (we
 also log what we put in the `IMap` sink thanks to the `peek()` stage

--- a/docs/modules/pipelines/pages/cdc.adoc
+++ b/docs/modules/pipelines/pages/cdc.adoc
@@ -190,37 +190,8 @@ Members {size:1, ver:1} [
 == Step 5. Create a New Java Project
 
 We'll assume you're using an IDE. Create a blank Java project named
-`cdc-tutorial` and copy the Gradle or Maven file into it:
+`cdc-tutorial` and copy the Maven file into it:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,groovy,subs="attributes+"]
-----
-plugins {
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
-    id 'java'
-}
-
-group 'org.example'
-version '1.0-SNAPSHOT'
-
-repositories.mavenCentral()
-
-dependencies {
-    implementation 'com.hazelcast:hazelcast:{os-version}'
-    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-debezium:{ee-version}'
-    implementation 'com.hazelcast.jet:hazelcast-enterprise-cdc-mysql:{ee-version}'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.0'
-}
-
-jar.manifest.attributes 'Main-Class': 'org.example.JetJob'
-----
---
-Maven:: 
-+ 
 -- 
 [source,xml,subs="attributes+"]
 ----
@@ -278,7 +249,6 @@ Maven::
 </project>
 ----
 --
-====
 
 == Step 6. Define a Data Pipeline
 
@@ -433,21 +403,6 @@ standalone process we need to give it all the code that we have written.
 For this reason we create a jar containing everything we need. All we
 need to do is to run the build command:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,bash]
-----
-gradle build
-----
-
-This will produce a JAR file called `cdc-tutorial-1.0-SNAPSHOT.jar`
-in the `build/libs` directory of our project.
---
-Maven:: 
-+ 
 -- 
 
 [source,bash]
@@ -458,32 +413,18 @@ mvn package
 This will produce a JAR file called `cdc-tutorial-1.0-SNAPSHOT.jar`
 in the `target` directory or our project.
 --
-====
 
 == Step 8. Submit the Job for Execution
 
 Assuming our cluster is <<4-start-hazelcast-jet, still running>> and the database <<2-start-mysql-database, is up>>, all we need to
 issue is following command:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,bash]
-----
-bin/hz-cli submit build/libs/cdc-tutorial-1.0-SNAPSHOT.jar
-----
---
-Maven:: 
-+ 
 -- 
 [source,bash]
 ----
 bin/hz-cli submit target/cdc-tutorial-1.0-SNAPSHOT.jar
 ----
 --
-====
 
 The output in the Hazelcast member's log should look something like this (we
 also log what we put in the `IMap` sink thanks to the `peek()` stage

--- a/docs/modules/pipelines/pages/grpc.adoc
+++ b/docs/modules/pipelines/pages/grpc.adoc
@@ -15,18 +15,6 @@ service. Hazelcast supports two link:https://grpc.io/docs/guides/concepts/[gRPC 
 
 Add this dependency to your Java project:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,groovy,subs="attributes+"]
-----
-compile 'com.hazelcast.jet:hazelcast-jet-grpc:{os-version}'
-----
---
-Maven:: 
-+ 
 -- 
 
 [source,xml,subs="attributes+"]
@@ -38,7 +26,6 @@ Maven::
 </dependency>
 ----
 --
-====
 
 The Hazelcast cluster must also have this module on the classpath.
 Make sure it is present in the `lib` directory, if not add it there and

--- a/docs/modules/pipelines/pages/kafka.adoc
+++ b/docs/modules/pipelines/pages/kafka.adoc
@@ -40,34 +40,8 @@ From now on we assume Hazelcast is running on your machine.
 == 3. Create a New Java Project
 
 We'll assume you're using an IDE. Create a blank Java project named
-`kafka-tutorial` and copy the Gradle or Maven file into it:
+`kafka-tutorial` and copy the Maven file into it:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-[source,groovy,subs="attributes+"]
-----
-plugins {
-    id 'java'
-}
-
-group 'org.example'
-version '1.0-SNAPSHOT'
-
-repositories.mavenCentral()
-
-dependencies {
-    implementation 'com.hazelcast:hazelcast:{os-version}'
-    implementation 'com.hazelcast.jet:hazelcast-jet-kafka:{os-version}'
-}
-
-jar.manifest.attributes 'Main-Class': 'org.example.JetJob'
-----
---
-Maven:: 
-+ 
 --
 [source,xml,subs="attributes+"]
 ----
@@ -115,7 +89,6 @@ Maven::
 </project>
 ----
 --
-====
 
 == 4. Publish an Event Stream to Kafka
 
@@ -223,25 +196,12 @@ You may run this code from your IDE, and it will work, but it will
 create its own Hazelcast member. To run it on the Hazelcast member you already
 started, use the command line like this:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-```bash
-gradle build
-<path_to_jet>/bin/hz-cli submit build/libs/kafka-tutorial-1.0-SNAPSHOT.jar
-```
---
-Maven:: 
-+ 
 --
 ```bash
 mvn package
 <path_to_jet>/bin/hz-cli submit target/kafka-tutorial-1.0-SNAPSHOT.jar
 ```
 --
-====
 
 Now go to the window where you started Hazelcast. Its log output will contain
 the output from the pipeline.

--- a/docs/modules/pipelines/pages/kinesis.adoc
+++ b/docs/modules/pipelines/pages/kinesis.adoc
@@ -38,35 +38,6 @@ NOTE: Keep in mind that you are setting up a stream called `Tweets` instead of `
 . To check that everything is set up correctly, link:https://docs.aws.amazon.com/streams/latest/dev/kinesis-tutorial-cli-installation.html[install the AWS CLI]
 and link:https://docs.aws.amazon.com/streams/latest/dev/fundamental-stream.html[perform some basic operations with it].
 
-== Step 2. Create a New Java Project
-
-We'll assume you're using an IDE. Create a blank Java project named
-`kinesis-tutorial` and copy the Gradle or Maven file into it:
-
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-[source,groovy,subs="attributes+"]
-----
-plugins {
-    id 'java'
-}
-
-group 'org.example'
-version '1.0-SNAPSHOT'
-
-repositories.mavenCentral()
-
-dependencies {
-    implementation 'com.hazelcast:hazelcast:{os-version}'
-    implementation 'com.hazelcast.jet:hazelcast-jet-kinesis:{os-version}'
-}
-----
---
-Maven:: 
-+ 
 --
 [source,xml,subs="attributes+"]
 ----
@@ -98,7 +69,6 @@ Maven::
 </project>
 ----
 --
-====
 
 == Step 3. Publish a Stream to Kinesis
 
@@ -156,25 +126,12 @@ You may run this code from your IDE, and it will work, but it will
 create its own Hazelcast member. To run it on the Hazelcast member you already
 started, use the command line like this:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-```bash
-gradle build
-bin/hz-cli submit -c org.example.TweetPublisher build/libs/kinesis-tutorial-1.0-SNAPSHOT.jar
-```
---
-Maven:: 
-+ 
 --
 ```bash
 mvn package
 bin/hz-cli submit -c org.example.TweetPublisher target/kinesis-tutorial-1.0-SNAPSHOT.jar
 ```
 --
-====
 
 Let it run in the background while we go on to creating the next class.
 
@@ -232,25 +189,12 @@ You may run this code from your IDE and it will work, but it will create
 its own Hazelcast instance. To run it on the Hazelcast instance you already started,
 use the command line like this:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-```bash
-gradle build
-bin/hz-cli submit -c org.example.JetJob build/libs/kinesis-tutorial-1.0-SNAPSHOT.jar
-```
---
-Maven:: 
-+ 
 --
 ```bash
 mvn package
 bin/hz-cli submit -c org.example.JetJob target/kinesis-tutorial-1.0-SNAPSHOT.jar
 ```
 --
-====
 
 Now go to the window where you started Hazelcast. Its log output will contain
 the output from the pipeline.

--- a/docs/modules/pipelines/pages/kinesis.adoc
+++ b/docs/modules/pipelines/pages/kinesis.adoc
@@ -38,6 +38,11 @@ NOTE: Keep in mind that you are setting up a stream called `Tweets` instead of `
 . To check that everything is set up correctly, link:https://docs.aws.amazon.com/streams/latest/dev/kinesis-tutorial-cli-installation.html[install the AWS CLI]
 and link:https://docs.aws.amazon.com/streams/latest/dev/fundamental-stream.html[perform some basic operations with it].
 
+== Step 2. Create a New Java Project
+
+We'll assume you're using an IDE. Create a blank Java project named
+`kinesis-tutorial` and copy the Maven file into it:
+
 --
 [source,xml,subs="attributes+"]
 ----

--- a/docs/modules/pipelines/pages/map-join.adoc
+++ b/docs/modules/pipelines/pages/map-join.adoc
@@ -23,45 +23,8 @@ To complete this tutorial, you need the following:
 == Step 1. Create a New Java Project
 
 We'll assume you're using an IDE. Create a blank Java project named
-`map-join-tutorial` and copy the Gradle or Maven file into it:
+`map-join-tutorial` and copy the Maven file into it:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,groovy,subs="attributes+"]
-----
-plugins {
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
-    id 'java'
-}
-
-group 'org.example'
-version '1.0-SNAPSHOT'
-
-repositories.mavenCentral()
-
-dependencies {
-    implementation 'com.hazelcast:hazelcast:{os-version}'
-    implementation 'com.hazelcast.samples.jet:hazelcast-jet-examples-trade-source:{os-version}'
-}
-
-jar {
-    enabled = false
-    dependsOn(shadowJar{archiveClassifier.set("")})
-    manifest.attributes 'Main-Class': 'org.example.JoinUsingMapJob'
-}
-
-shadowJar {
-    dependencies {
-        exclude(dependency('com.hazelcast:hazelcast:{os-version}'))
-    }
-}
-----
---
-Maven::
-+
 --
 [source,xml,subs="attributes+"]
 ----
@@ -129,7 +92,6 @@ Maven::
 </project>
 ----
 --
-====
 
 If you want to know more about packaging jobs, see
 xref:pipelines:submitting-jobs.adoc[].
@@ -230,25 +192,12 @@ public class JoinUsingMapJob {
 
 Submit the job to the Hazelcast cluster
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-```bash
-gradle build
-bin/hz-cli submit build/libs/map-join-tutorial-1.0-SNAPSHOT.jar
-```
---
-Maven:: 
-+ 
 --
 ```bash
 mvn package
 bin/hz-cli submit target/map-join-tutorial-1.0-SNAPSHOT.jar
 ```
 --
-====
 
 Now go to the window where you started Jet. Its log output will contain
 the output from the pipeline.

--- a/docs/modules/pipelines/pages/pulsar.adoc
+++ b/docs/modules/pipelines/pages/pulsar.adoc
@@ -44,50 +44,8 @@ localhost:6650.
 == Step 2. Create a New Java Project
 
 Create a blank Java project named
-`pulsar-example` and copy the Gradle or Maven file into it:
+`pulsar-example` and copy the Maven file into it:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-[source,groovy,subs="attributes+"]
-----
-plugins {
-    id 'java'
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
-}
-
-group 'org.example'
-version '1.0-SNAPSHOT'
-
-sourceCompatibility = 1.8
-
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    implementation 'com.hazelcast:hazelcast:{os-version}'
-    implementation 'com.hazelcast.jet-contrib:pulsar:0.1'
-    implementation 'org.apache.pulsar:pulsar-client:2.5.0'
-}
-
-jar {
-    enabled = false
-    dependsOn(shadowJar{archiveClassifier.set("")})
-    manifest.attributes 'Main-Class': 'org.example.JetJob'
-}
-
-shadowJar {
-    dependencies {
-        exclude(dependency('com.hazelcast:hazelcast:{os-version}'))
-    }
-}
-----
---
-Maven:: 
-+ 
 --
 [source,xml,subs="attributes+"]
 ----
@@ -171,7 +129,6 @@ Maven::
 </project>
 ----
 --
-====
 
 == Step 3. Publish Messages to a Pulsar Topic
 
@@ -328,22 +285,10 @@ public class JetJob {
 If you run this code from your IDE, it will create its own Hazelcast member
 and run the job on it. To run this on the previously started Hazelcast member,
 you need to create a runnable JAR including all dependencies required to
-run it. Then, submit it to the Hazelcast cluster. Since build.gradle/pom.xml
-files are configured to create a full JAR, we can do these steps easily
+run it. Then, submit it to the Hazelcast cluster. Since `pom.xml`
+is configused to create a full JAR, we can do these steps easily
 as shown as below:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
---
-```bash
-gradle build
-bin/hz-cli submit build/libs/pulsar-example-1.0-SNAPSHOT.jar
-```
---
-Maven:: 
-+ 
 --
 
 ```bash
@@ -351,7 +296,6 @@ mvn package
 bin/hz-cli submit target/pulsar-example-1.0-SNAPSHOT.jar
 ```
 --
-====
 
 Now go to the window where you started Hazelcast. Its log output will contain
 the output from the pipeline.

--- a/docs/modules/pipelines/pages/pulsar.adoc
+++ b/docs/modules/pipelines/pages/pulsar.adoc
@@ -286,7 +286,7 @@ If you run this code from your IDE, it will create its own Hazelcast member
 and run the job on it. To run this on the previously started Hazelcast member,
 you need to create a runnable JAR including all dependencies required to
 run it. Then, submit it to the Hazelcast cluster. Since `pom.xml`
-is configused to create a full JAR, we can do these steps easily
+is configured to create a full JAR, we can do these steps easily
 as shown as below:
 
 --

--- a/docs/modules/pipelines/pages/python.adoc
+++ b/docs/modules/pipelines/pages/python.adoc
@@ -47,34 +47,8 @@ Save this as `requirements.txt` in the `<python_src>` directory.
 == Step 2. Create a New Java Project
 
 We'll assume you're using an IDE. Create a blank Java project named
-`tutorial-python` and copy the Gradle or Maven file into it:
+`tutorial-python` and copy the Maven file into it:
 
-[tabs]
-==== 
-Gradle:: 
-+ 
---
-[source,groovy,subs="attributes+"]
-----
-plugins {
-    id 'java'
-}
-
-group 'org.example'
-version '1.0-SNAPSHOT'
-
-repositories.mavenCentral()
-
-dependencies {
-    implementation 'com.hazelcast:hazelcast:{os-version}'
-    implementation 'com.hazelcast.jet:hazelcast-jet-python:{os-version}'
-}
-
-jar.manifest.attributes 'Main-Class': 'org.example.JetJob'
-----
--- 
-Maven:: 
-+ 
 --
 [source,xml,subs="attributes+"]
 ----
@@ -122,7 +96,6 @@ Maven::
 </project>
 ----
 --
-====
 
 == Step 3. Apply the Python Function to a Pipeline
 
@@ -163,25 +136,12 @@ You may run this code from your IDE and it will work, but it will create
 its own Hazelcast member. `bin/hz-cli` directory is in the distribution which is downloaded before. To run it on the
 Hazelcast member you already started, use the command line like this:
 
-[tabs]
-====
-Gradle:: 
-+ 
---
-```bash
-gradle build
-bin/hz-cli submit build/libs/tutorial-python-1.0-SNAPSHOT.jar
-```
---
-Maven:: 
-+ 
 --
 ```bash
 mvn package
 bin/hz-cli submit target/tutorial-python-1.0-SNAPSHOT.jar
 ```
 --
-====
 
 Now go to the window where you started Hazelcast. Its log output will contain
 the output from the pipeline, like this:

--- a/docs/modules/pipelines/pages/serialization.adoc
+++ b/docs/modules/pipelines/pages/serialization.adoc
@@ -344,18 +344,6 @@ extension module that simplifies this for Protobuf version 3.
 If you want to use it locally within a job, add the extension as a
 dependency to your job's project:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,groovy,subs="attributes+"]
-----
-compile "com.hazelcast.jet:hazelcast-jet-protobuf:{os-version}"
-----
---
-Maven:: 
-+ 
 -- 
 [source,xml,subs="attributes+"]
 ----
@@ -366,7 +354,6 @@ Maven::
 </dependency>
 ----
 --
-====
 
 Implement the adapter by extending the provided class (where `Person`
 is of any Protobuf `GeneratedMessageV3` type):

--- a/docs/modules/pipelines/pages/spring-boot.adoc
+++ b/docs/modules/pipelines/pages/spring-boot.adoc
@@ -11,32 +11,8 @@ member and auto-wires it.
 == 1. Create a New Java Project
 
 We assume you're using an IDE. Create a blank Java project named
-`tutorial-jet-starter` and copy the Gradle or Maven file into it:
+`tutorial-jet-starter` and copy the Maven file into it:
 
-[tabs]
-====
-Gradle:: 
-+ 
---
-[source,groovy,subs="attributes+"]
-----
-plugins {
-  id 'org.springframework.boot' version '2.2.6.RELEASE'
-  id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-  id 'java'
-}
-group = 'org.example'
-version '1.0-SNAPSHOT'
-
-repositories.mavenCentral()
-
-dependencies {
-  implementation 'com.hazelcast.jet.contrib:hazelcast-jet-spring-boot-starter:2.0.0'
-}
-----
---
-Maven:: 
-+ 
 --
 [source,xml,subs="attributes+"]
 ----
@@ -66,7 +42,6 @@ Maven::
 </project>
 ----
 --
-====
 
 == 2. Create the Application Main Class
 

--- a/docs/modules/pipelines/pages/transforms.adoc
+++ b/docs/modules/pipelines/pages/transforms.adoc
@@ -961,18 +961,6 @@ You can also use supported annotations from
 link:https://github.com/FasterXML/jackson-annotations/wiki/Jackson-Annotations[Jackson Annotations]
 in your transforms by adding it to the classpath.
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,groovy,subs="attributes+"]
-----
-compile 'com.fasterxml.jackson.core:jackson-annotations:2.11.0'
-----
---
-Maven:: 
-+ 
 -- 
 [source,xml,subs="attributes+"]
 ----
@@ -983,7 +971,6 @@ Maven::
 </dependency>
 ----
 --
-====
 
 For example if your bean field names differ from the JSON
 string field names you can use `JsonProperty` annotation for mapping.

--- a/docs/modules/pipelines/pages/windowing.adoc
+++ b/docs/modules/pipelines/pages/windowing.adoc
@@ -27,46 +27,9 @@ To complete this tutorial, you need the following:
 == Step 1. Create a New Java Project
 
 We'll assume you're using an IDE. Create a blank Java project named
-`trade-monitor` and copy the Gradle or Maven file
+`trade-monitor` and copy the Maven file
 into it:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-[source,groovy,subs="attributes+"]
-----
-plugins {
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
-    id 'java'
-}
-
-group 'org.example'
-version '1.0-SNAPSHOT'
-
-repositories.mavenCentral()
-
-dependencies {
-    implementation 'com.hazelcast:hazelcast:{os-version}'
-    implementation 'com.hazelcast.samples.jet:hazelcast-jet-examples-trade-source:{jet-version}'
-}
-
-jar {
-    enabled = false
-    dependsOn(shadowJar{archiveClassifier.set("")})
-    manifest.attributes 'Main-Class': 'org.example.TradeMonitor'
-}
-
-shadowJar {
-    dependencies {
-        exclude(dependency('com.hazelcast:hazelcast:{os-version}'))
-    }
-}
-----
--- 
-Maven:: 
-+ 
 -- 
 [source,xml,subs="attributes+"]
 ----
@@ -134,7 +97,6 @@ Maven::
 </project>
 ----
 --
-====
 
 == Step 2. Define the Pipeline
 
@@ -232,20 +194,6 @@ give it all the code that we have written.
 For this reason we create a JAR containing everything we need. All we
 need to do is to run the build command:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-```bash
-gradle build
-```
-
-This will produce a JAR file called `trade-monitor-1.0-SNAPSHOT.jar`
-in the `build/libs` directory of our project.
---
-Maven:: 
-+ 
 -- 
 ```bash
 mvn package
@@ -254,30 +202,17 @@ mvn package
 This will produce a JAR file called `trade-monitor-1.0-SNAPSHOT.jar`
 in the `target` directory or our project.
 --
-====
 
 == Step 4. Submit the Job for Execution
 
 Assuming our cluster is still running all we
 need to issue is following command:
 
-[tabs] 
-==== 
-Gradle:: 
-+ 
--- 
-```bash
-bin/hz-cli submit build/libs/trade-monitor-1.0-SNAPSHOT.jar
-```
---
-Maven:: 
-+ 
 -- 
 ```bash
 bin/hz-cli submit target/trade-monitor-1.0-SNAPSHOT.jar
 ```
 --
-====
 
 The output you should be seeing in the Hazelcast member's log is one such
 message every 5 seconds:

--- a/docs/modules/sql/pages/mapping-to-mongo.adoc
+++ b/docs/modules/sql/pages/mapping-to-mongo.adoc
@@ -34,13 +34,6 @@ Add the following lines to your `pom.xml` to include it as a dependency to your 
 </dependency>
 ----
 
-or if you are using Gradle:
-
-[source,plain,subs="attributes+"]
-----
-compile group: 'com.hazelcast.jet', name: 'hazelcast-jet-mongodb', version: ${os-version}.
-----
-
 NOTE: To be able to use SQL over MongoDB, you have to include `hazelcast-sql` as well as a dependency.
 
 == Permissions

--- a/docs/modules/test/pages/testing.adoc
+++ b/docs/modules/test/pages/testing.adoc
@@ -13,18 +13,6 @@ classifier.
 To start using them, please add following dependencies to your
 project:
 
-[tabs] 
-====
-Gradle:: 
-+ 
---
-[source,shell,subs="attributes+"]
-----
-compile 'com.hazelcast:hazelcast:{os-version}:tests'
-----
---
-Maven:: 
-+ 
 --
 [source,xml,subs="attributes+"]
 ----
@@ -36,7 +24,6 @@ Maven::
 </dependency>
 ----
 --
-====
 
 After adding the dependencies to your project, the test classes should
 be available to your project.


### PR DESCRIPTION
[_Some_ examples include example Maven and Gradle configuration samples](https://docs.hazelcast.com/hazelcast/latest/test/testing), but most [don't](https://docs.hazelcast.com/hazelcast/latest/security/integrating-openssl#using-boringssl).

Moreover:
- we don't provide any instructions for using Hazelcast with Gradle, [only Maven](https://docs.hazelcast.com/hazelcast/latest/getting-started/install-hazelcast#using-maven)
- we aren't explicitly testing against Gradle

As such I don't see the value in these examples and they should be removed.