### PR TITLE
Rename `private` Hazelcast Maven repos -> `public`

### DIFF
--- a/docs/modules/getting-started/pages/install-enterprise.adoc
+++ b/docs/modules/getting-started/pages/install-enterprise.adoc
@@ -117,8 +117,8 @@ ifdef::snapshot[]
 ----
 <repositories>
     <repository>
-        <id>private-repository</id>
-        <name>Hazelcast Private Snapshot Repository</name>
+        <id>hazelcast-public-snapshot-repository</id>
+        <name>Hazelcast Public Snapshot Repository</name>
         <url>https://repository.hazelcast.com/snapshot/</url> <1>
         <releases>
             <enabled>false</enabled>
@@ -140,8 +140,8 @@ ifndef::snapshot[]
 ----
 <repositories>
     <repository>
-        <id>private-repository</id>
-        <name>Hazelcast Private Release Repository</name>
+        <id>hazelcast-public-repository</id>
+        <name>Hazelcast Public Release Repository</name>
         <url>https://repository.hazelcast.com/release/</url> <1>
         <snapshots>
             <enabled>false</enabled>


### PR DESCRIPTION
The repos in the documentation are public, unlike our our _actual_ private repos which... aren't.

The name/id of the repository makes no technical difference, but it could be confusing.

See https://github.com/hazelcast/hazelcast-mono/pull/6505