### PR TITLE
Remove `DISTINCT_ID` release workflow inputs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,9 +20,6 @@ on:
         description: 'Environment to use'
         required: true
         type: environment
-      distinct_id:
-        description: 'Required exclusively for automated execution to track status of workflow execution'
-        required: false
 
 jobs:
   package:
@@ -31,12 +28,6 @@ jobs:
       id-token: write
       contents: write
     steps:
-        # https://github.com/Codex-/return-dispatch#receiving-repository-action
-      - name: Logging distinct ID (${{ inputs.distinct_id }})
-        run: echo "${DISTINCT_ID}"
-        env:
-          DISTINCT_ID: ${{ inputs.distinct_id }}
-
       - name: Checkout `release` branch
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -20,9 +20,6 @@ on:
         description: 'Environment to use'
         required: true
         type: environment
-      distinct_id:
-        description: 'Required exclusively for automated execution to track status of workflow execution'
-        required: false
 
 jobs:
   promote:
@@ -34,12 +31,6 @@ jobs:
     env:
       RELEASE_VERSION: ${{ inputs.VERSION }}
     steps:
-        # https://github.com/Codex-/return-dispatch#receiving-repository-action
-      - name: Logging distinct ID (${{ inputs.distinct_id }})
-        run: echo "${DISTINCT_ID}"
-        env:
-          DISTINCT_ID: ${{ inputs.distinct_id }}
-
       - name: Checkout `release` branch
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION
No longer required since https://github.com/Codex-/return-dispatch/releases/tag/v4.0.0, as [GitHub now has built in functionality to support](https://github.blog/changelog/2026-02-19-workflow-dispatch-api-now-returns-run-ids/).