### PR TITLE
1256-docs-feedback-for-deploy-blue-green-clusters: corrected text

### DIFF
--- a/docs/modules/getting-started/pages/blue-green.adoc
+++ b/docs/modules/getting-started/pages/blue-green.adoc
@@ -41,7 +41,7 @@ To complete this tutorial, you need the following:
 
 == Step 1. Start the Blue {enterprise-product-name} Cluster
 
-In this step, you use the Hazelcast {enterprise-product-name}{enterprise-product-name} Docker image to start a local single-member cluster called `blue`.
+In this step, you use the Hazelcast {enterprise-product-name} Docker image to start a local single-member cluster called `blue`.
 This step also installs your {enterprise-product-name} license key.
 
 Run the following command on the terminal:


### PR DESCRIPTION
Corrected the text in Step 1 (caused by the addition of an extra variable) and double-checked the link to the MC docs which looks OK (uses this variable in the antora file: page-latest-supported-mc: '6.0-snapshot')