### PR TITLE
Clarify ZCCS security advice [DOC-768]

### DIFF
--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -1039,7 +1039,9 @@ of setting a result size limit.
 |`hazelcast.serialization.compact.allowlist.classes`
 |
 |string
-|Comma-separated list of fully qualified class names to allow for xref:serialization:compact-serialization.adoc[zero-config Compact serialization] (ZCCS). If set, only classes on this list (and not on the blocklist) are eligible for ZCCS. Default is empty.
+|NOTE: We recommend configuring the zero-config Compact serialization filter through the xref:serialization:compact-serialization.adoc#zero-config-filter[`zero-config-filter` element] in your member or client configuration, rather than through these system properties. The system properties are provided mainly to ease upgrades from pre-5.7 versions that rely on them for hardened configuration.
+
+Comma-separated list of fully qualified class names to allow for xref:serialization:compact-serialization.adoc[zero-config Compact serialization] (ZCCS). If set, only classes on this list (and not on the blocklist) are eligible for ZCCS. Default is empty.
 
 |`hazelcast.serialization.compact.allowlist.packages`
 |


### PR DESCRIPTION
https://hazelcast.atlassian.net/browse/DOC-768

Follow-up PR for #2265

Clarification that in versions where the ZCCS filter exists, it should be used instead of the system properties.