### PR TITLE
Warning that MySQL 5.7 does not support exactly-once processing [CTT-429]

### DIFF
--- a/docs/modules/integrate/pages/jdbc-connector.adoc
+++ b/docs/modules/integrate/pages/jdbc-connector.adoc
@@ -143,3 +143,5 @@ some records will be missing from the target database. To test your
 broker we provide a tool, please go to link:https://github.com/hazelcast/hazelcast-jet-contrib/tree/master/xa-test[XA tests]
 to get more information. This only applies to the JDBC sink, the source
 doesn't use XA transactions.
+
+WARNING: The exactly-once processing guarantee is not supported in MySQL 5.7 due to a https://bugs.mysql.com/bug.php?id=87836[known bug in that version] which will not be fixed. Please use MySQL 8 or above, as recommended by Oracle.

--- a/docs/modules/integrate/pages/jdbc-connector.adoc
+++ b/docs/modules/integrate/pages/jdbc-connector.adoc
@@ -144,4 +144,4 @@ broker we provide a tool, please go to link:https://github.com/hazelcast/hazelca
 to get more information. This only applies to the JDBC sink, the source
 doesn't use XA transactions.
 
-WARNING: The exactly-once processing guarantee is not supported in MySQL 5.7 due to a https://bugs.mysql.com/bug.php?id=87836[known bug in that version] which will not be fixed. Please use MySQL 8 or above, as recommended by Oracle.
+WARNING: The exactly-once processing guarantee is not supported in MySQL 5.7 due to a https://bugs.mysql.com/bug.php?id=87836[known bug in that version] which will not be fixed. Due to this, as well as the age and lack of support for MySQL 5.7, it is no longer supported by Hazelcast. Please use MySQL 8 or above, as recommended by Oracle.

--- a/docs/modules/integrate/pages/jdbc-connector.adoc
+++ b/docs/modules/integrate/pages/jdbc-connector.adoc
@@ -144,4 +144,4 @@ broker we provide a tool, please go to link:https://github.com/hazelcast/hazelca
 to get more information. This only applies to the JDBC sink, the source
 doesn't use XA transactions.
 
-WARNING: The exactly-once processing guarantee is not supported in MySQL 5.7 due to a https://bugs.mysql.com/bug.php?id=87836[known bug in that version]. MySQL 5.7 is not supported by Hazelcast. Please use MySQL 8 or above, as recommended by Oracle.
+WARNING: MySQL 5.7 is not supported by Hazelcast. Please use MySQL 8 or above, as recommended by Oracle. Due to a https://bugs.mysql.com/bug.php?id=87836[known bug in MySQL 5.7] the exactly-once processing guarantee does not work with MySQL 5.7. 

--- a/docs/modules/integrate/pages/jdbc-connector.adoc
+++ b/docs/modules/integrate/pages/jdbc-connector.adoc
@@ -144,4 +144,4 @@ broker we provide a tool, please go to link:https://github.com/hazelcast/hazelca
 to get more information. This only applies to the JDBC sink, the source
 doesn't use XA transactions.
 
-WARNING: The exactly-once processing guarantee is not supported in MySQL 5.7 due to a https://bugs.mysql.com/bug.php?id=87836[known bug in that version] which will not be fixed. Due to this, as well as the age and lack of support for MySQL 5.7, it is no longer supported by Hazelcast. Please use MySQL 8 or above, as recommended by Oracle.
+WARNING: The exactly-once processing guarantee is not supported in MySQL 5.7 due to a https://bugs.mysql.com/bug.php?id=87836[known bug in that version]. MySQL 5.7 is not supported by Hazelcast. Please use MySQL 8 or above, as recommended by Oracle.


### PR DESCRIPTION
It was discovered that a bug in MySQL 5.7 can break this guarantee - since it will not be fixed, we are recommending that users upgrade to MySQL 8 or above.

Fixes docs for https://hazelcast.atlassian.net/browse/CTT-429