### PR TITLE
Update C++ instructions post-`boost` upgrade [v/5.5]

### DIFF
--- a/docs/modules/clients/pages/cplusplus.adoc
+++ b/docs/modules/clients/pages/cplusplus.adoc
@@ -41,7 +41,7 @@ See https://github.com/microsoft/vcpkg#getting-started[Get started with vcpkg] t
 If you use Linux or Mac:
 
 ```sh
-git clone https://github.com/microsoft/vcpkg --branch 2025.02.14
+git clone https://github.com/microsoft/vcpkg
 ./vcpkg/bootstrap-vcpkg.sh
 ./vcpkg/vcpkg install "hazelcast-cpp-client[openssl]" --recurse
 ``` 
@@ -49,7 +49,7 @@ git clone https://github.com/microsoft/vcpkg --branch 2025.02.14
 If you use Windows:
 
 ```bat
-git clone https://github.com/microsoft/vcpkg --branch 2025.02.14
+git clone https://github.com/microsoft/vcpkg
 .\vcpkg\bootstrap-vcpkg.bat
 .\vcpkg\vcpkg install "hazelcast-cpp-client[openssl]:x64-windows" --recurse
 ``` 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1953

Update the instructions after https://github.com/hazelcast/hazelcast-cpp-client/pull/1322, specifically copying the changes from the (partially duplicated) `Reference_Manual`.