### PR TITLE
1279-docs-feedback-for-list-of-hazelcast-metrics: added note [v/5.5]

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -1370,7 +1370,9 @@ This is because the cluster has to communicate with more members, which can add 
 |Version number of the CP session, basically it shows how many times the session heartbeat is received
 |===
 
-We also have per-object type a `summary` section which provides live and destroyed object counts grouped by CP Group. These can be found under `cp.{atomiclong,atomicref,countdownlatch,lock,map,semaphore}.summary` and provide the following child attributes.
+NOTE: CP Subsystem metrics are {enterprise-product-name} only.
+
+We also have a `summary` section per object type which provides live and destroyed object counts grouped by CP Group. These can be found under `cp.{atomiclong,atomicref,countdownlatch,lock,map,semaphore}.summary` and provide the following child attributes:
 
 [cols="4,1,6a"]
 |===


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1834

For Docs ticket: 1279

Added a note to state CP Subsystem metrics are Enterprise Edition only.

The position of the note can't be higher up without breaking the table because of the way asciidoc behaves.