### PR TITLE
Fix example formatting for vector collection

### DIFF
--- a/docs/modules/data-structures/pages/vector-collections.adoc
+++ b/docs/modules/data-structures/pages/vector-collections.adoc
@@ -26,6 +26,7 @@ If you use Docker, you can use the following example command:
 docker run -p 5701:5701 -e HZ_LICENSEKEY=<YOUR_LICENSE_KEY> \
      -e "JAVA_OPTS=--add-modules jdk.incubator.vector" \
      hazelcast/hazelcast-enterprise:{ee-version}-slim
+----
 
 Replace the `<YOUR_LICENSE_KEY>` placeholder with your Hazelcast {enterprise-product-name} license key.
 


### PR DESCRIPTION
The marker was accidentally removed in https://github.com/hazelcast/hz-docs/pull/1784/files#diff-d656cee55b8c9c0888769f3fd4754c7fabb5c060b5f85881eef17b59e44858fcL29