### PR TITLE
Remove orphaned `java-client-standalone-version` property

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -17,7 +17,6 @@ asciidoc:
     # The minor.patch version, which is used as a variable in the docs for things like file versions
     minor-version: '5.7-SNAPSHOT'
     version: '5.7-SNAPSHOT'
-    java-client-standalone-version: '5.5.0-BETA'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true
     snapshot: true


### PR DESCRIPTION
Is no longer referenced in the docs