### PR TITLE
1785-java-docs-maven: add Maven dependency [v/5.5]

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -28,13 +28,29 @@ Add the `hazelcast-enterprise` dependency to your `pom.xml`:
 
 [source,xml,subs="attributes+"]
 ----
-<dependency>
-    <groupId>com.hazelcast</groupId>
-    <artifactId>hazelcast-enterprise</artifactId>
-    <version>{ee-version}</version>
-</dependency>
+<repositories>
+    <repository>
+        <id>private-repository</id>
+        <name>Hazelcast Private Repository</name>
+        <url>https://repository.hazelcast.com/snapshot/</url>
+        <releases>
+            <enabled>false</enabled>
+        </releases>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+</repositories>
+
+<dependencies>
+    <dependency>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>hazelcast-enterprise</artifactId>
+        <version>{ee-version}</version>
+    </dependency>
+</dependencies>
 ----
-NOTE: 
+ 
 --
 {open-source-product-name}:: 
 + 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1811

Added the Maven repo dependency to the java docs topic, as agreed as best strategy
Also deleted the empty note