### PR TITLE
1140-docs-feedback-HD-memory-store: change size to capacity [v/5.4]

### DIFF
--- a/docs/modules/storage/pages/high-density-memory.adoc
+++ b/docs/modules/storage/pages/high-density-memory.adoc
@@ -50,7 +50,7 @@ block size, page size and metadata space percentage.
 
 The following are the configuration element descriptions:
 
-* **size:** Size of the total native memory to allocate in megabytes.
+* **capacity:** The total native memory capacity to allocate.
 Its default value is **512 MB**.
 * **allocator type**: Type of the memory allocator. Available values are as follows:
 ** **STANDARD**: This option is used internally by Hazelcast's
@@ -117,7 +117,7 @@ XML::
 <hazelcast>
     ...
     <native-memory allocator-type="POOLED" enabled="true">
-        <size unit="MEGABYTES" value="512"/>
+        <capacity unit="MEGABYTES" value="512"/>
         <min-block-size>16</min-block-size>
         <page-size>4194304</page-size>
         <metadata-space-percentage>12.5</metadata-space-percentage>
@@ -141,7 +141,7 @@ hazelcast:
   native-memory:
     enabled: true
     allocator-type: POOLED
-    size:
+    capacity:
       unit: MEGABYTES
       value: 512
     min-block-size: 16


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1869

For Docs ticket: https://github.com/hazelcast/hz-docs/issues/1140, swap the "size" attribute (which has been deprecated) for "capacity" in the description and in the declarative configuration example.