### PR TITLE
Update C++ min requirements to C++14 level compiler and Boost 1.83.0 [HZ-5441]

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -31,7 +31,7 @@ asciidoc:
     # https://github.com/hazelcast/hazelcast-go-client/releases
     page-latest-supported-go-client: '1.5.0'
     # https://github.com/hazelcast/hazelcast-cpp-client/releases
-    page-latest-supported-cplusplus-client: '5.6.0'
+    page-latest-supported-cplusplus-client: '5.7.0'
     # https://github.com/hazelcast/hazelcast-csharp-client/releases
     page-latest-supported-csharp-client: '5.6.0'
     # https://github.com/hazelcast/hazelcast-python-client/releases

--- a/docs/modules/clients/pages/cplusplus.adoc
+++ b/docs/modules/clients/pages/cplusplus.adoc
@@ -87,12 +87,11 @@ This generates the `conanbuildinfo.cmake` file to be included in your CMakeLists
 === Install from source code using CMake
 ==== Requirements
 1. Linux, macOS or Windows
-2. A compiler that supports C++11 or above: The project detects the minimum C++ standard supported by the Boost library
-and uses the same language level for compilation. If you are using Boost 1.82.0 or later, the project requires
-C++14 or later because Boost.Math requires this language level to be a minimum of 1.82.0.
-For lower Boost versions, C++11 or later is sufficient.
+2. A compiler that supports C++14 or above: The project detects the minimum C++ standard supported by the Boost library
+and uses the same language level for compilation. If you are using Boost 1.83.0 or later, the project requires
+C++14 or later because Boot.Math requires this language level.
 3. https://cmake.org[CMake] 3.10 or above
-4. https://www.boost.org[Boost] 1.73 or later. The Boost libraries used are:
+4. https://www.boost.org[Boost] 1.83 or later. The Boost libraries used are:
       - boost-thread
       - boost-asio
       - boost-chrono


### PR DESCRIPTION
Update C++ min requirements to C++14 level compiler and Boost 1.83.0  as minimum.

Update C++ client version to 5.7.0 for preparing the next release.

related to https://github.com/hazelcast/hazelcast-cpp-client/pull/1454
