### PR TITLE
Relabel `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT` [CTT-504]

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -3,7 +3,7 @@
 site:
 #  title: Documentation
   url: https://hardcore-allen-f5257d.netlify.app/
-  start_page: 6.0-snapshot@hazelcast:ROOT:what-is-hazelcast.adoc
+  start_page: 5.6-snapshot@hazelcast:ROOT:what-is-hazelcast.adoc
   robots: disallow
 #  keys:
 #    docsearch_id: 'QK2EAH8GB0'

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,20 +1,20 @@
 name: hazelcast
 title: Hazelcast Platform
 # Version in the URL (minor.patch version)
-version: '6.0-snapshot'
+version: '5.6-snapshot'
 # Version in the version selector (we display only the latest major.minor version)
-display_version: '6.0-SNAPSHOT'
+display_version: '5.6-SNAPSHOT'
 # Displays a banner to inform users that this is a prerelease version 
 prerelease: true
 asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
-    full-version: '6.0.0-SNAPSHOT'
-    os-version: '6.0.0-SNAPSHOT'
-    ee-version: '6.0.0-SNAPSHOT'
+    full-version: '5.6.0-SNAPSHOT'
+    os-version: '5.6.0-SNAPSHOT'
+    ee-version: '5.6.0-SNAPSHOT'
     jet-version: '4.5.4'
     # Same as `version` above but as an asciidoc attribute
-    version: '6.0-SNAPSHOT'
+    version: '5.6-SNAPSHOT'
     java-client-standalone-version: '5.5.0-BETA'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true


### PR DESCRIPTION
Renames the version on `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT`.

Supports https://github.com/hazelcast/hazelcast-mono/pull/4852

Fixes: [CTT-504](https://hazelcast.atlassian.net/browse/CTT-504)