### PR TITLE
[EMGR-477] Reference IAtomicLong as an alternative for PNCounter

### DIFF
--- a/docs/modules/data-structures/pages/pn-counter.adoc
+++ b/docs/modules/data-structures/pages/pn-counter.adoc
@@ -20,6 +20,11 @@ replica count). If there is no member failure, it is guaranteed that each replic
 sees the final value of the counter eventually. Counter's state converges with each
 update and all CRDT replicas that can communicate to each other will eventually have the same state.
 
+[NOTE]
+===
+CRDTs are eventually consistent. If you require strong consistency then consider using xref:data-structures:iatomiclong.adoc[IAtomicLong] within the xref:cp-subsystem:cp-subsystem.adoc[CP Subsystem].
+===
+
 Using the PN Counter, you can get a distributed counter, increment and decrement it,
 and query its value with RYW (read-your-writes) and monotonic reads. The implementation
 borrows most methods from the `AtomicLong` which should be familiar in most cases and

--- a/docs/modules/data-structures/pages/pn-counter.adoc
+++ b/docs/modules/data-structures/pages/pn-counter.adoc
@@ -20,10 +20,7 @@ replica count). If there is no member failure, it is guaranteed that each replic
 sees the final value of the counter eventually. Counter's state converges with each
 update and all CRDT replicas that can communicate to each other will eventually have the same state.
 
-[NOTE]
-===
-CRDTs are eventually consistent. If you require strong consistency then consider using xref:data-structures:iatomiclong.adoc[IAtomicLong] within the xref:cp-subsystem:cp-subsystem.adoc[CP Subsystem].
-===
+NOTE: CRDTs are eventually consistent. If you require strong consistency then consider using xref:data-structures:iatomiclong.adoc[IAtomicLong] within the xref:cp-subsystem:cp-subsystem.adoc[CP Subsystem].
 
 Using the PN Counter, you can get a distributed counter, increment and decrement it,
 and query its value with RYW (read-your-writes) and monotonic reads. The implementation


### PR DESCRIPTION
`PNCounter` is eventually consistent and you can have duplicate observations upon mutation -- that's by design. This PR adds a note that if you want strong consistency then consider using `IAtomicLong`.