### PR TITLE
DOC-548: Migrate tech content from node.js readme & ref manual to Docs

### DIFF
--- a/docs/modules/clients/pages/nodejs.adoc
+++ b/docs/modules/clients/pages/nodejs.adoc
@@ -146,4 +146,4 @@ Raise an issue in the https://github.com/hazelcast/hazelcast-nodejs-client/issue
 For more information, see: 
 
 - Hazelcast Node.js client GitHub https://github.com/hazelcast/hazelcast-nodejs-client[repo^]
-- https://github.com/hazelcast/hazelcast-nodejs-client/tree/master/code_samples[code samples^]
+- https://github.com/hazelcast/hazelcast-nodejs-client/tree/master/code_samples[Code samples^]


### PR DESCRIPTION
Migrate technical content from the node.js readme and ref manual to the Docs site. 
See https://hazelcast.atlassian.net/browse/DOC-548

Readme is here: https://github.com/hazelcast/hazelcast-nodejs-client/blob/v5.3.0/README.md