### PR TITLE
Fix member instantiation in usercode namespace enable example

### DIFF
--- a/docs/modules/clusters/pages/ucn-enable.adoc
+++ b/docs/modules/clusters/pages/ucn-enable.adoc
@@ -19,13 +19,13 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.UserCodeNamespaceConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
 
 public class Member {
 
     public static void main(String[] args) {
         Config config = new Config();
         config.getNamespacesConfig().setEnabled(true);
+        Hazelcast.newHazelcastInstance(config);
     }
 }
 ----


### PR DESCRIPTION
Member instantiation was in a wrong place. It should be in the main method.