### PR TITLE
Update java.adoc client connection strategy

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -514,7 +514,7 @@ Hazelcast creates the client without waiting for a connection to the cluster.
 In this case, the client instance throws an exception until it connects to the cluster.
 If it is `false`, the client is not created until the cluster is ready to use clients and
 a connection with each of the cluster members (defined by the <<client-cluster-routing-modes, routing mode>>) is established.
-The default value is `false` (sync)
+The default value is `false` (sync).
 
 You can also configure how the client reconnects to the cluster after a disconnection.
 This is configured using the configuration element `reconnect-mode`, which has three options:

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -513,7 +513,8 @@ the configuration element `async-start`. When it is set to `true` (async),
 Hazelcast creates the client without waiting for a connection to the cluster.
 In this case, the client instance throws an exception until it connects to the cluster.
 If it is `false`, the client is not created until the cluster is ready to use clients and
-a connection with the cluster is established. The default value is `false` (sync)
+a connection with each of the cluster members (defined by the <<client-cluster-routing-modes, routing mode>>) is established.
+The default value is `false` (sync)
 
 You can also configure how the client reconnects to the cluster after a disconnection.
 This is configured using the configuration element `reconnect-mode`, which has three options:


### PR DESCRIPTION
Clarify that when `async-start` = false, the client waits for all cluster members (defined by routing mode) to be connected. This comes from a discussion with İhsan in SUP-972.