### PR TITLE
DOC-606: update artifacts to latest

### DIFF
--- a/docs/modules/pipelines/pages/windowing.adoc
+++ b/docs/modules/pipelines/pages/windowing.adoc
@@ -27,8 +27,12 @@ To complete this tutorial, you need the following:
 == Step 1. Create a New Java Project
 
 We'll assume you're using an IDE. Create a blank Java project named
-`trade-monitor` and copy the Maven file
-into it:
+`trade-monitor` and copy the Maven file into it:
+
+// AUTHORS NOTE: if we are to tell them to use mvn clean install to build the project, where
+// should this go? Here or later in the process, such as line 203 instead of mvn package? 
+// For example "Run mvn clean install to make sure you can build the project and get its artifacts locally."
+// Does that sound OK? If so, I will apply the same chnage in the map-join.adoc file which is similar.
 
 -- 
 [source,xml,subs="attributes+"]
@@ -50,12 +54,12 @@ into it:
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
-            <version>{jet-version}</version>
+            <version>{os-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.samples.jet</groupId>
-            <artifactId>hazelcast-jet-examples-trade-source</artifactId>
-            <version>{jet-version}</version>
+            <artifactId>jet-trade-source</artifactId>
+            <version>0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
For https://hazelcast.atlassian.net/browse/DOC-606

Apply same changes to windowing.adoc as per #580 (https://github.com/hazelcast/hz-docs/pull/1883) which corrected the artifacts for the samples so these point to the correct versions.  Affects lines 57 & 58 in windowing.adoc 

@k-jamroz  Please also take a look at the authors question on line 32:

// AUTHORS NOTE: if we are to tell them to use mvn clean install to build the project, where
// should this go? Here or later in the process, such as line 203 instead of mvn package? 
// For example "Run mvn clean install to make sure you can build the project and get its artifacts locally."
// Does that sound OK? If so, I will apply the same chnage in the map-join.adoc file which is similar.

Please advise