### PR TITLE
Fix `backport` workflow permissions

### DIFF
--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -36,7 +36,7 @@ jobs:
       - if: ${{ steps.check_pr_labels.outputs.result == 'true' }}
         uses: hazelcast/backport/.github/actions/backport@master
         with:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.DEVOPSHAZELCAST_PAT_FOR_MONOREPO }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           REF_TO_BACKPORT: ${{ github.sha }}
           BACKPORT_OPTIONS: --omit-labels


### PR DESCRIPTION
The jobs [fail](https://github.com/hazelcast/hz-docs/actions/runs/16600339169/job/46957935878#logs) with permissions errors.

In `hazelcast-mono` we use an explicit token with the required permissions, but here we were using the "base" token missing some.

Updated to use the same token as `hazelcast-mono`.

Note - despite [extensive testing](https://github.com/hazelcast/hz-docs/pull/1798) I have been unable to properly test this change.