### PR TITLE
Update map-join.adoc for jet code sample version

### DIFF
--- a/docs/modules/pipelines/pages/map-join.adoc
+++ b/docs/modules/pipelines/pages/map-join.adoc
@@ -50,7 +50,7 @@ We'll assume you're using an IDE. Create a blank Java project named
         <dependency>
             <groupId>com.hazelcast.samples.jet</groupId>
             <artifactId>jet-trade-source</artifactId>
-            <version>{os-version}</version>
+            <version>0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
For Doc bug: https://github.com/hazelcast/hz-docs/issues/580
Description: Error "Could not find artifact com.hazelcast.samples.jet:hazelcast-jet-examples-trade-source”
Fix: Update {jet-version} to: {os-version}