### PR TITLE
Use EE version in hazelcast-spring dependency

### DIFF
--- a/docs/modules/spring/pages/configuration.adoc
+++ b/docs/modules/spring/pages/configuration.adoc
@@ -33,7 +33,7 @@ To enable Spring integration:
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-spring</artifactId>
-    <version>{os-version}</version>
+    <version>{ee-version}</version>
     <exclusions>
         <exclusion>
           <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
EE example should use most up-to-date patched version of `hazelcast-spring`.

Currently the discrepancy is visible in 5.5 docs (5.5.0 vs 5.5.7)