### PR TITLE
Document CVE-2024-6763 Jetty fix in 5.7.0

### DIFF
--- a/docs/modules/release-notes/pages/community.adoc
+++ b/docs/modules/release-notes/pages/community.adoc
@@ -130,6 +130,8 @@ NOTE: Docker users who want to run Hazelcast on an earlier Java version instead 
 
 * *Resolved https://nvd.nist.gov/vuln/detail/CVE-2026-22731[CVE-2026-22731], https://nvd.nist.gov/vuln/detail/CVE-2026-22733[CVE-2026-22733], https://nvd.nist.gov/vuln/detail/CVE-2026-22737[CVE-2026-22737], and https://nvd.nist.gov/vuln/detail/CVE-2026-22735[CVE-2026-22735] in Spring Boot*: Fixed vulnerabilities by upgrading the Spring Boot dependency.
 
+* *Resolved https://nvd.nist.gov/vuln/detail/CVE-2024-6763[CVE-2024-6763] in Jetty*: Fixed vulnerability by upgrading the Jetty dependency. Note that although this CVE is fixed, it may be flagged as still present in security scans due to the EOL status of Jetty 9. Hazelcast are aware of the issue and are working to upgrade Jetty in a future release.
+
 === Known issues
 
 * *Deeply nested JSON objects on JDK 25*: When running on JDK 25, extremely deeply nested JSON objects (approaching the ~1000 nesting depth limit) may trigger a `StackOverflowError`, causing the operation to fail. This is due to changes in the JDK and not caused by Hazelcast code changes in this release. As a workaround, increase the JVM stack size using the `-Xss` startup flag.

--- a/docs/modules/release-notes/pages/enterprise.adoc
+++ b/docs/modules/release-notes/pages/enterprise.adoc
@@ -142,6 +142,8 @@ NOTE: The Hazelcast Platform Operator defaults to Java 25 unless the deployment 
 
 * *`@ExposeHazelcastObjects` with dependent Hazelcast configuration or instance beans*: When running an application with Spring integration and `@ExposeHazelcastObjects` (explicit or implicit via autoconfiguration), beans with Hazelcast `Config` and/or `HazelcastInstance` cannot rely on dependencies such as classes marked as `@ConfigurationProperties`. The system incorrectly triggers early initialization of those beans before `@ConfigurationProperties` are injected.
 
+* *https://nvd.nist.gov/vuln/detail/CVE-2024-6763[CVE-2024-6763] may be flagged as unresolved in Jetty despite the fix*: Although CVE-2024-6763 was resolved in Hazelcast Platform 5.6.1 by upgrading the Jetty dependency, the vulnerability may continue to be reported as present in security scans. This occurs because Jetty 9 has reached End of Life and scanners may flag it regardless of the fix. Hazelcast is aware of this and is working to upgrade Jetty in a future release.
+
 === Contributors
 
 We would like to thank the contributors from our open source community


### PR DESCRIPTION
Added CVE-2024-6763 as a Security fix in community edition release notes and also a Known Issue in enterprise notes since is was fixed in 5.6.1 but may still flag up in scans.