### PR TITLE
Add metric cp.session.summary [HZ-5529]

### DIFF
--- a/docs/modules/ROOT/pages/list-of-metrics.adoc
+++ b/docs/modules/ROOT/pages/list-of-metrics.adoc
@@ -1521,6 +1521,10 @@ Scope: client-side only.
 |count
 |Version number of the CP session, basically it shows how many times the session heartbeat is received
 
+|`cp.session.summary`
+|
+|Summary information across all CP sessions grouped by CP group. The summary entails `sessionCount` (`count`) which is the count of CP sessions per CP group that are not closed.
+
 |===
 
 We also have a `summary` section per object type which provides live and destroyed object counts grouped by CP Group. These can be found under `cp.{atomiclong,atomicref,countdownlatch,lock,map,semaphore}.summary` and provide the following child attributes:


### PR DESCRIPTION
Short description on newly added `cp.session.summary` metric.