### PR TITLE
Use `PreparedStatement`s in `MapStore` examples

### DIFF
--- a/docs/modules/ROOT/examples/dds/map/StatementIterable.java
+++ b/docs/modules/ROOT/examples/dds/map/StatementIterable.java
@@ -13,7 +13,7 @@ public class StatementIterable<T> implements Iterable<T> {
     @Override
     public Iterator<T> iterator() {
         try {
-            return new ResultSetIterator<T>(statement.executeQuery());
+            return new ResultSetIterator<>(statement.executeQuery());
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Using `String#format` in SQL queries is vulnerable to [SQL injection](https://stackoverflow.com/q/1582161) - we should be using examples using `PreparedStatement`s instead.

Also fixed IDE warnings in example at the same time.