### PR TITLE
Correctly mark new CDC connector as EE feature [v/5.5]

### DIFF
--- a/docs/modules/integrate/pages/cdc-connectors.adoc
+++ b/docs/modules/integrate/pages/cdc-connectors.adoc
@@ -1,5 +1,5 @@
 = CDC Connector
-[.enterprise]*Enterprise*
+:page-enterprise: true
 
 NOTE: This page refers to Hazelcast's {enterprise-product-name} CDC connectors. For more information on {open-source-product-name} CDC connectors, see xref:integrate:legacy-cdc-connectors.adoc[].
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1858

Enterprise marker was not rendered