### PR TITLE
Add `brew trust` command for Homebrew installation

### DIFF
--- a/docs/modules/getting-started/pages/install-hazelcast.adoc
+++ b/docs/modules/getting-started/pages/install-hazelcast.adoc
@@ -39,6 +39,7 @@ To install on macOS, use the Homebrew package manager.
 [source,bash,subs="attributes+"]
 ----
 brew tap hazelcast/hz
+brew trust hazelcast/hz
 brew install hazelcast@{os-version}
 ----
 


### PR DESCRIPTION
[brew changes](https://docs.brew.sh/Tap-Trust) require taps to be explicitly trusted, else installation is blocked:
```
% brew install hazelcast      
Error: Refusing to load formula hazelcast/hz/hazelcast from untrusted tap hazelcast/hz.
Run `brew trust --formula hazelcast/hz/hazelcast` or `brew trust hazelcast/hz` to trust it.
```