### PR TITLE
Update `5.7-SNAPSHOT` references

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -3,7 +3,7 @@
 site:
 #  title: Documentation
   url: https://hardcore-allen-f5257d.netlify.app/
-  start_page: 5.7-snapshot@hazelcast:ROOT:index.adoc
+  start_page: 5.8-snapshot@hazelcast:ROOT:index.adoc
   robots: disallow
 #  keys:
 #    docsearch_id: 'QK2EAH8GB0'

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -15,8 +15,8 @@ asciidoc:
     hz-repo-swagger-branch: 'master'
     jet-version: '4.5.4'
     # The minor.patch version, which is used as a variable in the docs for things like file versions
-    minor-version: '5.7-SNAPSHOT'
-    version: '5.7-SNAPSHOT'
+    minor-version: '5.8-SNAPSHOT'
+    version: '5.8-SNAPSHOT'
     java-client-standalone-version: '5.5.0-BETA'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true


### PR DESCRIPTION
Since 5.7 was released, references to (implicitly latest) `SNAPSHOT` should be updated - else we get [validation failures](https://github.com/hazelcast/hz-docs/actions/runs/26168054589/job/76977660541?pr=2195).