### PR TITLE
1774-docs-feedback-for-community-edition-rest-api: added Ent API info

### DIFF
--- a/docs/modules/maintain-cluster/pages/monitoring.adoc
+++ b/docs/modules/maintain-cluster/pages/monitoring.adoc
@@ -930,11 +930,26 @@ See the https://docs.hazelcast.org/docs/{os-version}/javadoc/com/hazelcast/execu
 
 == Health Check and Monitoring
 
-Hazelcast provides the following options for monitoring the health of your Hazelcast clusters:
+The Hazelcast health check feature provides you with tools to monitor the health and status of your Hazelcast clusters
+to ensure these are running smoothly, to identify issues early, and maintain high availability and reliability. 
+
+The following options are provided for monitoring the health of your Hazelcast clusters:
 
 * HTTP-based health check endpoint
 * Health check script
 * Health monitoring utility
+
+// Melike: is the health check script and health monitoring utility available only for the Community Edition REST API or
+// are these also available with the Enterprise REST API once enabled? 
+// I may have to re-order this section depending on the answer.
+
+How you enable the health check endpoint depends on whether you are using the {open-source-product-name} or {enterprise-product-name} REST API. 
+
+For information about using the Enterprise REST API, see: https://docs.hazelcast.com/hazelcast/latest/getting-started/get-started-rest-api-with-java. After enabling the Enterprise REST API, you can reach all the endpoints—including the health check ones—without further configuration. To see the available endpoints, and learn more about how to make a request and the expected responses etc., refer to the https://docs.hazelcast.com/hazelcast/latest/maintain-cluster/rest-api-swagger#tag/Health-Controller[Swagger documentation].
+
+If you are using the Community Edition REST API, follow the steps below to use the health check feature. 
+
+include::clients:partial$rest-deprecation.adoc[]
 
 [[enable-hcheck]]
 === Enabling the Health Check Endpoint and Script


### PR DESCRIPTION
As agreed with Melike: added information for Enterprise Edition customers about how to use the health check endpoint, and made it clearer that the existing content is for Community Edition customers. 
Added deprecation notice for Community Rest API
