### PR TITLE
Refactor `build-site-workflow` to avoid secret usage in command.

### DIFF
--- a/.github/workflows/build-site-workflow.yml
+++ b/.github/workflows/build-site-workflow.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   trigger:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
         #   https://docs.netlify.com/configure-builds/build-hooks/
-      - run: curl -d {} https://api.netlify.com/build_hooks/${{ secrets.netlify_build_hook_id }}
+      - run: curl -d {} https://api.netlify.com/build_hooks/${BUILD_HOOK_ID}
+    env:
+      BUILD_HOOK_ID: ${{ secrets.netlify_build_hook_id }}


### PR DESCRIPTION
Addresses [Sonar warning]( https://next.sonarqube.com/sonarqube/coding_rules?open=githubactions%3AS7636&rule_key=githubactions%3AS7636) by using an alternative implementation that does not require directly injecting the URL into a command argument.

Also minimized runner as action resource requirements are minimal.