### PR TITLE
Update Jet Python versions for 5.6.0 [CTT-271] [5.6.z]

### DIFF
--- a/docs/modules/pipelines/pages/python.adoc
+++ b/docs/modules/pipelines/pages/python.adoc
@@ -13,7 +13,7 @@ To complete this tutorial, you need the following:
 |===
 |Prerequisites|Useful resources
 
-|Python 3.7+ |link:https://www.python.org/downloads[Python downloads]
+|Python 3.9+ |link:https://www.python.org/downloads[Python downloads]
 
 |A Hazelcast cluster running in client/server mode
 |xref:getting-started:install-hazelcast.adoc#use-the-binary[Install Hazelcast]

--- a/docs/modules/pipelines/pages/transforms.adoc
+++ b/docs/modules/pipelines/pages/transforms.adoc
@@ -258,7 +258,7 @@ to efficient batching.
 Hazelcast can call Python code to perform a mapping step in the
 pipeline. The prerequisite is that the Hazelcast servers are Linux or Mac with Python installed and that the `hazelcast-jet-python` module is deployed
 on the classpath, through being present in the `lib` directory. Hazelcast
-supports Python versions 3.5-3.7.
+supports Python versions 3.9-3.13.
 
 For a full tutorial, see xref:python.adoc[Apply a Python Function].
 


### PR DESCRIPTION
Backports https://github.com/hazelcast/hz-docs/pull/2007

Starting from 5.6.0, we now require Python 3.9+ and officially support 3.9-3.13.

Fixes https://hazelcast.atlassian.net/browse/CTT-271