### PR TITLE
Improve `Queue` `empty-queue-ttl` property description [v/5.5]

### DIFF
--- a/docs/modules/data-structures/pages/queue.adoc
+++ b/docs/modules/data-structures/pages/queue.adoc
@@ -626,9 +626,7 @@ A queue can also have asynchronous backups: you can define the number of
 asynchronous backups using the `async-backup-count` element.
 
 To set the maximum size of the queue, use the `max-size` element.
-To purge unused or empty queues after a period of time, use the `empty-queue-ttl` element.
-If you define a value (time in seconds) for the `empty-queue-ttl` element,
-then your queue will be destroyed if it stays empty or unused for the time in seconds that you give.
+To destroy empty queues after a period of time, use the `empty-queue-ttl` element.
 
 The following is the full list of queue configuration elements with their descriptions:
 
@@ -641,9 +639,8 @@ data structure, so all entries of a queue reside in one partition. When this
 parameter is '1', it means there will be one backup of that queue in another
 member in the cluster. When it is '2', two members will have the backup.
 * `async-backup-count`: Number of asynchronous backups.
-* `empty-queue-ttl`: Used to purge unused or empty queues. If you define a
-value (time in seconds) for this element, then your queue will be destroyed
-if it stays empty or unused for that time.
+* `empty-queue-ttl`: Used to destroy the queue once items have been removed and it has been empty empty for a given amount of time (seconds).
+Has no effect until the queue has been populated.
 * `item-listeners`: Adds listeners (listener classes) for the queue items.
 You can also set the attribute `include-value` to `true` if you want the item
 event to contain the item values. You can set `local` to `true` if you want to


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1863

[The documentation](https://docs.hazelcast.com/hazelcast/latest/data-structures/queue#configuring-queue) says:
> Used to purge unused or empty queues {...} your queue will be destroyed if it stays empty or unused for that time.

The scheduled eviction task was _only_ triggered when elements were removed, not when the `Queue` was first constructed - so unused `Queue`s would not be removed.

Changes:
- replace `purge` with `destory` for consistency with other pages
- remove duplicated description
- explain the nuance

Also updated the [Javadoc](https://github.com/hazelcast/hazelcast-mono/pull/4991).

Note - there was [a discussion on changing the implementation](https://github.com/hazelcast/hazelcast-mono/pull/4943) but as a change in behaviour / breaking change, safer to document the _actual_ behaviour.

Fixes: https://github.com/hazelcast/hazelcast/issues/26525, https://github.com/hazelcast/imdg-docs/issues/310