### PR TITLE
Add info about restarting with lite members in the cluster [CTT-664]

### DIFF
--- a/docs/modules/storage/pages/persistence.adoc
+++ b/docs/modules/storage/pages/persistence.adoc
@@ -59,7 +59,7 @@ not possible to restore persisted data.
 ** 255+ characters
 ** Special characters (`*``:``"``'``|``<````,``>``?``/`)
 
-- **Lite and non-lite members**: When cluster consist of lite and non-lite members and non-lite members will be shut down before lite members, then it is not possible to restore persisted data. Lite members should be shut down before non-lite members.
+- **Lite and non-lite members**: When a cluster includes both lite and non-lite (data) members, lite members should be shut down before non-lite members. If the non-lite members are shut down first, it is not possible to restore persisted data. 
 
 == Related Resources
 


### PR DESCRIPTION
From issue summary:
When we have persistence enabled on non-lite and lite member and when non-lite members gracefully shot dows, and the lite member shut dows, it’s impossible to get data back 

Fixes https://hazelcast.atlassian.net/browse/SUP-1000
Fixes https://hazelcast.atlassian.net/browse/CTT-664