### PR TITLE
1824-docs-feedback-for-advanced-features: improved description [v/5.5]

### DIFF
--- a/docs/modules/wan/pages/advanced-features.adoc
+++ b/docs/modules/wan/pages/advanced-features.adoc
@@ -1154,7 +1154,7 @@ differently.
 
 The processing behavior is configured using the `consumer` element. It has the following sub-elements:
 
-* `persist-wan-replicated-data`: When set to `true`, an incoming event over WAN replication can be persisted to a database for example, otherwise it is not persisted. Default value is `false`.
+* `persist-wan-replicated-data`: When set to `true`, incoming WAN events received on the target cluster will be passed to the configured MapStore (if present), allowing the data to be persisted to the external system defined by the MapStore implementation. When set to `false` (the default), WAN events are applied only to the in-memory data structures and are not passed to MapStore, so no persistence to the external system occurs as a result of WAN replication. This setting allows you to control whether WAN-replicated data should be synchronized with your external data store via MapStore, or kept only in memory on the target cluster.
 
 [[securing-wan-connections]]
 == Securing the Connections for WAN Replication


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1832

For Docs ticket: https://github.com/hazelcast/hz-docs/issues/1824

The current documentation for the persist-wan-replicated-data setting describes its effect in general terms, stating that when set to true, incoming WAN events can be persisted to a database, but it does not explicitly mention the relationship to MapStore or how this setting interacts with MapStore processing.

The task is to improve the description to make this clearer. 

@jszap Please check you are happy with this new description. Thank you!