### PR TITLE
DOC-546: include install & get started info from readme [v/5.5]

### DIFF
--- a/docs/modules/clients/pages/python.adoc
+++ b/docs/modules/clients/pages/python.adoc
@@ -33,7 +33,7 @@ The quickest way to start a single member cluster for development purposes is to
 Launch a Hazelcast Docker Container by running the following command:
 
 ```bash
-docker run -p 5701:5701 hazelcast/hazelcast:5.3.0
+docker run -p 5701:5701 hazelcast/hazelcast
 ```
 TIP: For a step-by-step guide, see the https://docs.hazelcast.com/hazelcast/latest/getting-started/get-started-docker[Start a local cluster in Docker] and https://docs.hazelcast.com/hazelcast/latest/getting-started/enterprise-overview[Get Started with Hazelcast Enterprise Edition] tutorials. 
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1783

For https://hazelcast.atlassian.net/browse/DOC-546 - include get started & installation instructions, basic config and usage. This is existing info in the Python client readme and the 'readthedocs' site which has been scrubbed. 