### PR TITLE
Update `apache.org` download links to use `closer.lua`

### DIFF
--- a/docs/modules/sql/pages/learn-sql.adoc
+++ b/docs/modules/sql/pages/learn-sql.adoc
@@ -40,7 +40,7 @@ Binary::
 +
 [source,shell]
 ----
-wget https://www.apache.org/dyn/closer.lua/kafka/2.7.0/kafka-2.7.0-src.tgz?action=download
+wget "https://www.apache.org/dyn/closer.lua/kafka/2.7.0/kafka-2.7.0-src.tgz?action=download"
 tar xvf kafka-2.7.0-src.tgz
 cd kafka-2.7.0-src
 ----


### PR DESCRIPTION
[We have seen instability downloading from `archive.apache.org`](https://github.com/hazelcast/client-compatibility-suites/actions/runs/15973338298/job/45050422979).

Update links to use `closer.lua` instead, as mentioned in [Apache's documentation](https://infra.apache.org/release-download-pages.html).