### PR TITLE
Use centralised Slack notification to avoid (deprecated) `8398a7/action-slack`

### DIFF
--- a/.github/workflows/maven-pr-builder.yaml
+++ b/.github/workflows/maven-pr-builder.yaml
@@ -46,12 +46,9 @@ jobs:
             "-Dmaven.compiler.release=${{ steps.get-antora-properties.outputs.minimum-java-version }}"
 
       - name: Slack notification
-        uses: 8398a7/action-slack@v3
+        uses: hazelcast/docker-actions/slack-notification@master
         if: failure() && github.event_name == 'schedule'
         with:
+          slack-webhook-url: ${{ inputs.SLACK_WEBHOOK }}
+          slack-channel: "#docs-notifications"
           status: failure
-          fields: repo,job,workflow
-          text: "👎 Test Maven compilation failed."
-          channel: "#docs-notifications"
-        env:
-          SLACK_WEBHOOK_URL: ${{ inputs.SLACK_WEBHOOK }}


### PR DESCRIPTION
The action is now archived - https://github.com/8398a7/action-slack - "use at own risk".

Update to use `docker-actions` implementations to remove explicit references to `8398a7/action-slack`.

Fixes: [DI-767](https://hazelcast.atlassian.net/browse/DI-767)

[DI-767]: https://hazelcast.atlassian.net/browse/DI-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ