### PR TITLE
Fix Maven EE `SNAPSHOT` repository configuration

### DIFF
--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -86,9 +86,9 @@ ifdef::snapshot[]
     <repository>
         <id>private-repository</id>
         <name>Hazelcast Private Repository</name>
-        <url>https://repository.hazelcast.com/release/</url>
+        <url>https://repository.hazelcast.com/snapshot/</url>
         <releases>
-            <enabled>true</enabled>
+            <enabled>false</enabled>
         </releases>
         <snapshots>
             <enabled>true</enabled>


### PR DESCRIPTION
For `SNAPSHOT` pages, the suggested repository is `release` which _doesn't contain_ any `SNAPSHOT`s.

Updated to match the configuration we use [as part of the validation process](https://github.com/hazelcast/hz-docs/blob/5161e839ea85409e25fdf9d6f738af5948cd65b8/pom.xml#L68-L74).

