### PR TITLE
Mixing strings and numbers is not supported in PredicateAPI queries [SUP-966] [v/5.4]

### DIFF
--- a/docs/modules/query/pages/predicate-overview.adoc
+++ b/docs/modules/query/pages/predicate-overview.adoc
@@ -306,6 +306,11 @@ as `String`, `boolean` and `null`, respectively. We treat the extracted
 `number` values as `long` where possible. Otherwise, `number` types are treated
 as `double`.
 
+WARNING: Mixing types of numeric values of the attribute (e.g. short, int, double) is supported in Predicate API queries,
+but mixing numbers and strings is not supported and queries may produce incorrect results.
+This is an easy mistake to make when using JSON as simply adding or removing quotation marks changes the type.
+However, the same applies to all other value kinds, like POJOs or Compact-serialized values.
+
 It is possible to query nested attributes and arrays in JSON documents, using the Predicates API.
 The query syntax is the same
 as <<collections, querying collections and arrays>> in other Hazelcast objects.


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1918

For more details see https://github.com/hazelcast/hazelcast-mono/pull/4847