### PR TITLE
Update invalidation docs for Near Cache [CTT-412] [v/5.5]

### DIFF
--- a/docs/modules/cluster-performance/pages/near-cache.adoc
+++ b/docs/modules/cluster-performance/pages/near-cache.adoc
@@ -15,7 +15,7 @@ Benefits:
 Costs:
 
 * Increased memory consumption in the local JVM.
-* High invalidation rates can outweigh the benefits of locality of reference.
+* High invalidation rates can outweigh the benefits from locality of reference.
 * Strong consistency is not maintained; you might read stale data.
 
 Map or Cache entries in Hazelcast are partitioned across the cluster members.
@@ -588,6 +588,11 @@ a background process sends them periodically. Its default value is `10` seconds.
 
 If there are a lot of clients or many mutating operations, batching should remain enabled and
 the batch size should be configured with the `hazelcast.map.invalidation.batch.size` system property to a suitable value.
+
+NOTE: Near Cache invalidation is triggered only by user-initiated entry updates or removals. System operations (such as IMap
+expirations or evictions) do NOT trigger Near Cache invalidation. Since evictions are typically acceptable for Near Cache use
+cases, this behavior is intentional. If you need entries to expire from the Near Cache, configure expiration directly on the
+Near Cache itself.
 
 == Near Cache Consistency
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1917

Adds clarity regarding system operations which evict/expire entries, and their relationship with Near Cache.

Fixes https://hazelcast.atlassian.net/browse/CTT-412