### PR TITLE
DOC-300: replace compatibility table

### DIFF
--- a/docs/modules/deploy/pages/versioning-compatibility.adoc
+++ b/docs/modules/deploy/pages/versioning-compatibility.adoc
@@ -42,7 +42,6 @@ Hazelcast Platform has been tested on the following system architectures.
 |AArch64/ARM64
 |From Platform 5.3
 
-
 |===
 
 == Supported operating systems
@@ -209,17 +208,17 @@ The following table shows compatibility between this version of Hazelcast Platfo
 
 == Compatibility guarantees
 
-==== Cluster members
+=== Cluster members
 
 Hazelcast Platform members operating on the same major and minor Platform version are always compatible, regardless of the patch version.
 
 Each minor version is always compatible with the previous minor version.
 
-==== Management Center
+=== Management Center
 
 All 5.x.y versions of Management Center are compatible with Hazelcast Platform 5.x.y versions. We recommend you use a version of Management Center at least as high as the Hazelcast Platform version in your cluster. For example, Management Center 5.1.1 may not support all the features of Hazelcast Platform 5.2, or vice versa. You should generally upgrade to the latest version of Management Center when available and refer to xref:{page-latest-supported-mc}@management-center:release-notes:releases.adoc[Management Center release notes] for details on each version.
 
-==== Job states
+=== Job states
 
 Hazelcast Platform job states are only backward-compatible across the same minor versions.  A newer patch version is able to understand the job states only from the previous patch versions of the same minor version.
 
@@ -227,14 +226,14 @@ If you have a running job, using the rolling upgrades feature, you are able to u
 
 Hazelcast clients that submit jobs (currently only Java clients) are compatible with members running on the same minor version. This means that a client using an older or newer patch version is able to connect and submit a job to a cluster that's running a different patch version.
 
-==== Command line tools
+=== Command line tools
 
 Hazelcast xref:management:cluster-utilities.adoc#hazelcast-command-line-tool[CLI] and xref:management:cluster-utilities.adoc#using-the-hz-cluster-admin-script[cluster admin] tools are backwards-compatible across the same minor versions.
 
-==== Configuration files
+=== Configuration files
 
 XML and YAML configuration files provided with the Hazelcast Platform package are backward-compatible across the same minor versions. After upgrading a cluster to a new minor version, the configuration files for the previous version can be used without any modification.
 
-==== Names of metrics
+=== Names of metrics
 
 Hazelcast Platform sends metrics to Management Center and other means such as JMX. The names of these metrics may change across minor versions but not between patch versions.


### PR DESCRIPTION
Replace ‘Table 5. Client Version Compatibilities’ with a table similar to the ‘V1: Compatibility Range’ table in Burak's Confluence page, but do not include the LTS/STS column.