### PR TITLE
Update map-join.adoc for jet code sample version [v/5.5]

### DIFF
--- a/docs/modules/pipelines/pages/map-join.adoc
+++ b/docs/modules/pipelines/pages/map-join.adoc
@@ -87,8 +87,8 @@ Maven::
         </dependency>
         <dependency>
             <groupId>com.hazelcast.samples.jet</groupId>
-            <artifactId>hazelcast-jet-examples-trade-source</artifactId>
-            <version>{jet-version}</version>
+            <artifactId>jet-trade-source</artifactId>
+            <version>0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1883

For Doc bug: https://github.com/hazelcast/hz-docs/issues/580
Description: Error "Could not find artifact com.hazelcast.samples.jet:hazelcast-jet-examples-trade-source”
Fix: Update {jet-version} to: {os-version}