### PR TITLE
Relocate documentation `hazelcast.client.io` `thread.count` properties to the client property page

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -1984,12 +1984,14 @@ A value smaller than 1 disables the balancer.
 |int
 |Controls the number of I/O input threads. Defaults to -1, i.e., the system decides.
 If the client is using either the `ALL_MEMBERS` or the `MULTI_MEMBER` cluster routing mode, it defaults to 3, otherwise it defaults to 1.
+If there are more than 8 processors, it defaults to 3 threads.
 
 |`hazelcast.client.io.output.thread.count`
 |-1
 |int
 |Controls the number of I/O output threads. Defaults to -1, i.e., the system decides.
 If the client is using either the `ALL_MEMBERS` or the `MULTI_MEMBER` cluster routing mode, it defaults to 3, otherwise it defaults to 1.
+If there are more than 8 processors, it defaults to 3 threads.
 
 |`hazelcast.client.io.write.through`
 |true

--- a/docs/modules/cluster-performance/pages/performance-tips.adoc
+++ b/docs/modules/cluster-performance/pages/performance-tips.adoc
@@ -646,10 +646,8 @@ For a more permanent solution, modify the
 
 Clients using Hazelcast's Java `ALL_MEMBERS` and `MULTI_MEMBER` cluster routing modes automatically make use of extra I/O threads
 for encryption/decryption and this has a significant impact on the performance.
-The number of threads used can be changed using the `hazelcast.client.io.input.thread.count` and
-`hazelcast.client.io.output.thread.count` client system properties.
-By default it is 1 input thread and 1 output thread. If there are more than 8 processors,
-it defaults to 3 input threads and 3 output threads.
+The number of threads used can be changed using the xref:clients:java.adoc#client-system-properties[`hazelcast.client.io.input.thread.count`] and
+xref:clients:java.adoc#client-system-properties[`hazelcast.client.io.output.thread.count`] client system properties.
 Having more client I/O threads than members in the cluster does not lead to
 an increased performance. So with a 2-member cluster,
 2 in and 2 out threads give the best performance.


### PR DESCRIPTION
Rather than describing the property on the `performance-tips` page, we should link to the existing documentation on the property and expand the definition there.