### PR TITLE
[HZ-4796] Docs: Allow clients without a matching cluster name to connect with the membersadd skip namecheck property

### DIFF
--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -80,7 +80,7 @@ it cleans up the local resources that are owned by that client.
 |`hazelcast.client.internal.skip.cluster.namecheck.during.connection`
 |false
 |bool
-|Allows clients to connect without matching the cluster name.
+|Allows clients to connect without matching the cluster name. This can help if you have a large number of existing clients and it would be impractical to update them. When enabled, cluster name validation is skipped during client authentication.
 
 |[[client-tpc-enabled]] `hazelcast.client.tpc.enabled`
 |false

--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -77,6 +77,11 @@ it cleans up the local resources that are owned by that client.
 |int
 |Time after which the member assumes the client is dead and closes its connections to the client.
 
+|`hazelcast.client.internal.skip.cluster.namecheck.during.connection`
+|false
+|bool
+|Allows clients to connect without matching the cluster name.
+
 |[[client-tpc-enabled]] `hazelcast.client.tpc.enabled`
 |false
 |bool


### PR DESCRIPTION
https://hazelcast.atlassian.net/browse/HZ-4796