### PR TITLE
Revert change to client compatibility

### DIFF
--- a/docs/modules/deploy/pages/versioning-compatibility.adoc
+++ b/docs/modules/deploy/pages/versioning-compatibility.adoc
@@ -158,8 +158,8 @@ The following table shows compatibility between this version of Hazelcast Platfo
 |Client |Minimum version |Recommended version
 
 |Java
-|Platform version
-|Platform version
+|4.0.0
+|{full-version}
 
 |.NET
 |4.0.0


### PR DESCRIPTION
A recent change (PR #2056 ) to client compatibility was a mistake. It showed "Platform version" for both the minimum and recommended client version, meaning that the only supported client version would be the same as the cluster. The format is different from previous versions, so this changes the "minimum version" to 4.0.0 and "recommended version" to be the cluster version to match the meaning (Java v4/5 clients are compatible with cluster v4/5).