### PR TITLE
Document resolution of CVE-2024-6763 for Jetty in 5.6.1

### DIFF
--- a/docs/modules/release-notes/pages/enterprise.adoc
+++ b/docs/modules/release-notes/pages/enterprise.adoc
@@ -55,6 +55,8 @@ For help downloading Hazelcast {enterprise-product-name}, see xref:getting-start
 
 * *Resolved https://nvd.nist.gov/vuln/detail/CVE-2026-22731[CVE-2026-22731], https://nvd.nist.gov/vuln/detail/CVE-2026-22733[CVE-2026-22733], https://nvd.nist.gov/vuln/detail/CVE-2026-22737[CVE-2026-22737], and https://nvd.nist.gov/vuln/detail/CVE-2026-22735[CVE-2026-22735] in Spring Boot*: Fixed vulnerabilities by upgrading the Spring Boot dependency.
 
+* *Resolved https://nvd.nist.gov/vuln/detail/CVE-2024-6763[CVE-2024-6763] in Jetty: Fixed vulnerability by upgrading the Jetty dependency. Note that although this CVE is fixed, it may be flagged as still present in security scans due to the EOL status of Jetty 9. Hazelcast are aware of the issue and are working to upgrade Jetty in a future release.
+
 === Contributors
 
 We would like to thank the contributors from our open source community

--- a/docs/modules/release-notes/pages/enterprise.adoc
+++ b/docs/modules/release-notes/pages/enterprise.adoc
@@ -55,7 +55,7 @@ For help downloading Hazelcast {enterprise-product-name}, see xref:getting-start
 
 * *Resolved https://nvd.nist.gov/vuln/detail/CVE-2026-22731[CVE-2026-22731], https://nvd.nist.gov/vuln/detail/CVE-2026-22733[CVE-2026-22733], https://nvd.nist.gov/vuln/detail/CVE-2026-22737[CVE-2026-22737], and https://nvd.nist.gov/vuln/detail/CVE-2026-22735[CVE-2026-22735] in Spring Boot*: Fixed vulnerabilities by upgrading the Spring Boot dependency.
 
-* *Resolved https://nvd.nist.gov/vuln/detail/CVE-2024-6763[CVE-2024-6763] in Jetty: Fixed vulnerability by upgrading the Jetty dependency. Note that although this CVE is fixed, it may be flagged as still present in security scans due to the EOL status of Jetty 9. Hazelcast are aware of the issue and are working to upgrade Jetty in a future release.
+* *Resolved https://nvd.nist.gov/vuln/detail/CVE-2024-6763[CVE-2024-6763] in Jetty*: Fixed vulnerability by upgrading the Jetty dependency. Note that although this CVE is fixed, it may be flagged as still present in security scans due to the EOL status of Jetty 9. Hazelcast are aware of the issue and are working to upgrade Jetty in a future release.
 
 === Contributors
 


### PR DESCRIPTION
Added a note about resolving CVE-2024-6763 in Jetty by upgrading the Jetty dependency, including information about its EOL status and future plans.