### PR TITLE
Add complete example how to invoke embedding model from Jet pipeline [v/5.5]

### DIFF
--- a/docs/modules/integrate/pages/vector-collection-connector.adoc
+++ b/docs/modules/integrate/pages/vector-collection-connector.adoc
@@ -56,3 +56,27 @@ p.readFrom(TestSources.items("text to search for"))
   // use the results
   .writeTo(Sinks.logger());
 ```
+
+== Embedding Models
+
+The examples above use the `all-minilm-l6-v2` model via a langchain4j binding for ONNX, but any embedding model can be invoked from a Jet pipeline in a similar way.
+
+The embedding model requires adding a dependency:
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
+    <version>0.30.0</version>
+</dependency>
+```
+
+The dependency must be provided on the member classpath or, for smaller models, uploaded in job resources.
+
+The embedding model is defined as a non-cooperative Jet service because the embedding computation can take some time.
+
+```java
+ServiceFactory<?, AllMiniLmL6V2EmbeddingModel> getAllMiniLmL6V2EmbeddingModelServiceFactory() {
+    return ServiceFactories.sharedService(c -> new AllMiniLmL6V2EmbeddingModel()).toNonCooperative();
+}
+```


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1859

ServiceFactory definition was missing from the docs