### PR TITLE
Improve code block formatting and use enterprise jar in raft-log-file-exporter

### DIFF
--- a/docs/modules/cp-subsystem/pages/raft-log-file-exporter.adoc
+++ b/docs/modules/cp-subsystem/pages/raft-log-file-exporter.adoc
@@ -28,7 +28,7 @@ Run the RaftLogFileExporter tool, specifying the following parameters:
 
 [source,bash,subs="attributes+"]
 ----
-java -Xms2g -Xmx4g -cp hazelcast-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \ <1>
+java -Xms2g -Xmx4g -cp hazelcast-enterprise-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \ <1>
     --source=/path/to/raft/logs \ <2>
     --output=migrated_output \ <3>
     --max-uncommitted-entries=10000 <4>
@@ -71,7 +71,7 @@ You can also view these parameters using the help command:
 
 [source,bash,subs="attributes+"]
 ----
-java -cp hazelcast-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter --help
+java -cp hazelcast-enterprise-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter --help
 ----
 
 == Example
@@ -98,7 +98,7 @@ The following example migrates Raft logs from a Hazelcast V5.6 cluster to V5.5 f
 +
 [source,bash,subs="attributes+"]
 ----
-java -Xms2g -Xmx4g -cp hazelcast-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \
+java -Xms2g -Xmx4g -cp hazelcast-enterprise-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \
     --source=/data/hazelcast/cp-data \
     --output=migrated_v55 \
     --max-uncommitted-entries=10000
@@ -143,7 +143,7 @@ If you encounter an out of memory error, try increasing the Java heap size. The 
 
 [source,bash,subs="attributes+"]
 ----
-java -Xms2g -Xmx8g -cp hazelcast-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \
+java -Xms2g -Xmx8g -cp hazelcast-enterprise-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \
     --source=/path/to/raft/logs \
     --output=migrated_output \
     --max-uncommitted-entries=10000


### PR DESCRIPTION
Use enterprise jar. Updated code blocks in raft-log-file-exporter.adoc to include subs=attributes for better syntax highlighting.