### PR TITLE
1261-docs-feedback-for-rolling-upgrades: clarified rolling upgrades &…

### DIFF
--- a/docs/modules/maintain-cluster/pages/rolling-upgrades.adoc
+++ b/docs/modules/maintain-cluster/pages/rolling-upgrades.adoc
@@ -56,9 +56,9 @@ cluster version are always compatible, regardless of patch version.
 
 - Each minor version is compatible with the previous one.
 
-As a result, you can use rolling upgrades to upgrade clusters to the following member codebase versions:
+As a result, you can use rolling upgrades to upgrade clusters to the following member codebase versions within the same edition ({open-source-product-name} to {open-source-product-name} or {enterprise-product-name} to {enterprise-product-name} only):
 
-- A new patch version of the same major and minor version ({open-source-product-name} and {enterprise-product-name})
+- A new patch version of the same major and minor version ({open-source-product-name} or {enterprise-product-name})
 - The next minor version of the same major version ({enterprise-product-name} only)
 +
 This also includes the ability of rolling upgrade from Hazelcast IMDG 4.2 to Platform 5.0, since IMDG is part of the Platform and 5.0 is considered to be the next minor version after IMDG 4.2.


### PR DESCRIPTION
Fix to address the reported confusion arising because the compatibility guarantee for rolling upgrades between patch versions does not explicitly state that this applies only within the same edition (Community or Enterprise), and not for upgrades from Community Edition (OSS) to Enterprise Edition. 