### PR TITLE
Remove enterprise refs from metrics page

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -511,7 +511,7 @@ This is because the cluster has to communicate with more members, which can add 
 |===
 ====
 
-.Vector Collection (Beta) [.enterprise]*{enterprise-product-name}*
+.Vector Collection (Beta)
 [%collapsible]
 ====
 [cols="4,1,6a"]
@@ -1459,8 +1459,6 @@ This is because the cluster has to communicate with more members, which can add 
 |Version number of the CP session, basically it shows how many times the session heartbeat is received
 
 |===
-
-NOTE: CP Subsystem metrics are {enterprise-product-name} only.
 
 We also have a `summary` section per object type which provides live and destroyed object counts grouped by CP Group. These can be found under `cp.{atomiclong,atomicref,countdownlatch,lock,map,semaphore}.summary` and provide the following child attributes:
 


### PR DESCRIPTION
It's applied inconsistently and there's no need to note which features are EE in this context. You get metrics for features you use, EE, or otherwise.