### PR TITLE
Clarify ZCCS security advice [DOC-768] [v/5.7]

### DIFF
--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -1039,7 +1039,9 @@ of setting a result size limit.
 |`hazelcast.serialization.compact.allowlist.classes`
 |
 |string
-|Comma-separated list of fully qualified class names to allow for xref:serialization:compact-serialization.adoc[zero-config Compact serialization] (ZCCS). If set, only classes on this list (and not on the blocklist) are eligible for ZCCS. Default is empty.
+|NOTE: We recommend configuring the zero-config Compact serialization filter through the xref:serialization:compact-serialization.adoc#zero-config-filter[`zero-config-filter` element] in your member or client configuration, rather than through these system properties. The system properties are provided mainly to ease upgrades from pre-5.7 versions that rely on them for hardened configuration.
+
+Comma-separated list of fully qualified class names to allow for xref:serialization:compact-serialization.adoc[zero-config Compact serialization] (ZCCS). If set, only classes on this list (and not on the blocklist) are eligible for ZCCS. Default is empty.
 
 |`hazelcast.serialization.compact.allowlist.packages`
 |

--- a/docs/modules/ROOT/pages/system-properties.adoc
+++ b/docs/modules/ROOT/pages/system-properties.adoc
@@ -1036,6 +1036,41 @@ of setting a result size limit.
 |string
 |When set to any non-null value, security recommendations are logged at the `INFO` level during the member startup.
 
+|`hazelcast.serialization.compact.allowlist.classes`
+|
+|string
+|Comma-separated list of fully qualified class names to allow for xref:serialization:compact-serialization.adoc[zero-config Compact serialization] (ZCCS). If set, only classes on this list (and not on the blocklist) are eligible for ZCCS. Default is empty.
+
+|`hazelcast.serialization.compact.allowlist.packages`
+|
+|string
+|Comma-separated list of package names to allow for ZCCS. Only classes in the exact package (not sub-packages) are matched.
+
+|`hazelcast.serialization.compact.allowlist.prefixes`
+|
+|string
+|Comma-separated list of class-name prefixes to allow for ZCCS.
+
+|`hazelcast.serialization.compact.blocklist.classes`
+|
+|string
+|Comma-separated list of fully qualified class names to block from ZCCS. Default is empty.
+
+|`hazelcast.serialization.compact.blocklist.defaults`
+|true
+|bool
+|Controls whether the default blocklist of known-problematic classes is applied for ZCCS. Note that this property is `defaults`, not `defaultsDisabled` as seen for other configuration options.
+
+|`hazelcast.serialization.compact.blocklist.packages`
+|
+|string
+|Comma-separated list of package names to block from ZCCS. Only classes in the exact package (not sub-packages) are matched.
+
+|`hazelcast.serialization.compact.blocklist.prefixes`
+|
+|string
+|Comma-separated list of class-name prefixes to block from ZCCS.
+
 |`hazelcast.serialization.version`
 |
 |long


### PR DESCRIPTION
https://hazelcast.atlassian.net/browse/DOC-768

Final follow-up PR for #2265 and #2273, for v5.7 because the backport didn't work 🫠.

Adds details about ZCCS system properties, plus clarification that the filter is preferred.