### PR TITLE
Add MULTI_MEMBER capacity planning docs [v/5.5]

### DIFF
--- a/docs/modules/ROOT/pages/capacity-planning.adoc
+++ b/docs/modules/ROOT/pages/capacity-planning.adoc
@@ -220,10 +220,12 @@ staying below these numbers. Please contact Hazelcast if you plan to
 use higher limits.
 
 * Maximum 100 clients using the `ALL_MEMBERS` cluster routing mode per member
+* Maximum 100 clients using the `MULTI_MEMBER` cluster routing mode per member
 * Maximum 1,000 clients using the `SINGLE_MEMBER` cluster routing mode per member
 * Maximum of 200GB xref:storage:high-density-memory.adoc[High-Density Memory Store] per member
 
 Clients that use the `ALL_MEMBERS` cluster routing mode maintain a connection to each member.
+Clients that use the `MULTI_MEMBER` cluster routing mode maintain connections to a subset of members in the cluster.
 Clients that use the `SINGLE_MEMBER` cluster routing mode have a single connection to the entire cluster.
 You can also choose to connect to a partition group which provides direct connections to members in that group with those members acting as a gateway to the other members in the cluster.
 You can find more information about the cluster routing modes here: xref:clients:java.adoc#java-cluster-routing-modes[Java Cluster Routing Modes].


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1809

Using same values for `ALL_MEMBERS` as it's more aligned with this. We will need to formally benchmark and revisit this in the future.

Fixes https://hazelcast.atlassian.net/browse/HZG-564