### PR TITLE
Adding release notes for Hazelcast Platform 5.4.5

### DIFF
--- a/docs/modules/release-notes/pages/enterprise.adoc
+++ b/docs/modules/release-notes/pages/enterprise.adoc
@@ -1,10 +1,36 @@
 = Enterprise Edition Release Notes
 :description: These release notes list any new features, enhancements, fixes and breaking changes that were made for Hazelcast Platform {enterprise-product-name}.
-:page-aliases: release-notes:5-4-1.adoc, release-notes:5-4-2.adoc, release-notes:5-4-3.adoc, release-notes:5-4-4.adoc
+:page-aliases: release-notes:5-4-1.adoc, release-notes:5-4-2.adoc, release-notes:5-4-3.adoc, release-notes:5-4-4.adoc, release-notes:5-4-5.adoc
 
 {description}
 
 For help downloading Hazelcast {enterprise-product-name}, see xref:getting-started:install-enterprise.adoc[] or https://hazelcast.com/trial-request/?utm_source=docs-website[request a trial license key].
+
+== 5.4.5
+
+**Release date**: 2026-06-11
+
+This is the last planned maintenance release for Hazelcast Platform {enterprise-product-name} 5.4.
+
+For help downloading Hazelcast {enterprise-product-name}, see xref:getting-started:install-enterprise.adoc[] or https://hazelcast.com/trial-request/?utm_source=docs-website[request a trial license key].
+
+=== Security
+* *Enforced checks on classes in `JsonUtil` deserialization:* Some classes, which are unlikely to be used, are no longer allowed to be deserialized using `JsonUtil`.
+* *Ensured SQL is enabled before deserializing messages:* Applied additional hardening to prevent SQL parameters from being deserialized when SQL is not enabled.
+* *Enforced stricter checks on classes in SQL:* Resolved an issue where restrictions on class names used in SQL mappings and types were not checked in some cases.
+* *Enforced checks on classes used in the client protocol:* Resolved an issue where it was possible to instantiate arbitrary classes under client protocol error conditions. Strict filtering has been implemented to prevent this.
+* *Resolved https://nvd.nist.gov/vuln/detail/CVE-2025-33042[CVE-2025-33042] in Apache Avro:* Fixed a vulnerability by upgrading the Avro and Parquet dependencies.
+* *Resolved CVEs in Netty:* Fixed multiple high-severity vulnerabilities by upgrading the Netty dependency (https://nvd.nist.gov/vuln/detail/CVE-2025-59419[CVE-2025-59419], https://nvd.nist.gov/vuln/detail/CVE-2025-55163[CVE-2025-55163], https://nvd.nist.gov/vuln/detail/CVE-2026-42578[CVE-2026-42578], https://nvd.nist.gov/vuln/detail/CVE-2026-42579[CVE-2026-42579], https://nvd.nist.gov/vuln/detail/CVE-2026-42580[CVE-2026-42580], https://nvd.nist.gov/vuln/detail/CVE-2026-42581[CVE-2026-42581], https://nvd.nist.gov/vuln/detail/CVE-2026-42582[CVE-2026-42582], https://nvd.nist.gov/vuln/detail/CVE-2026-42583[CVE-2026-42583], https://nvd.nist.gov/vuln/detail/CVE-2026-42584[CVE-2026-42584], https://nvd.nist.gov/vuln/detail/CVE-2026-42585[CVE-2026-42585], https://nvd.nist.gov/vuln/detail/CVE-2026-42586[CVE-2026-42586], https://nvd.nist.gov/vuln/detail/CVE-2026-42587[CVE-2026-42587], https://nvd.nist.gov/vuln/detail/CVE-2026-33870[CVE-2026-33870], https://nvd.nist.gov/vuln/detail/CVE-2026-33871[CVE-2026-33871], https://nvd.nist.gov/vuln/detail/CVE-2026-41417[CVE-2026-41417], and https://nvd.nist.gov/vuln/detail/CVE-2026-44248[CVE-2026-44248]).
+* *Resolved CVEs in Log4j:* Fixed multiple high-severity vulnerabilities by upgrading the Log4j dependency (https://nvd.nist.gov/vuln/detail/CVE-2025-68161[CVE-2025-68161], https://nvd.nist.gov/vuln/detail/CVE-2026-34477[CVE-2026-34477], https://nvd.nist.gov/vuln/detail/CVE-2026-34478[CVE-2026-34478], and https://nvd.nist.gov/vuln/detail/CVE-2026-34480[CVE-2026-34480]).
+* *Resolved https://nvd.nist.gov/vuln/detail/CVE-2025-48924[CVE-2025-48924] in Apache Commons Lang:* Fixed a vulnerability by upgrading the Apache Commons Lang dependency.
+* *Resolved CVEs in Spring Boot and Spring WebMVC:* Fixed multiple high-severity vulnerabilities by upgrading the Spring Boot and Spring WebMVC dependencies (https://nvd.nist.gov/vuln/detail/CVE-2026-22731[CVE-2026-22731], https://nvd.nist.gov/vuln/detail/CVE-2026-22733[CVE-2026-22733], https://nvd.nist.gov/vuln/detail/CVE-2026-22735[CVE-2026-22735], and https://nvd.nist.gov/vuln/detail/CVE-2026-22737[CVE-2026-22737]).
+* *Resolved CVEs in Apache Tomcat Embed Core:* Fixed multiple high-severity vulnerabilities by upgrading the Tomcat Embed Core dependency (https://nvd.nist.gov/vuln/detail/CVE-2026-29129[CVE-2026-29129], https://nvd.nist.gov/vuln/detail/CVE-2026-29145[CVE-2026-29145], https://nvd.nist.gov/vuln/detail/CVE-2026-25854[CVE-2026-25854], https://nvd.nist.gov/vuln/detail/CVE-2026-32990[CVE-2026-32990], https://nvd.nist.gov/vuln/detail/CVE-2026-34483[CVE-2026-34483], https://nvd.nist.gov/vuln/detail/CVE-2026-34487[CVE-2026-34487], and https://nvd.nist.gov/vuln/detail/CVE-2026-34500[CVE-2026-34500]).
+* *Resolved https://nvd.nist.gov/vuln/detail/CVE-2025-55163[CVE-2025-55163] in gRPC Netty Shaded:* Fixed a vulnerability by upgrading the gRPC Netty Shaded dependency.
+* *Resolved https://nvd.nist.gov/vuln/detail/CVE-2025-53864[CVE-2025-53864] in Nimbus JOSE+JWT:* Fixed a vulnerability by upgrading the Nimbus JOSE+JWT dependency.
+* *Resolved https://nvd.nist.gov/vuln/detail/CVE-2025-67721[CVE-2025-67721] in Aircompressor:* Fixed a vulnerability by upgrading the Aircompressor dependency.
+* *Resolved CVEs in Guava:* Fixed vulnerabilities by upgrading the Hadoop dependency, which transitively upgrades the Guava dependency (https://nvd.nist.gov/vuln/detail/CVE-2020-8908[CVE-2020-8908] and https://nvd.nist.gov/vuln/detail/CVE-2023-2976[CVE-2023-2976]).
+* *Resolved https://nvd.nist.gov/vuln/detail/CVE-2025-5115[CVE-2025-5115] in Jetty:* Fixed a vulnerability by upgrading the Jetty BOM dependency.
+* *Security advisory regarding Elasticsearch 7:* https://nvd.nist.gov/vuln/detail/CVE-2025-66566[CVE-2025-66566] has been identified in Elasticsearch 7. As Elasticsearch 7 is currently End of Life (EOL), no upstream fix is available from the vendor. We strongly recommend that users evaluate the security risks associated with this CVE. Support for Elasticsearch 7 will be removed in a future version of Hazelcast.
 
 == 5.4.4
 


### PR DESCRIPTION
Added release notes for version 5.4.5. Contains only security updates.