### PR TITLE
Fix OrderKey code snipped

### DIFF
--- a/docs/modules/ROOT/examples/performance/OrderKey.java
+++ b/docs/modules/ROOT/examples/performance/OrderKey.java
@@ -24,6 +24,6 @@ final class OrderKey implements PartitionAware, Serializable {
                 + "orderId=" + orderId
                 + ", customerId=" + customerId
                 + '}';
-//end::orderkey[]
     }
 }
+//end::orderkey[]


### PR DESCRIPTION
OrderKey snipped was prematurely truncated. It is used in https://docs.hazelcast.com/hazelcast/latest/cluster-performance/data-affinity/