### PR TITLE
[HZ-4796] Docs: Allow clients without a matching cluster name to connect with the membersadd skip namecheck property (V5.3)

### DIFF
--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -77,6 +77,11 @@ it cleans up the local resources that are owned by that client.
 |int
 |Time after which the member assumes the client is dead and closes its connections to the client.
 
+|`hazelcast.client.internal.skip.cluster.namecheck.during.connection`
+|false
+|bool
+|Allows clients to connect without matching the cluster name. This can help if you have a large number of existing clients and it would be impractical to update them. When enabled, cluster name validation is skipped during client authentication.
+
 |`hazelcast.client.protocol.max.message.bytes`
 | 1024
 |int


### PR DESCRIPTION
Manual backport of https://github.com/hazelcast/hz-docs/pull/1740