### PR TITLE
Update `cluster-utilities`

### DIFF
--- a/docs/modules/management/pages/cluster-utilities.adoc
+++ b/docs/modules/management/pages/cluster-utilities.adoc
@@ -7,93 +7,23 @@ to check whether the cluster and/or members are safe before shutting down a memb
 to define the minimum number of cluster members required for the cluster to remain up and running.
 It also gives information about the Hazelcast Lite Member.
 
+
+These tools are included with the Hazelcast package.
+
 == Hazelcast Command Line Tool
 
-This is a tool using which you can install and run Hazelcast and Management Center
-on your Unix-like local environments. You need https://www.oracle.com/java/technologies/javase-downloads.html[JRE 8 or newer^]
-as a prerequisite.
-
-You can install this tool using its Homebrew, RPM, or Debian packages:
-
-[tabs] 
-==== 
-Homebrew:: 
-+ 
--- 
-
-[source,bash,subs="attributes+"]
-----
-brew tap hazelcast/hz
-brew install hazelcast@{os-version}
-----
---
-
-Debian::
-+
-ifdef::snapshot[]
-[source,bash]
-----
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
-echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
-sudo apt update && sudo apt install hazelcast
-----
-endif::[]
-ifndef::snapshot[]
-[source,shell,subs="attributes+"]
-----
-wget -qO - https://repository.hazelcast.com/api/gpg/key/public | gpg --dearmor | sudo tee /usr/share/keyrings/hazelcast-archive-keyring.gpg > /dev/null
-echo "deb [signed-by=/usr/share/keyrings/hazelcast-archive-keyring.gpg] https://repository.hazelcast.com/debian stable main" | sudo tee -a /etc/apt/sources.list
-sudo apt update && sudo apt install hazelcast={os-version}
-----
-endif::[]
-
-RPM::
-+
-ifdef::snapshot[]
-[source,bash]
-----
-wget https://repository.hazelcast.com/rpm/hazelcast-rpm.repo -O hazelcast-rpm.repo
-sudo mv hazelcast-rpm.repo /etc/yum.repos.d/
-sudo yum install hazelcast
-----
-endif::[]
-ifndef::snapshot[]
-[source,shell,subs="attributes+"]
-----
-wget https://repository.hazelcast.com/rpm/stable/hazelcast-rpm-stable.repo -O hazelcast-rpm-stable.repo
-sudo mv hazelcast-rpm-stable.repo /etc/yum.repos.d/
-sudo yum install hazelcast-{os-version}
-----
-endif::[]
-====
-
-Alternatively, you can manually download and install this tool using
-the TAR package on its GitHub https://github.com/hazelcast/hazelcast-command-line/releases[repo^].
-After you download and extract the package, you see the `hazelcast-<version>` directory.
-Simply run the following commands to install it:
-
-```
-cd hazelcast-<version>/bin
-./hz
-```
-
-You are now ready to use the tool.
+This is a tool using which you can install and run Hazelcast 
+on your Unix-like local environments.
 
 * **Starting a standalone Hazelcast member with the default configuration:**
 +
 `./hz start`
 *
-* **Starting Hazelcast Management Center:**
-+
-`./hz mc start`
-
-Please see the tool's https://github.com/hazelcast/hazelcast-command-line[documentation^]
-for all the other usages.
 
 [[using-the-hz-cluster-admin-script]]
 == Using the `hz-cluster-admin` Script
 
-You can use the script `hz-cluster-admin`, which comes with the Hazelcast package, to
+You can use the script `hz-cluster-admin`, to
 get/change the state of your cluster, to shutdown your cluster and
 to force your cluster to clean its persisted data and make a fresh start.
 The latter is the force-start operation of Persistence.


### PR DESCRIPTION
This documentation seems to be outdated, predating when the command line tool was integrated into platform / MC respectively in https://github.com/hazelcast/hazelcast/pull/20262

Specifically:
- removed references to Management Center as the platform tool does not support that
- Removed Java 8 pre-requisite reference
   - if you try and run with Java 8, it just says  `Unrecognized option: --add-modules Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.`
- removed references on _how_ to install it
   - duplicated elsewhere
   - in the following section we refer to `Hazelcast package` and _assume_ users will know how to obtain that
- removed links to the _old_ home of the `hazelcast-command-line` tool