### PR TITLE
Remove hardcoded `5.5` versions

### DIFF
--- a/docs/modules/integrate/pages/cdc-connectors.adoc
+++ b/docs/modules/integrate/pages/cdc-connectors.adoc
@@ -26,7 +26,7 @@ To use this connector in a Maven project, add the following entries to the `<dep
 
 Generic connector:
 
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <dependency>
     <groupId>com.hazelcast.jet</groupId>
@@ -37,7 +37,7 @@ Generic connector:
 
 MySQL-specific connector:
 
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <dependency>
     <groupId>com.hazelcast.jet</groupId>
@@ -49,7 +49,7 @@ NOTE: Due to licensing, MySQL connector does not include the MySQL driver as a d
 
 PostgreSQL-specific connector:
 
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <dependency>
     <groupId>com.hazelcast.jet</groupId>

--- a/docs/modules/integrate/pages/integrate-with-vertx.adoc
+++ b/docs/modules/integrate/pages/integrate-with-vertx.adoc
@@ -43,7 +43,7 @@ NOTE: Older versions may not be supported by Hazelcast or receive any patches.
 
 There are multiple ways to replace the transitive dependency. The most reliable way is to exclude the `com.hazelcast:hazelcast` transitive dependency of the `vertx-hazelcast` module and add a direct dependency on `com.hazelcast:hazelcast` to the pom.xml of your project.
 
-[source,xml]
+[source,xml,subs="attributes+"]
 ----
 <dependency>
   <groupId>io.vertx</groupId>

--- a/docs/modules/integrate/pages/integrate-with-vertx.adoc
+++ b/docs/modules/integrate/pages/integrate-with-vertx.adoc
@@ -58,6 +58,6 @@ There are multiple ways to replace the transitive dependency. The most reliable 
 <dependency>
   <groupId>com.hazelcast</groupId>
   <artifactId>hazelcast</artifactId>
-  <version>5.5.0</version>
+  <version>{os-version}</version>
 </dependency>
 ----

--- a/docs/modules/maintain-cluster/pages/enterprise-rest-api.adoc
+++ b/docs/modules/maintain-cluster/pages/enterprise-rest-api.adoc
@@ -472,7 +472,7 @@ If successful the following response is returned:
       "liteMember": false,
       "localMember": true,
       "uuid": "3d8b9c35-a35f-461a-9e7f-d64e3f1f0f03",
-      "memberVersion": "5.5.0"
+      "memberVersion": "{ee-version}"
     }
   ],
   "clientCount": 0,

--- a/docs/modules/maintain-cluster/pages/enterprise-rest-api.adoc
+++ b/docs/modules/maintain-cluster/pages/enterprise-rest-api.adoc
@@ -463,7 +463,7 @@ curl -X 'GET' \
 
 If successful the following response is returned:
 
-[source,json]
+[source,json,subs="attributes+"]
 ----
 {
   "members": [


### PR DESCRIPTION
And fix a couple of other non-resolving references.

Post-merge actions:
- [ ] backport to `5.6.0`.