### PR TITLE
Escape {PROTOCOL} usage

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -2370,7 +2370,7 @@ Based on your latency tolerance in your business use case, you can define a thre
 .TCP
 [%collapsible]
 ====
-Protocol-specific TCP byte metrics are available only when Advanced Networking is enabled. `{PROTOCOL}` is one of `MEMBER`, `CLIENT`, `WAN`, `REST`, or `MEMCACHE`; `WAN` includes all WAN protocol endpoints on the reporting member.
+Protocol-specific TCP byte metrics are available only when Advanced Networking is enabled. `\{PROTOCOL}` is one of `MEMBER`, `CLIENT`, `WAN`, `REST`, or `MEMCACHE`; `WAN` includes all WAN protocol endpoints on the reporting member.
 
 [cols="4,1,6a"]
 |===
@@ -2406,7 +2406,7 @@ Protocol-specific TCP byte metrics are available only when Advanced Networking i
 |bytes
 |Number of bytes received over all connections (active and closed)
 
-|`tcp.bytesReceived.{PROTOCOL}`
+|`tcp.bytesReceived.\{PROTOCOL}`
 |bytes
 |Number of bytes received over all connections for the protocol (Advanced Networking only)
 
@@ -2414,7 +2414,7 @@ Protocol-specific TCP byte metrics are available only when Advanced Networking i
 |bytes
 |Number of bytes sent over all connections (active and closed)
 
-|`tcp.bytesSend.{PROTOCOL}`
+|`tcp.bytesSend.\{PROTOCOL}`
 |bytes
 |Number of bytes sent over all connections for the protocol (Advanced Networking only)
 


### PR DESCRIPTION
Previous PR added `{PROTOCOL}` tags which need to be escaped.