### PR TITLE
Centralise netlify build trigger

### DIFF
--- a/.github/workflows/build-site-workflow.yml
+++ b/.github/workflows/build-site-workflow.yml
@@ -1,0 +1,14 @@
+name: Dispatch docs deployment
+
+on:
+  workflow_call:
+    secrets:
+      netlify_build_hook_id:
+        required: true
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+        #   https://docs.netlify.com/configure-builds/build-hooks/
+      - run: curl -d {} https://api.netlify.com/build_hooks/${{ secrets.netlify_build_hook_id }}

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch docs deployment
-        #   https://docs.netlify.com/configure-builds/build-hooks/
-        run: curl -d {} https://api.netlify.com/build_hooks/${{ secrets.NETLIFY_BUILD_HOOK_ID }}
+    uses: ./.github/workflows/build-site-workflow.yml
+    secrets:
+      netlify_build_hook_id: ${{ secrets.NETLIFY_BUILD_HOOK_ID }}


### PR DESCRIPTION
The netlify build trigger is trivial, but duplicated across many repos. This should be centralised to subsequently support refactoring to improve secret usage _in a single place_.