### PR TITLE
DOC-630: add security best practice [v/5.6]

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -84,6 +84,7 @@
 ** xref:cluster-performance:near-cache.adoc[]
 ** xref:cluster-performance:imap-bulk-read-operations.adoc[]
 ** xref:cluster-performance:data-affinity.adoc[]
+** xref:cluster-performance:security-best-practices.adoc[Security]
 // Discovery
 * Member and client discovery
 ** xref:clusters:discovery-mechanisms.adoc[]

--- a/docs/modules/cluster-performance/pages/best-practices.adoc
+++ b/docs/modules/cluster-performance/pages/best-practices.adoc
@@ -1,14 +1,16 @@
 = Best practices
 :page-aliases: performance:data-affinity.adoc, performance:near-cache.adoc, performance:back-pressure.adoc, performance:cpu-thread-affinity.adoc, performance:best-practices.adoc, performance:pipelining.adoc, performance:slowoperationdetector.adoc, performance:threading-model.adoc, ROOT:production-checklist.adoc
 
-Learn more about best practices and Hazelcast recommendations:
+This section provides guidance on optimizing your Hazelcast deployment for performance, reliability, and operational efficiency. The following topics cover essential best practices across multiple areas: 
 
-* xref:ROOT:capacity-planning.adoc[]
-* xref:cluster-performance:performance-tips.adoc[]
-* xref:cluster-performance:back-pressure.adoc[]
-* xref:cluster-performance:pipelining.adoc[]
-* xref:cluster-performance:aws-deployments.adoc[]
-* xref:cluster-performance:threading.adoc[]
-* xref:cluster-performance:near-cache.adoc[]
-* xref:cluster-performance:imap-bulk-read-operations.adoc[]
-* xref:cluster-performance:data-affinity.adoc[]
+* xref:ROOT:capacity-planning.adoc[] — for resource estimation and cluster sizing.
+* xref:cluster-performance:performance-tips.adoc[] — for tuning your production environment.
+* xref:cluster-performance:back-pressure.adoc[] and xref:cluster-performance:pipelining.adoc[] — for optimizing throughput.
+* xref:cluster-performance:aws-deployments.adoc[] — for cloud-specific considerations.
+* xref:cluster-performance:threading.adoc[] — for efficient operation execution.
+* xref:cluster-performance:near-cache.adoc[] — for reducing latency.
+* xref:cluster-performance:imap-bulk-read-operations.adoc[] — for preventing out-of-memory issues.
+* xref:cluster-performance:data-affinity.adoc[] — for optimizing data locality.
+* xref:cluster-performance:security-best-practices.adoc[] — for planning and optimizing security.
+
+Additionally, refer to xref:test:testing-bestpractices.adoc[Testing best practices] for guidance on writing reliable and efficient tests for your Hazelcast applications, and xref:cp-subsystem:best-practices.adoc[CP Subsystem best practices] to get the best performance out of your CP Subsystem deployment.

--- a/docs/modules/cluster-performance/pages/performance-tips.adoc
+++ b/docs/modules/cluster-performance/pages/performance-tips.adoc
@@ -591,11 +591,9 @@ See the xref:data-structures:entry-processor.adoc[Entry Processors section].
 [[tls-ssl-perf]]
 == Security
 
-Here are the essential tips:
+This section explains how to tune TLS performance, and Hazelcast's High-Density Memory Store (HDMS).
 
-* Security probably won’t be the first thing built
-* But it needs to be considered from the outset, as it affects architecture, performance and coding
-* Security can then be added before go-live without rework
+For general security best practices and recommendations (such as planning, performance, authorization and authentication), see xref:cluster-performance:security-best-practices.adoc[]. 
 
 === TLS Tuning
 

--- a/docs/modules/cluster-performance/pages/security-best-practices.adoc
+++ b/docs/modules/cluster-performance/pages/security-best-practices.adoc
@@ -1,0 +1,86 @@
+= Security best practices
+:description: This section provides a set of best practices and recommendations for security, including planning, performance impact, authorization and authentication, and integration. 
+
+{description}
+
+Security has architectural, performance, and coding implications that must be considered from the start of a project. Planning early ensures that introducing authentication, encryption, and authorization later does not require re-architecture or re-testing.
+
+== Key considerations
+
+*Plan security from the outset*. Security configuration affects how your cluster is structured, especially whether it runs in client-server mode or embedded mode.
+
+Best practice:
+
+* Design for client-server deployments if you will need authorization/access control (RBAC). In embedded mode, application code and data share the same JVM and memory space, meaning data can be accessed without permission.
+Client-server separation enforces true security boundaries: data resides on the members; clients interact only through authenticated, authorized APIs.
+
+Migrating from embedded to client-server later is costly and disruptive, therefore, plan for the correct mode early, even if you enable security features later.
+
+*Performance impact*. Network encryption (TLS/SSL) adds CPU overhead for encrypting and decrypting packets.
+
+Best practice:
+
+* Enable xref:security:tls-ssl.adoc[TLS/SSL] between all members and clients for data-in-transit protection. Expect a small throughput impact (typically 1-2%, though up to 10% in some environments).
+* Benchmark under realistic workloads — CPU overhead reduces available capacity for other processing (like serialization).
+* Consider modern cipher suites to minimize the cost.
+
+Security should not come at the expense of cluster stability, so it's important to understand the overhead of enabling TLS to ensure that you size the cluster correctly for stability.
+
+TIP: See xref:performance-tips.adoc#tls-ssl-perf[TLS Tuning] for information on tuning TLS performance.
+
+*Authentication and connection management*. Authentication ensures that only trusted clients and members can join or communicate with the cluster.
+
+Best practice:
+
+* Use identity providers such as xref:security:ldap-authentication.adoc[LDAP], Active Directory, or custom token-based authentication for centralized management.
+* Keep connections persistent: authentication overhead is negligible for long-lived clients but significant for short-lived, one-shot requests.
+* Where possible, pool or reuse connections to minimize repeated authentication latency.
+
+Secure connection establishment can become a bottleneck if many clients connect briefly or frequently.
+
+*Authorization and Role-Based Access Control (RBAC)*. Each operation (read, write, compute) can be checked against the user’s permissions.
+
+Best practice:
+
+* Use Hazelcast's xref:security:authentication-overview.adoc[role-based access control] to assign least-privilege permissions, for example, read-only users for analytics, full access for administration.
+* Be aware that every authorized operation adds a small CPU cost. When many operations occur, the total overhead can become measurable. Combine multiple operations into batched calls (putAll(), getAll()) when appropriate — one authorization per bulk request instead of per item.
+
+Properly configured RBAC limits exposure while maintaining performance.
+
+*Coding for secure outcomes*. Once security is enabled, operations may fail with new types of exceptions (e.g. AccessControlException) that did not occur previously.
+
+Best practice:
+
+* Review all client and member-side code that accesses distributed data structures.
+* Handle authorization exceptions gracefully and log them for auditing.
+* Never assume a null result always means “no value”; it could also mean “access denied.”
+* Incorporate exception handling into unit and integration tests once security is active.
+
+Adding security changes functional behavior. Code that assumes simple null/not-null logic can break silently without proper handling.
+
+*Integration and compliance*. Security settings may need to align with organizational policies (for example, encryption standards, audit requirements, or data-handling regulations).
+
+Best practice:
+
+* Engage compliance teams early.
+* Plan for secure key and certificate management (rotation, expiration, and revocation).
+* Use Hazelcast audit logging features and secure configuration storage.
+
+Compliance-driven environments often require certification evidence or change control before go-live — retrofitting compliance is expensive.
+
+== Summary
+
+* Plan for security at design time, not at go-live.
+* Prefer client–server architecture for deployments requiring authentication or RBAC.
+* Enable TLS/SSL early and benchmark to understand performance impact.
+* Use centralized authentication and persistent connections for efficiency.
+* Apply least-privilege RBAC and combine operations where possible.
+* Update code and tests to handle new security exceptions.
+* Coordinate with compliance and operations teams for key management and audit needs.
+
+== Further reading
+For information about:
+
+* Security hardening, see xref:secure-cluster:hardening-recommendations.adoc[].
+* Tuning TLS performance, see xref:performance-tips.adoc#tls-ssl-perf[TLS Tuning] 
+* Data at rest encryption, see xref:storage:configuring-persistence.adoc[].


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hz-docs/pull/1974

Add a security best practice topic, and improve the best practices overview description to include this.

Please note that the other best practice topics will be scrubbed and the style guide applied as part of a separate PR, so ignore the use of initial caps etc. in their headings in the nav
