### PR TITLE
1279-docs-feedback-for-list-of-hazelcast-metrics: added note

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -1460,6 +1460,8 @@ This is because the cluster has to communicate with more members, which can add 
 
 |===
 
+NOTE: CP Subsystem metrics are {enterprise-product-name} only.
+
 We also have per-object type a `summary` section which provides live and destroyed object counts grouped by CP Group. These can be found under `cp.{atomiclong,atomicref,countdownlatch,lock,map,semaphore}.summary` and provide the following child attributes.
 
 [cols="4,1,6a"]


### PR DESCRIPTION
For Docs ticket: 1279

Added a note to state CP Subsystem metrics are Enterprise Edition only.

The position of the note can't be higher up without breaking the table because of the way asciidoc behaves.