### PR TITLE
Remove recommendation to use TPC

### DIFF
--- a/docs/modules/cluster-performance/pages/performance-tips.adoc
+++ b/docs/modules/cluster-performance/pages/performance-tips.adoc
@@ -59,8 +59,6 @@ such as the Raspberry Pi Zero (1GHz single-core CPU, 512MB RAM).
 
 We suggest at least 8 CPU cores or equivalent per member, as well as running a single Hazelcast member for each host.
 
-NOTE: For environments with _either_ fewer or more cores than 8 CPU, we recommend enabling Thread-Per-Core (TPC). For more info, see xref:cluster-performance:thread-per-core-tpc.adoc[].
-
 As a starting point for data-intensive operations, consider machines  such as AWS https://aws.amazon.com/ec2/instance-types/c5/[c5.2xlarge]
 with:
 


### PR DESCRIPTION
TPC is experimental and should not be recommended at this time.
On [the TPC page](https://docs.hazelcast.com/hazelcast/5.6/cluster-performance/thread-per-core-tpc):
> This is an experimental feature and is not recommended for production use. It is separately licensed. If you are interested in trialing this feature, contact your Hazelcast representative.