### PR TITLE
Replace `mvnrepository.com` links with `search.maven.org`

### DIFF
--- a/docs/modules/getting-started/pages/get-started-java.adoc
+++ b/docs/modules/getting-started/pages/get-started-java.adoc
@@ -194,7 +194,7 @@ To use SQL in embedded mode, you must add the `hazelcast-sql` module to your `po
 
 [source,xml,subs="attributes+"]
 ----
-<!-- https://mvnrepository.com/artifact/com.hazelcast/hazelcast-sql -->
+<!-- https://search.maven.org/artifact/com.hazelcast/hazelcast-sql -->
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-sql</artifactId>

--- a/docs/modules/integrate/pages/file-connector.adoc
+++ b/docs/modules/integrate/pages/file-connector.adoc
@@ -35,27 +35,27 @@ If you use the slim distribution of Hazelcast, be sure to add the respective mod
 |path/to/a/directory
 
 |Hadoop Distributed File System (HDFS)
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-hadoop-all/{os-version}[hazelcast-jet-hadoop-all]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-hadoop-all/{os-version}/jar[hazelcast-jet-hadoop-all]
 |hdfs://path/to/a/directory
 
 |Amazon S3
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{os-version}[hazelcast-jet-files-s3]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{os-version}/jar[hazelcast-jet-files-s3]
 |s3a://example-bucket/path/in/the/bucket
 
 |Google Cloud Storage
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-gcs/{os-version}[hazelcast-jet-files-gcs]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-gcs/{os-version}/jar[hazelcast-jet-files-gcs]
 |gs://example-bucket/path/in/the/bucket
 
 |Windows Azure Blob Storage
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}/jar[hazelcast-jet-files-azure]
 |wasbs://example-container@examplestorageaccount.blob.core.windows.net/path/in/the/container
 
 |Azure Data Lake Generation 1
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}/jar[hazelcast-jet-files-azure]
 |adl://exampledatalake.azuredatalakestore.net/path/in/the/container
 
 |Azure Data Lake Generation 2
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}/jar[hazelcast-jet-files-azure]
 |abfs://example-container@exampledatalakeaccount.dfs.core.windows.net/path/in/the/container
 |===
 

--- a/docs/modules/integrate/pages/kafka-connector.adoc
+++ b/docs/modules/integrate/pages/kafka-connector.adoc
@@ -12,7 +12,7 @@ the Kafka cluster.
 
 This connector is included in the full distribution of Hazelcast.
 
-If you're using the slim distribution, you must add the link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-kafka/{os-version}[`hazelcast-jet-kafka` module] to your member's classpath.
+If you're using the slim distribution, you must add the link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-kafka/{os-version}/jar[`hazelcast-jet-kafka` module] to your member's classpath.
 
 == Permissions
 [.enterprise]*{enterprise-product-name}*

--- a/docs/modules/integrate/pages/legacy-file-connector.adoc
+++ b/docs/modules/integrate/pages/legacy-file-connector.adoc
@@ -38,13 +38,13 @@ If you use the slim distribution of Hazelcast, be sure to add the respective mod
 |Included in both full and slim distributions of Hazelcast.
 
 |Apache Avro
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-avro/{os-version}[hazelcast-jet-avro]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-avro/{os-version}/jar[hazelcast-jet-avro]
 
 |Hadoop Distributed File System (HDFS)
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-hadoop/{os-version}[hazelcast-jet-hadoop]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-hadoop/{os-version}/jar[hazelcast-jet-hadoop]
 
 |Amazon S3
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{os-version}[hazelcast-jet-files-s3]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{os-version}/jar[hazelcast-jet-files-s3]
 |===
 
 Although these are the officially supported sources, you can also read from

--- a/docs/modules/migrate/pages/upgrading-from-jet.adoc
+++ b/docs/modules/migrate/pages/upgrading-from-jet.adoc
@@ -314,7 +314,7 @@ See xref:storage:configuring-persistence.adoc[].
 
 == SQL
 
-The slim distribution of Hazelcast Platform does not include the SQL module. If you use the slim distribution with SQL, link:https://mvnrepository.com/artifact/com.hazelcast/hazelcast-sql[download the `hazelcast-sql` module]. For a complete list of contents in each distribution of Hazelcast Platform, see xref:getting-started:install-hazelcast.adoc#full-and-slim-packages[Full and Slim Packages].
+The slim distribution of Hazelcast Platform does not include the SQL module. If you use the slim distribution with SQL, link:https://search.maven.org/artifact/com.hazelcast/hazelcast-sql[download the `hazelcast-sql` module]. For a complete list of contents in each distribution of Hazelcast Platform, see xref:getting-started:install-hazelcast.adoc#full-and-slim-packages[Full and Slim Packages].
 
 In the `information_schema.mappings` table, the following column names have been changed to make them consistent with the ANSI SQL standard. If you queried this table in Jet, make sure to use the correct column names in Hazelcast Platform.
 

--- a/docs/modules/sql/pages/mapping-to-a-file-system.adoc
+++ b/docs/modules/sql/pages/mapping-to-a-file-system.adoc
@@ -276,27 +276,27 @@ a|Included in both full and slim distributions of Hazelcast.
 |path/to/a/directory
 
 |Hadoop Distributed File System (HDFS)
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-hadoop-all/{os-version}[hazelcast-jet-hadoop-all]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-hadoop-all/{os-version}/jar[hazelcast-jet-hadoop-all]
 |hdfs://path/to/a/directory
 
 |Amazon S3
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{os-version}[hazelcast-jet-files-s3]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-s3/{os-version}/jar[hazelcast-jet-files-s3]
 |s3a://example-bucket/path/in/the/bucket
 
 |Google Cloud Storage
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-gcs/{os-version}[hazelcast-jet-files-gcs]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-gcs/{os-version}/jar[hazelcast-jet-files-gcs]
 |gs://example-bucket/path/in/the/bucket
 
 |Windows Azure Blob Storage
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}/jar[hazelcast-jet-files-azure]
 |wasbs://example-container@examplestorageaccount.blob.core.windows.net/path/in/the/container
 
 |Azure Data Lake Generation 1
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}/jar[hazelcast-jet-files-azure]
 |adl://exampledatalake.azuredatalakestore.net/path/in/the/container
 
 |Azure Data Lake Generation 2
-|link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}[hazelcast-jet-files-azure]
+|link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-files-azure/{os-version}/jar[hazelcast-jet-files-azure]
 |abfs://example-container@exampledatalakeaccount.dfs.core.windows.net/path/in/the/container
 |===
 

--- a/docs/modules/sql/pages/mapping-to-kafka.adoc
+++ b/docs/modules/sql/pages/mapping-to-kafka.adoc
@@ -12,7 +12,7 @@ The Kafka connector acts as a consumer or a producer so that you can create stre
 
 This connector is included in the full distribution of Hazelcast.
 
-If you're using the slim distribution, you must add the link:https://mvnrepository.com/artifact/com.hazelcast.jet/hazelcast-jet-kafka/{os-version}[`hazelcast-jet-kafka` module] to your member's classpath.
+If you're using the slim distribution, you must add the link:https://search.maven.org/artifact/com.hazelcast.jet/hazelcast-jet-kafka/{os-version}/jar[`hazelcast-jet-kafka` module] to your member's classpath.
 
 The Kafka connector is compatible with Kafka version equal to
 or greater than 1.0.0.


### PR DESCRIPTION
`mvnrepository.com` is a third-party website, for our documentation we should instead link to the official Maven search page (`search.maven.org`).

[Further reading](https://stackoverflow.com/q/62882189).