### PR TITLE
Add ZCCS config properties [DOC-768]

### DIFF
--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -1036,6 +1036,41 @@ of setting a result size limit.
 |string
 |When set to any non-null value, security recommendations are logged at the `INFO` level during the member startup.
 
+|`hazelcast.serialization.compact.allowlist.classes`
+|
+|string
+|Comma-separated list of fully qualified class names to allow for xref:serialization:compact-serialization.adoc[zero-config Compact serialization] (ZCCS). If set, only classes on this list (and not on the blocklist) are eligible for ZCCS. Default is empty.
+
+|`hazelcast.serialization.compact.allowlist.packages`
+|
+|string
+|Comma-separated list of package names to allow for ZCCS. Only classes in the exact package (not sub-packages) are matched.
+
+|`hazelcast.serialization.compact.allowlist.prefixes`
+|
+|string
+|Comma-separated list of class-name prefixes to allow for ZCCS.
+
+|`hazelcast.serialization.compact.blocklist.classes`
+|
+|string
+|Comma-separated list of fully qualified class names to block from ZCCS. Default is empty.
+
+|`hazelcast.serialization.compact.blocklist.defaults`
+|true
+|bool
+|Controls whether the default blocklist of known-problematic classes is applied for ZCCS.
+
+|`hazelcast.serialization.compact.blocklist.packages`
+|
+|string
+|Comma-separated list of package names to block from ZCCS. Only classes in the exact package (not sub-packages) are matched.
+
+|`hazelcast.serialization.compact.blocklist.prefixes`
+|
+|string
+|Comma-separated list of class-name prefixes to block from ZCCS.
+
 |`hazelcast.serialization.version`
 |
 |long

--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -1059,7 +1059,7 @@ of setting a result size limit.
 |`hazelcast.serialization.compact.blocklist.defaults`
 |true
 |bool
-|Controls whether the default blocklist of known-problematic classes is applied for ZCCS.
+|Controls whether the default blocklist of known-problematic classes is applied for ZCCS. Note that this property is `defaults`, not `defaultsDisabled` as seen for other configuration options.
 
 |`hazelcast.serialization.compact.blocklist.packages`
 |


### PR DESCRIPTION
https://hazelcast.atlassian.net/browse/DOC-768

Lists the zero-config Compact serialisation filter properties. 

For v5.7, `CompactSerializationConfig.zeroConfigFilter` is preferred - documented in #2264.
