### PR TITLE
Drop patch numbers from supported Spring framework versions

### DIFF
--- a/docs/modules/spring/pages/overview.adoc
+++ b/docs/modules/spring/pages/overview.adoc
@@ -26,8 +26,4 @@ You can embed Hazelcast members in the same Java process as your Spring applicat
 
 == Supported versions
 
-Hazelcast supports the following Spring Framework versions:
-
-* **Supported**: 5.3
-
-* **Latest tested**: 6.2
+Hazelcast supports Spring Framework `6.2` and `5.3`.


### PR DESCRIPTION
- we can trust that if we support _a_ patch version of Spring, we support all in the same minor
- avoids updating the documentation every time a patch is released