### PR TITLE
1219-docs-feedback-for lts-releases: note added

### DIFF
--- a/docs/modules/migrate/pages/lts.adoc
+++ b/docs/modules/migrate/pages/lts.adoc
@@ -6,7 +6,8 @@
 
 LTS releases have been introduced with Hazelcast Platform 5.5. You can upgrade directly from 5.2 or later to 5.5 without the need to upgrade to each release between your current version and the LTS release. We recommend that you upgrade to 5.5 from the latest available patch for your current release.
 
-NOTE: Features marked as Beta in the source version are upgraded, but are supported only in a cluster of the source version due to changes that can occur between releases. For further information on rolling upgrade compatibilities, see xref:maintain-cluster:rolling-upgrades.adoc#hazelcast-members-compatibility[Upgrade Compatibility].
+NOTE: Long-term support (LTS) releases are available only with the {enterprise-product-name}. LTS requires the xref:maintain-cluster:rolling-upgrades.adoc[Rolling Upgrade] feature, which allows you to upgrade one member at a time without downtime. The {open-source-product-name} does not include Rolling Upgrade and does not receive patch releases including CVE fixes. 
+In addition, features marked as Beta in the source version are upgraded, but are supported only in a cluster of the source version due to changes that can occur between releases. For further information on rolling upgrade compatibilities, see xref:maintain-cluster:rolling-upgrades.adoc#hazelcast-members-compatibility[Upgrade Compatibility].
 
 Between LTS releases, Hazelcast will provide short-term support (STS) releases. You can choose to upgrade directly from one LTS to the next LTS, or you can upgrade from one LTS to each STS release and then from the last STS release to the next LTS release. Before deciding the approach that best suits your needs, consider the following:
 


### PR DESCRIPTION
As agreed with JamesG, add the following note for clarity:

"Long-term support (LTS) releases are available only with the Enterprise Edition.  LTS requires the Rolling Upgrade feature, which allows you to upgrade one member at a time without downtime. The Community Edition does not include Rolling Upgrade and does not receive patch releases including CVE fixes". 

