### PR TITLE
Update Maven central URL

### DIFF
--- a/docs/modules/deploy/pages/deploying-with-docker.adoc
+++ b/docs/modules/deploy/pages/deploying-with-docker.adoc
@@ -251,7 +251,7 @@ This example creates a Docker image for Hazelcast with the Kafka extension.
 ----
 FROM hazelcast:{os-version}-slim
 ARG HZ_HOME=/opt/hazelcast
-ARG REPO_URL=https://repo1.maven.org/maven2/com/hazelcast/jet
+ARG REPO_URL=https://repo.maven.apache.org/maven2/com/hazelcast/jet
 ADD $REPO_URL/hazelcast-jet-kafka/{os-version}/hazelcast-jet-kafka-{os-version}-jar-with-dependencies.jar $HZ_HOME/lib/
 # ... more ADD statements ...
 ----

--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -187,7 +187,7 @@ ifndef::snapshot[]
 
 If you aren't using a build tool:
 
-* link:https://repo1.maven.org/maven2/com/hazelcast/hazelcast/{os-version}/hazelcast-{os-version}.jar[download the Hazelcast JAR file]
+* link:https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast/{os-version}/hazelcast-{os-version}.jar[download the Hazelcast JAR file]
 * add it to your classpath.
 endif::[]
 


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/MNG-5151 Maven updated the default URL from `repo1.maven.org/maven2` -> `repo.maven.apache.org/maven2`.

Updated references to suit.