### PR TITLE
DOC-536: include Go install & get started info

### DIFF
--- a/docs/modules/clients/pages/go.adoc
+++ b/docs/modules/clients/pages/go.adoc
@@ -1,20 +1,85 @@
 = Go Client
 :page-api-reference: https://pkg.go.dev/github.com/hazelcast/hazelcast-go-client@v{page-latest-supported-go-client}
 
-TIP: For the latest Go API documentation, see https://pkg.go.dev/github.com/hazelcast/hazelcast-go-client@v{page-latest-supported-go-client}[Hazelcast Go Client docs].
+== Overview
+
+This section provides information about the Go client for Hazelcast, and explains how to install and get started with the client.
+
+TIP: To learn how to get started quickly with the Hazelcast Go client, follow our simple xref:clients:go-client-getting-started.adoc[Get started with Go] tutorial.
 
 The Hazelcast native Go client is an official library that allows Go applications to connect to and interact with Hazelcast clusters. It is implemented using the Hazelcast Open Binary Client Protocol. The key features and benefits include:
 
-* Distributed Data Structures: supports various distributed implementations like Map, Queue, Set, List, MultiMap, and Replicated Map, mimicking natural interfaces of these structures in Go
-* SQL Support: allows running SQL queries on Hazelcast 5.x clusters, enhancing data querying capabilities
-* JSON Support: declarative configuration support via JSON
-* High Performance: offers high-performance aggregation functions such as sum, average, max, and min, for Hazelcast Map entries. They can run in parallel for each partition and are highly optimized for speed and low-memory consumption
-* Near Cache: improves read performance for frequently accessed data, optimizing application speed
-* External Smart Client Discovery: allows for dynamic discovery of cluster members, enhancing scalability and fault tolerance
+* Distributed Data Structures: supports various distributed implementations like Map, Queue, Set, List, MultiMap, and Replicated Map, mimicking natural interfaces of these structures in Go.
+* SQL Support: allows running SQL queries on Hazelcast 5.x clusters, enhancing data querying capabilities.
+* JSON Support: declarative configuration support via JSON.
+* High Performance: offers high-performance aggregation functions such as sum, average, max, and min, for Hazelcast Map entries. They can run in parallel for each partition and are highly optimized for speed and low-memory consumption.
+* Near Cache: improves read performance for frequently accessed data, optimizing application speed.
+* External Smart Client Discovery: allows for dynamic discovery of cluster members, enhancing scalability and fault tolerance.
 
 The Hazelcast Go client provides a robust, efficient, and Go-friendly way to work with Hazelcast clusters, enabling developers to build scalable and distributed applications with ease.
 
+TIP: For the latest Go API documentation, see https://pkg.go.dev/github.com/hazelcast/hazelcast-go-client@v{page-latest-supported-go-client}[Hazelcast Go Client docs].
+
+== Install the Go client
+
+This section explains how to install the Hazelcast Go client.
+
+Requirements:
+
+- The Hazelcast Go client is compatible only with Hazelcast 4.x and 5.x.
+- Hazelcast supports the two most recent releases of Go, currently 1.20 and up.
+
+In your Go-module-enabled project, add a dependency to `github.com/hazelcast/hazelcast-go-client`:
+
+[source]
+----
+# Depend on the latest release
+$ go get github.com/hazelcast/hazelcast-go-client@latest
+----
+
+== Quick start
+
+The Hazelcast Go client requires a working Hazelcast cluster to run. This cluster handles storage and manipulation of the user data. Clients are a way to connect to the Hazelcast cluster and access such data.
+
+Check out our https://hazelcast.com/get-started/[Get started] page for options.
+
+=== Start the default client
+
+Start the client with the default Hazelcast host and port using `hazelcast.StartNewClient`, when Hazelcast is running on local with the default options:
+
+```go
+ctx := context.TODO()
+client, err := hazelcast.StartNewClient(ctx)
+// handle client start error
+```
+
+=== Starting the client with given options
+
+Note that `Config` structs are not thread-safe. Complete creation of the configuration in a single goroutine.
+
+```go
+// create the default configuration
+config := hazelcast.Config{}
+// optionally set member addresses manually
+config.Cluster.Network.SetAddresses("member1.example.com:5701", "member2.example.com:5701")
+// create and start the client with the configuration provider
+client, err := hazelcast.StartNewClientWithConfig(ctx, config)
+// handle client start error
+```
+
 == Next steps
 
-For more information, see the https://github.com/hazelcast/hazelcast-go-client[Hazelcast Go client GitHub repo].
+Hazelcast Go Client documentation is hosted at https://pkg.go.dev/github.com/hazelcast/hazelcast-go-client[pkg.go.dev].
+
+You can view the documentation locally by using godoc:
+```  
+$ godoc -http=localhost:5500
+```
+
+godoc is not installed by default with the base Go distribution. Install it using:
+```
+$ go get -u golang.org/x/tools/...`
+```
+
+See also the https://github.com/hazelcast/hazelcast-go-client[Hazelcast Go client GitHub repo]
 and https://github.com/hazelcast/hazelcast-go-client/tree/master/examples[code samples^].


### PR DESCRIPTION
Expand the Go Client topic to include Install and get started info