### PR TITLE
Improve code block formatting and use enterprise jar in raft-log-file-exporter [v/5.6]

### DIFF
--- a/docs/modules/cp-subsystem/pages/raft-log-file-exporter.adoc
+++ b/docs/modules/cp-subsystem/pages/raft-log-file-exporter.adoc
@@ -26,9 +26,9 @@ The tool is included in `hazelcast-enterprise.jar`. Note that you must configure
 
 Run the RaftLogFileExporter tool, specifying the following parameters:
 
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-java -Xms2g -Xmx4g -cp hazelcast-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \ <1>
+java -Xms2g -Xmx4g -cp hazelcast-enterprise-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \ <1>
     --source=/path/to/raft/logs \ <2>
     --output=migrated_output \ <3>
     --max-uncommitted-entries=10000 <4>
@@ -69,9 +69,9 @@ java -Xms2g -Xmx4g -cp hazelcast-{full-version}.jar com.hazelcast.cp.RaftLogFile
 
 You can also view these parameters using the help command:
 
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-java -cp hazelcast-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter --help
+java -cp hazelcast-enterprise-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter --help
 ----
 
 == Example
@@ -96,9 +96,9 @@ The following example migrates Raft logs from a Hazelcast V5.6 cluster to V5.5 f
 
 . Run the tool:
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-java -Xms2g -Xmx4g -cp hazelcast-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \
+java -Xms2g -Xmx4g -cp hazelcast-enterprise-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \
     --source=/data/hazelcast/cp-data \
     --output=migrated_v55 \
     --max-uncommitted-entries=10000
@@ -141,9 +141,9 @@ java -Xms2g -Xmx4g -cp hazelcast-{full-version}.jar com.hazelcast.cp.RaftLogFile
 
 If you encounter an out of memory error, try increasing the Java heap size. The following example uses `-Xmx8g` to set the maximum heap size to 8GB:
 
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-java -Xms2g -Xmx8g -cp hazelcast-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \
+java -Xms2g -Xmx8g -cp hazelcast-enterprise-{full-version}.jar com.hazelcast.cp.RaftLogFileExporter \
     --source=/path/to/raft/logs \
     --output=migrated_output \
     --max-uncommitted-entries=10000


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1965

Use enterprise jar. Updated code blocks in raft-log-file-exporter.adoc to include subs=attributes for better syntax highlighting.