### PR TITLE
hz-docs issue 1785 - annotate Maven install config

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -20,10 +20,10 @@ NOTE: If you have a Hazelcast {enterprise-product-name} license, you don't need 
 If you prefer to use Maven, make sure you have added the appropriate `hazelcast` or `hazelcast-enterprise` dependency to your `pom.xml`:
 
 [tabs] 
-====
--- 
+==== 
 {enterprise-product-name}:: 
-+ 
++
+--
 include::getting-started:install-enterprise.adoc[tag=maven-full-ee]
 --
 {open-source-product-name}:: 

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -20,7 +20,8 @@ NOTE: If you have a Hazelcast {enterprise-product-name} license, you don't need 
 If you prefer to use Maven, make sure you have added the appropriate `hazelcast` or `hazelcast-enterprise` dependency to your `pom.xml`:
 
 [tabs] 
-==== 
+====
+-- 
 {enterprise-product-name}:: 
 + 
 include::getting-started:install-enterprise.adoc[tag=maven-full-ee]

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -23,52 +23,12 @@ If you prefer to use Maven, make sure you have added the appropriate `hazelcast`
 ==== 
 {enterprise-product-name}:: 
 + 
---
-Add the `hazelcast-enterprise` dependency to your `pom.xml`:
-
-[source,xml,subs="attributes+"]
-----
-<repositories>
-    <repository>
-        <id>private-repository</id>
-        <name>Hazelcast Private Repository</name>
-        <url>https://repository.hazelcast.com/snapshot/</url> <1>
-        <releases>
-            <enabled>false</enabled>
-        </releases>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </repository>
-</repositories>
-
-<dependencies>
-    <dependency>
-        <groupId>com.hazelcast</groupId>
-        <artifactId>hazelcast-enterprise</artifactId> <2>
-        <version>{ee-version}</version>
-    </dependency>
-</dependencies>
-----
-<1> Specifies the location for Maven to access Hazelcast artifacts.
-<2> Specifies the Hazelcast {enterprise-product-name} dependency and version.
-
+include::getting-started:install-enterprise.adoc[tag=maven-full-ee]
 --
 {open-source-product-name}:: 
 + 
 --
-Add the `hazelcast` dependency to your `pom.xml`:
-
-[source,xml,subs="attributes+"]
-----
-<dependency>
-    <groupId>com.hazelcast</groupId>
-    <artifactId>hazelcast</artifactId> <1>
-    <version>{os-version}</version>
-</dependency>
-----
-<1> Specifies the Hazelcast {open-source-product-name} dependency and version.
-
+include::getting-started:install-hazelcast.adoc[tag=maven-full]
 --
 ====
 

--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -32,7 +32,7 @@ Add the `hazelcast-enterprise` dependency to your `pom.xml`:
     <repository>
         <id>private-repository</id>
         <name>Hazelcast Private Repository</name>
-        <url>https://repository.hazelcast.com/snapshot/</url>
+        <url>https://repository.hazelcast.com/snapshot/</url> <1>
         <releases>
             <enabled>false</enabled>
         </releases>
@@ -45,12 +45,14 @@ Add the `hazelcast-enterprise` dependency to your `pom.xml`:
 <dependencies>
     <dependency>
         <groupId>com.hazelcast</groupId>
-        <artifactId>hazelcast-enterprise</artifactId>
+        <artifactId>hazelcast-enterprise</artifactId> <2>
         <version>{ee-version}</version>
     </dependency>
 </dependencies>
 ----
- 
+<1> Specifies the location for Maven to access Hazelcast artifacts.
+<2> Specifies the Hazelcast {enterprise-product-name} dependency and version.
+
 --
 {open-source-product-name}:: 
 + 
@@ -61,10 +63,11 @@ Add the `hazelcast` dependency to your `pom.xml`:
 ----
 <dependency>
     <groupId>com.hazelcast</groupId>
-    <artifactId>hazelcast</artifactId>
+    <artifactId>hazelcast</artifactId> <1>
     <version>{os-version}</version>
 </dependency>
 ----
+<1> Specifies the Hazelcast {open-source-product-name} dependency and version.
 
 --
 ====

--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -86,7 +86,7 @@ ifdef::snapshot[]
     <repository>
         <id>private-repository</id>
         <name>Hazelcast Private Repository</name>
-        <url>https://repository.hazelcast.com/snapshot/</url>
+        <url>https://repository.hazelcast.com/snapshot/</url> <1>
         <releases>
             <enabled>false</enabled>
         </releases>
@@ -99,11 +99,13 @@ ifdef::snapshot[]
 <dependencies>
     <dependency>
         <groupId>com.hazelcast</groupId>
-        <artifactId>hazelcast-enterprise</artifactId>
+        <artifactId>hazelcast-enterprise</artifactId> <2>
         <version>{ee-version}</version>
     </dependency>
 </dependencies>
 ----
+<1> Specifies the location for Maven to access Hazelcast artifacts.
+<2> Specifies the Hazelcast {enterprise-product-name} dependency and version.
 endif::[]
 ifndef::snapshot[]
 [source,xml,subs="attributes+"]
@@ -112,7 +114,7 @@ ifndef::snapshot[]
     <repository>
         <id>private-repository</id>
         <name>Hazelcast Private Repository</name>
-        <url>https://repository.hazelcast.com/release/</url>
+        <url>https://repository.hazelcast.com/release/</url> <1>
         <releases>
             <enabled>true</enabled>
         </releases>
@@ -125,11 +127,13 @@ ifndef::snapshot[]
 <dependencies>
     <dependency>
         <groupId>com.hazelcast</groupId>
-        <artifactId>hazelcast-enterprise</artifactId>
+        <artifactId>hazelcast-enterprise</artifactId> <2>
         <version>{ee-version}</version>
     </dependency>
 </dependencies>
 ----
+<1> Specifies the location for Maven to access Hazelcast artifacts.
+<2> Specifies the Hazelcast {enterprise-product-name} dependency and version.
 endif::[]
 // end::maven-full-ee[]
 --

--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -85,7 +85,7 @@ ifdef::snapshot[]
 <repositories>
     <repository>
         <id>private-repository</id>
-        <name>Hazelcast Private Repository</name>
+        <name>Hazelcast Private Release Repository</name>
         <url>https://repository.hazelcast.com/snapshot/</url> <1>
         <releases>
             <enabled>false</enabled>
@@ -100,12 +100,10 @@ ifdef::snapshot[]
     <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-enterprise</artifactId> <2>
-        <version>{ee-version}</version>
+        <version>{ee-version}</version> <3>
     </dependency>
 </dependencies>
 ----
-<1> Specifies the location for Maven to access Hazelcast artifacts.
-<2> Specifies the Hazelcast {enterprise-product-name} dependency and version.
 endif::[]
 ifndef::snapshot[]
 [source,xml,subs="attributes+"]
@@ -113,7 +111,7 @@ ifndef::snapshot[]
 <repositories>
     <repository>
         <id>private-repository</id>
-        <name>Hazelcast Private Repository</name>
+        <name>Hazelcast Private Snapshot Repository</name>
         <url>https://repository.hazelcast.com/release/</url> <1>
         <releases>
             <enabled>true</enabled>
@@ -128,13 +126,14 @@ ifndef::snapshot[]
     <dependency>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-enterprise</artifactId> <2>
-        <version>{ee-version}</version>
+        <version>{ee-version}</version> <3>
     </dependency>
 </dependencies>
 ----
-<1> Specifies the location for Maven to access Hazelcast artifacts.
-<2> Specifies the Hazelcast {enterprise-product-name} dependency and version.
 endif::[]
+<1> Location for Maven to access Hazelcast artifacts.
+<2> Hazelcast {enterprise-product-name} dependency.
+<3> Hazelcast {enterprise-product-name} version.
 // end::maven-full-ee[]
 --
 

--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -85,14 +85,11 @@ ifdef::snapshot[]
 <repositories>
     <repository>
         <id>private-repository</id>
-        <name>Hazelcast Private Release Repository</name>
+        <name>Hazelcast Private Snapshot Repository</name>
         <url>https://repository.hazelcast.com/snapshot/</url> <1>
         <releases>
             <enabled>false</enabled>
         </releases>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
     </repository>
 </repositories>
 
@@ -111,11 +108,8 @@ ifndef::snapshot[]
 <repositories>
     <repository>
         <id>private-repository</id>
-        <name>Hazelcast Private Snapshot Repository</name>
+        <name>Hazelcast Private Release Repository</name>
         <url>https://repository.hazelcast.com/release/</url> <1>
-        <releases>
-            <enabled>true</enabled>
-        </releases>
         <snapshots>
             <enabled>false</enabled>
         </snapshots>

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -168,11 +168,12 @@ The Java package includes both a member API and a Java client API. The member AP
 <dependencies>
    <dependency>
        <groupId>com.hazelcast</groupId>
-       <artifactId>hazelcast</artifactId>
+       <artifactId>hazelcast</artifactId> <1>
        <version>{os-version}</version>
    </dependency>
 </dependencies>
 ----
+<1> Specifies the Hazelcast {open-source-product-name} dependency and version.
 
 // end::maven-full[]
 --

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -169,11 +169,12 @@ The Java package includes both a member API and a Java client API. The member AP
    <dependency>
        <groupId>com.hazelcast</groupId>
        <artifactId>hazelcast</artifactId> <1>
-       <version>{os-version}</version>
+       <version>{os-version}</version> <2>
    </dependency>
 </dependencies>
 ----
-<1> Specifies the Hazelcast {open-source-product-name} dependency and version.
+<1> Hazelcast {open-source-product-name} dependency.
+<2> Hazelcast {open-source-product-name} version.
 
 // end::maven-full[]
 --


### PR DESCRIPTION
Follow on from https://github.com/hazelcast/hz-docs/pull/1811 to explain the config.

Community Edition doesn't require specifying our repo because it's hosted on Maven Central, but I don't think we need to explain that difference between the two editions because we prompt users to choose one or the other.

Not an entirely accurate use of in-line annotations but seemed the neatest way to do it. Switched to includes to avoid duplication in source.

https://github.com/hazelcast/hz-docs/issues/1785