### PR TITLE
Remove memory cost metrics for MultiMap [INBOX-801]

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -764,10 +764,6 @@ This is because the cluster has to communicate with more members, which can add 
 |count
 |Number of backup entries held by the member
 
-|`multiMap.backupEntryMemoryCost`
-|bytes
-|Memory cost of backup entries in this member
-
 |`multiMap.creationTime`
 |ms
 |Creation time of the multimap in the member
@@ -791,10 +787,6 @@ This is because the cluster has to communicate with more members, which can add 
 |`multiMap.getCount`
 |count
 |Number of local get operations on the multimap
-
-|`multiMap.heapCost`
-|count
-|Total heap cost for the multimap on this member
 
 |`multiMap.hits`
 |count
@@ -839,10 +831,6 @@ This is because the cluster has to communicate with more members, which can add 
 |`multiMap.ownedEntryCount`
 |count
 |Number of multimap entries owned by the member
-
-|`multiMap.ownedEntryMemoryCost`
-|bytes
-|Memory cost of owned multimap entries on this member
 
 |`multiMap.putCount`
 |count


### PR DESCRIPTION
These metrics are not currently implemented for reporting on `MultiMap`, as discussed on: https://hazelcast.atlassian.net/browse/INBOX-801