### PR TITLE
Mixing strings and numbers is not supported in PredicateAPI queries [SUP-966]

### DIFF
--- a/docs/modules/query/pages/predicate-overview.adoc
+++ b/docs/modules/query/pages/predicate-overview.adoc
@@ -307,8 +307,8 @@ as `String`, `boolean` and `null`, respectively. We treat the extracted
 as `double`.
 
 WARNING: Mixing types of numeric values of the attribute (e.g. short, int, double) is supported in Predicate API queries,
-but mixing numbers and strings is not supported and may produce incorrect results of queries.
-This is particularly easy mistake to make when using JSON as just adding or removing quotation marks changes the type.
+but mixing numbers and strings is not supported and queries may produce incorrect results.
+This is an easy mistake to make when using JSON as simply adding or removing quotation marks changes the type.
 However, the same applies to all other value kinds, like POJOs or Compact-serialized values.
 
 It is possible to query nested attributes and arrays in JSON documents, using the Predicates API.


### PR DESCRIPTION
For more details see https://github.com/hazelcast/hazelcast-mono/pull/4847